### PR TITLE
Migrate Fly deployment config and add Meta webhook compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.pnpm-store
+dist
+.git
+.gitignore
+.vscode
+.idea
+.env
+.env.*
+coverage

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+FB_VERIFY_TOKEN=replace_with_verify_token
+FB_PAGE_ACCESS_TOKEN=replace_with_page_access_token
+# Optional: used to verify the X-Hub-Signature-256 header
+FB_APP_SECRET=optional_app_secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-bookworm-slim AS base
+WORKDIR /app
+RUN corepack enable
+
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM deps AS build
+COPY . .
+RUN pnpm run build
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/client ./client
+
+EXPOSE 8080
+CMD ["pnpm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# leaderbot-fb-image-gen
+
+Deploy this repository to the existing Fly app **groepsscore** so the Meta callback URL remains unchanged:
+
+- https://groepsscore.fly.dev/webhook/facebook
+
+## Environment variables
+
+Copy `.env.example` to `.env` for local development and set:
+
+- `FB_VERIFY_TOKEN`
+- `FB_PAGE_ACCESS_TOKEN`
+- `FB_APP_SECRET` (optional)
+
+Do not commit secrets.
+
+## Deploy to Fly
+
+```bash
+fly deploy -a groepsscore
+fly secrets list -a groepsscore
+fly logs -a groepsscore
+```
+
+## Webhook behavior
+
+- `GET /webhook/facebook`
+  - returns `200` with `hub.challenge` if `hub.verify_token` matches `FB_VERIFY_TOKEN` (or `VERIFY_TOKEN` fallback)
+  - returns `403` otherwise
+- `POST /webhook/facebook`
+  - returns `200` immediately
+  - logs minimal event metadata (event type, sender id, content kind)
+
+## Deployment verification checklist
+
+1. Verify webhook challenge response:
+
+   ```powershell
+   iwr "https://groepsscore.fly.dev/webhook/facebook?hub.mode=subscribe&hub.verify_token=YOUR_VERIFY_TOKEN&hub.challenge=123"
+   ```
+
+   The response body should be `123`.
+
+2. Send a message to the connected Facebook Page and confirm POST delivery in Fly logs:
+
+   ```bash
+   fly logs -a groepsscore
+   ```
+
+   You should see `[facebook-webhook] event` log lines.

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,24 @@
+app = "groepsscore"
+primary_region = "ams"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  NODE_ENV = "production"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "10s"
+    method = "GET"
+    path = "/healthz"


### PR DESCRIPTION
## Summary
- Added Fly deployment configuration for the existing app name `groepsscore` via `fly.toml`.
- Added a production Dockerfile and `.dockerignore` for reliable Fly builds.
- Updated server boot logic to bind to `0.0.0.0` on `PORT` (default `8080`) and added `/healthz` endpoint for Fly checks.
- Implemented Meta-compatible webhook routes:
  - `GET /webhook/facebook` challenge verification using `FB_VERIFY_TOKEN` with `VERIFY_TOKEN` fallback.
  - `POST /webhook/facebook` immediate `200` response plus minimal safe event logging.
- Added `.env.example` with required Facebook-related secrets and updated docs in new `README.md` with deploy commands and verification checklist.

## Notes
- Callback path remains unchanged at `/webhook/facebook`, keeping `https://groepsscore.fly.dev/webhook/facebook` stable.
- No secrets were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1252fd408325a903c4a5ae4280e3)