### PR TITLE
Fix dailyQuota unique index and add atomic reserve/release quota

### DIFF
--- a/drizzle/0002_fix_daily_quota_unique.sql
+++ b/drizzle/0002_fix_daily_quota_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `dailyQuota` DROP INDEX `dailyQuota_userId_unique`;
+ALTER TABLE `dailyQuota` ADD UNIQUE INDEX `dailyQuota_userId_date_unique`(`userId`,`date`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1771792056712,
       "tag": "0001_big_the_phantom",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "5",
+      "when": 1771798491450,
+      "tag": "0002_fix_daily_quota_unique",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- The daily quota model incorrectly enforced uniqueness on `userId` only, preventing one-row-per-user-per-day semantics and enabling race conditions during concurrent generation attempts.
- Image generation flow relied on a non-atomic check-and-increment which could allow double consumption under concurrency.

### Description
- Change the `dailyQuota` Drizzle schema to declare a composite unique index on `(userId, date)` using `uniqueIndex` so per-day uniqueness is enforced (`drizzle/schema.ts`).
- Add a migration SQL file `drizzle/0002_fix_daily_quota_unique.sql` that drops the old unique index and creates the composite unique index, and update `drizzle/meta/_journal.json` to include the migration.
- Add `reserveUserDailyQuota` and `releaseUserDailyQuota` helpers to `server/db.ts` to atomically reserve one quota slot and to release it on failure using an `INSERT` with fallback `UPDATE`/conditional `UPDATE` via raw `sql`.
- Update the image generation procedure in `server/routers.ts` to call `reserveUserDailyQuota` before starting generation and to call `releaseUserDailyQuota` if generation fails, replacing the previous non-atomic increment flow.

### Testing
- Ran `pnpm test`, which completed successfully (`11 tests` passed), with test-suite output showing successful test run.
- Ran `pnpm check` (`tsc --noEmit`), which failed due to unrelated pre-existing frontend TypeScript errors in `client/src` (e.g. type mismatches in `AIChatBox.tsx`, `Markdown.tsx`, and `ComponentShowcase.tsx`) and not because of these server/db/schema changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7e1c54308325915c5a788d3999e7)