### PR TITLE
Implement Messenger photo-first UX with mock image generation and daily quota

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -1,0 +1,14 @@
+import { getStyleById, type StyleId } from "./messengerStyles";
+
+export function getMockGeneratedImage(styleId: StyleId, cursor = 0): { imageUrl: string; nextCursor: number } {
+  const style = getStyleById(styleId);
+  const index = cursor % style.mockResultUrls.length;
+
+  return {
+    imageUrl: style.mockResultUrls[index],
+    nextCursor: cursor + 1,
+  };
+}
+
+// Future integration point:
+// Replace getMockGeneratedImage with OpenAI/real generation logic and keep the webhook UX unchanged.

--- a/server/_core/messengerApi.ts
+++ b/server/_core/messengerApi.ts
@@ -1,0 +1,95 @@
+const GRAPH_API_VERSION = "v21.0";
+
+type QuickReply = {
+  content_type: "text";
+  title: string;
+  payload: string;
+};
+
+type GenericTemplateElement = {
+  title: string;
+  subtitle?: string;
+  image_url?: string;
+  buttons?: Array<{
+    type: "postback";
+    title: string;
+    payload: string;
+  }>;
+};
+
+function getPageToken(): string {
+  const token = process.env.FB_PAGE_ACCESS_TOKEN;
+
+  if (!token) {
+    throw new Error("FB_PAGE_ACCESS_TOKEN is missing");
+  }
+
+  return token;
+}
+
+function getSendApiUrl(): string {
+  return `https://graph.facebook.com/${GRAPH_API_VERSION}/me/messages?access_token=${encodeURIComponent(getPageToken())}`;
+}
+
+async function sendMessage(psid: string, message: Record<string, unknown>): Promise<void> {
+  const response = await fetch(getSendApiUrl(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      recipient: { id: psid },
+      message,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Messenger API error ${response.status}: ${body}`);
+  }
+}
+
+export function safeLog(event: string, details: Record<string, unknown> = {}): void {
+  const redacted = Object.fromEntries(
+    Object.entries(details).filter(([key]) => !key.toLowerCase().includes("token"))
+  );
+
+  console.log(`[messenger] ${event}`, redacted);
+}
+
+export async function sendText(psid: string, text: string): Promise<void> {
+  await sendMessage(psid, { text });
+}
+
+export async function sendQuickReplies(psid: string, text: string, replies: QuickReply[]): Promise<void> {
+  await sendMessage(psid, {
+    text,
+    quick_replies: replies,
+  });
+}
+
+export async function sendGenericTemplate(psid: string, elements: GenericTemplateElement[]): Promise<void> {
+  await sendMessage(psid, {
+    attachment: {
+      type: "template",
+      payload: {
+        template_type: "generic",
+        elements,
+      },
+    },
+  });
+}
+
+export async function sendImage(psid: string, imageUrl: string): Promise<void> {
+  await sendMessage(psid, {
+    attachment: {
+      type: "image",
+      payload: {
+        url: imageUrl,
+        is_reusable: false,
+      },
+    },
+  });
+}
+
+export type { QuickReply, GenericTemplateElement };

--- a/server/_core/messengerQuota.ts
+++ b/server/_core/messengerQuota.ts
@@ -1,0 +1,25 @@
+import { getDayKey, getOrCreateState } from "./messengerState";
+
+const FREE_DAILY_LIMIT = 1;
+
+function syncQuotaDay(psid: string, now = Date.now()) {
+  const state = getOrCreateState(psid);
+  const dayKey = getDayKey(now);
+
+  if (state.quota.dayKey !== dayKey) {
+    state.quota.dayKey = dayKey;
+    state.quota.count = 0;
+  }
+
+  return state;
+}
+
+export function canGenerate(psid: string, now = Date.now()): boolean {
+  const state = syncQuotaDay(psid, now);
+  return state.quota.count < FREE_DAILY_LIMIT;
+}
+
+export function increment(psid: string, now = Date.now()): void {
+  const state = syncQuotaDay(psid, now);
+  state.quota.count += 1;
+}

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,0 +1,71 @@
+import type { StyleId } from "./messengerStyles";
+
+type QuotaState = {
+  dayKey: string;
+  count: number;
+};
+
+export type MessengerUserState = {
+  pendingImageUrl?: string;
+  pendingImageAt?: number;
+  lastImageUrl?: string;
+  lastStyle?: StyleId;
+  lastGeneratedAt?: number;
+  lastVariantCursor?: number;
+  quota: QuotaState;
+  updatedAt: number;
+};
+
+const DEFAULT_DAY_KEY = "1970-01-01";
+const stateByPsid = new Map<string, MessengerUserState>();
+
+export function getDayKey(now = Date.now()): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+export function getOrCreateState(psid: string): MessengerUserState {
+  const existing = stateByPsid.get(psid);
+
+  if (existing) {
+    existing.updatedAt = Date.now();
+    return existing;
+  }
+
+  const created: MessengerUserState = {
+    quota: {
+      dayKey: DEFAULT_DAY_KEY,
+      count: 0,
+    },
+    updatedAt: Date.now(),
+  };
+
+  stateByPsid.set(psid, created);
+  return created;
+}
+
+export function setPendingImage(psid: string, imageUrl: string, now = Date.now()): void {
+  const state = getOrCreateState(psid);
+  state.pendingImageUrl = imageUrl;
+  state.pendingImageAt = now;
+  state.updatedAt = now;
+}
+
+export function setLastGenerated(psid: string, style: StyleId, resultImageUrl: string, now = Date.now()): void {
+  const state = getOrCreateState(psid);
+  state.lastStyle = style;
+  state.lastImageUrl = resultImageUrl;
+  state.lastGeneratedAt = now;
+  state.updatedAt = now;
+}
+
+export function getState(psid: string): MessengerUserState | undefined {
+  return stateByPsid.get(psid);
+}
+
+export function pruneOldState(maxAgeMs = 1000 * 60 * 60 * 24 * 7, now = Date.now()): void {
+  for (const [psid, state] of Array.from(stateByPsid.entries())) {
+    if (now - state.updatedAt > maxAgeMs) {
+      stateByPsid.delete(psid);
+    }
+  }
+}

--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -1,0 +1,74 @@
+export type StyleId = "STYLE_DISCO" | "STYLE_CINEMATIC" | "STYLE_ANIME" | "STYLE_MEME";
+
+export type StyleConfig = {
+  id: StyleId;
+  payload: StyleId;
+  label: string;
+  demoThumbnailUrl: string;
+  mockResultUrls: string[];
+};
+
+const baseMockUrl = "https://picsum.photos";
+
+export const STYLE_CONFIGS: StyleConfig[] = [
+  {
+    id: "STYLE_DISCO",
+    payload: "STYLE_DISCO",
+    label: "🪩 Disco Glow",
+    demoThumbnailUrl: `${baseMockUrl}/seed/disco-demo/640/640`,
+    mockResultUrls: [
+      `${baseMockUrl}/seed/disco-result-1/1024/1024`,
+      `${baseMockUrl}/seed/disco-result-2/1024/1024`,
+      `${baseMockUrl}/seed/disco-result-3/1024/1024`,
+    ],
+  },
+  {
+    id: "STYLE_CINEMATIC",
+    payload: "STYLE_CINEMATIC",
+    label: "🎬 Cinematic",
+    demoThumbnailUrl: `${baseMockUrl}/seed/cinematic-demo/640/640`,
+    mockResultUrls: [
+      `${baseMockUrl}/seed/cinematic-result-1/1024/1024`,
+      `${baseMockUrl}/seed/cinematic-result-2/1024/1024`,
+      `${baseMockUrl}/seed/cinematic-result-3/1024/1024`,
+    ],
+  },
+  {
+    id: "STYLE_ANIME",
+    payload: "STYLE_ANIME",
+    label: "🌸 Anime",
+    demoThumbnailUrl: `${baseMockUrl}/seed/anime-demo/640/640`,
+    mockResultUrls: [
+      `${baseMockUrl}/seed/anime-result-1/1024/1024`,
+      `${baseMockUrl}/seed/anime-result-2/1024/1024`,
+      `${baseMockUrl}/seed/anime-result-3/1024/1024`,
+    ],
+  },
+  {
+    id: "STYLE_MEME",
+    payload: "STYLE_MEME",
+    label: "😂 Meme",
+    demoThumbnailUrl: `${baseMockUrl}/seed/meme-demo/640/640`,
+    mockResultUrls: [
+      `${baseMockUrl}/seed/meme-result-1/1024/1024`,
+      `${baseMockUrl}/seed/meme-result-2/1024/1024`,
+      `${baseMockUrl}/seed/meme-result-3/1024/1024`,
+    ],
+  },
+];
+
+export const STYLE_IDS = new Set<StyleId>(STYLE_CONFIGS.map(style => style.id));
+
+export function isStylePayload(value: string): value is StyleId {
+  return STYLE_IDS.has(value as StyleId);
+}
+
+export function getStyleById(styleId: StyleId): StyleConfig {
+  const style = STYLE_CONFIGS.find(item => item.id === styleId);
+
+  if (!style) {
+    throw new Error(`Unknown style: ${styleId}`);
+  }
+
+  return style;
+}

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,0 +1,216 @@
+import express from "express";
+import {
+  sendGenericTemplate,
+  sendImage,
+  sendQuickReplies,
+  sendText,
+  safeLog,
+  type GenericTemplateElement,
+} from "./messengerApi";
+import { canGenerate, increment } from "./messengerQuota";
+import { getOrCreateState, pruneOldState, setLastGenerated, setPendingImage } from "./messengerState";
+import { isStylePayload, STYLE_CONFIGS, type StyleId } from "./messengerStyles";
+import { getMockGeneratedImage } from "./imageService";
+
+type FacebookWebhookEvent = {
+  sender?: { id?: string };
+  message?: {
+    is_echo?: boolean;
+    text?: string;
+    quick_reply?: { payload?: string };
+    attachments?: Array<{ type?: string; payload?: { url?: string } }>;
+  };
+  postback?: {
+    title?: string;
+    payload?: string;
+  };
+};
+
+function buildStyleElements(): GenericTemplateElement[] {
+  return STYLE_CONFIGS.map(style => ({
+    title: style.label,
+    subtitle: "Kies deze stijl",
+    image_url: style.demoThumbnailUrl,
+    buttons: [
+      {
+        type: "postback",
+        title: "Kies stijl",
+        payload: style.payload,
+      },
+    ],
+  }));
+}
+
+async function sendStylePicker(psid: string): Promise<void> {
+  await sendGenericTemplate(psid, buildStyleElements());
+}
+
+async function processGeneration(psid: string, styleId: StyleId): Promise<void> {
+  const state = getOrCreateState(psid);
+
+  if (!state.pendingImageUrl) {
+    await sendText(psid, "Stuur eerst een foto om te starten 📸");
+    return;
+  }
+
+  if (!canGenerate(psid)) {
+    await sendText(psid, "Je gratis limiet is bereikt (1 per dag). Kom morgen terug of upgrade.");
+    return;
+  }
+
+  increment(psid);
+  await sendText(psid, "Bezig… ⏳");
+
+  const variant = getMockGeneratedImage(styleId, 0);
+  await sendImage(psid, variant.imageUrl);
+
+  state.lastVariantCursor = variant.nextCursor;
+  setLastGenerated(psid, styleId, variant.imageUrl);
+
+  await sendQuickReplies(psid, "Klaar! Wil je nog een versie?", [
+    { content_type: "text", title: "🔁 Variatie", payload: "VARIATION" },
+    { content_type: "text", title: "💥 Sterker", payload: "STRONGER" },
+    { content_type: "text", title: "🎨 Nieuwe stijl", payload: "NEW_STYLE" },
+  ]);
+}
+
+async function processVariation(psid: string): Promise<void> {
+  const state = getOrCreateState(psid);
+
+  if (!state.lastStyle || !state.lastImageUrl) {
+    await sendText(psid, "Stuur een foto en kies een stijl om te beginnen.");
+    return;
+  }
+
+  if (!canGenerate(psid)) {
+    await sendText(psid, "Je gratis limiet is bereikt (1 per dag). Kom morgen terug of upgrade.");
+    return;
+  }
+
+  increment(psid);
+  await sendText(psid, "Bezig… ⏳");
+
+  const variant = getMockGeneratedImage(state.lastStyle, state.lastVariantCursor ?? 1);
+  await sendImage(psid, variant.imageUrl);
+
+  state.lastVariantCursor = variant.nextCursor;
+  setLastGenerated(psid, state.lastStyle, variant.imageUrl);
+
+  await sendQuickReplies(psid, "Nog eentje?", [
+    { content_type: "text", title: "🔁 Variatie", payload: "VARIATION" },
+    { content_type: "text", title: "💥 Sterker", payload: "STRONGER" },
+    { content_type: "text", title: "🎨 Nieuwe stijl", payload: "NEW_STYLE" },
+  ]);
+}
+
+async function handlePayload(psid: string, payload: string): Promise<void> {
+  if (payload === "TRENDING") {
+    await sendGenericTemplate(psid, buildStyleElements());
+    await sendText(psid, "Stuur je foto om te starten.");
+    return;
+  }
+
+  if (payload === "SEND_PHOTO") {
+    await sendText(psid, "Top! Stuur nu je foto 📸");
+    return;
+  }
+
+  if (payload === "NEW_STYLE") {
+    await sendStylePicker(psid);
+    return;
+  }
+
+  if (payload === "VARIATION" || payload === "STRONGER") {
+    await processVariation(psid);
+    return;
+  }
+
+  if (isStylePayload(payload)) {
+    await processGeneration(psid, payload);
+    return;
+  }
+
+  safeLog("unknown_payload", { psid, payload });
+}
+
+async function handleMessage(psid: string, event: FacebookWebhookEvent): Promise<void> {
+  const message = event.message;
+
+  if (!message || message.is_echo) {
+    return;
+  }
+
+  const quickPayload = message.quick_reply?.payload;
+  if (quickPayload) {
+    await handlePayload(psid, quickPayload);
+    return;
+  }
+
+  const imageAttachment = message.attachments?.find(att => att.type === "image" && att.payload?.url);
+
+  if (imageAttachment?.payload?.url) {
+    setPendingImage(psid, imageAttachment.payload.url);
+    await sendStylePicker(psid);
+    return;
+  }
+
+  if (typeof message.text === "string" && message.text.trim().length > 0) {
+    await sendQuickReplies(psid, "Welkom! Klaar om je foto te transformeren?", [
+      { content_type: "text", title: "📸 Stuur foto", payload: "SEND_PHOTO" },
+      { content_type: "text", title: "🔥 Trending", payload: "TRENDING" },
+    ]);
+    await sendText(psid, "Je kan ook meteen een foto sturen.");
+  }
+}
+
+async function handleEvent(event: FacebookWebhookEvent): Promise<void> {
+  const psid = event.sender?.id;
+
+  if (!psid) {
+    return;
+  }
+
+  if (event.postback?.payload) {
+    await handlePayload(psid, event.postback.payload);
+    return;
+  }
+
+  await handleMessage(psid, event);
+}
+
+export function registerMetaWebhookRoutes(app: express.Express): void {
+  app.get("/webhook/facebook", (req, res) => {
+    const mode = req.query["hub.mode"];
+    const token = req.query["hub.verify_token"];
+    const challenge = req.query["hub.challenge"];
+    const verifyToken = process.env.FB_VERIFY_TOKEN || process.env.VERIFY_TOKEN;
+
+    if (mode === "subscribe" && token === verifyToken && typeof challenge === "string") {
+      return res.status(200).send(challenge);
+    }
+
+    return res.sendStatus(403);
+  });
+
+  app.post("/webhook/facebook", (req, res) => {
+    const payload = req.body;
+    res.sendStatus(200);
+
+    setImmediate(async () => {
+      try {
+        pruneOldState();
+        const entries = Array.isArray(payload?.entry) ? payload.entry : [];
+
+        for (const entry of entries) {
+          const events: FacebookWebhookEvent[] = Array.isArray(entry?.messaging) ? entry.messaging : [];
+
+          for (const event of events) {
+            await handleEvent(event);
+          }
+        }
+      } catch (error) {
+        console.error("[facebook-webhook] failed to process event", error);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- keep existing Meta webhook routes (`GET/POST /webhook/facebook`) while upgrading POST handling into a complete Messenger UX flow
- add reusable Messenger send helpers (`sendText`, `sendQuickReplies`, `sendGenericTemplate`, `sendImage`) and safe logging
- implement in-memory PSID state management for pending image, last generation context, and lightweight pruning
- implement free-tier daily quota service (`1 generation/day`) with day-key reset logic
- add style configuration for Disco/Cinematic/Anime/Meme with demo thumbnails and rotating mock result URLs
- add mock image service as the future OpenAI integration point
- update README with end-to-end Messenger testing steps and quota behavior

## Behavior implemented
- text-first message: welcome + quick replies (`📸 Stuur foto`, `🔥 Trending`) + hint text
- image message: stores pending image URL and returns style carousel
- trending action: sends style carousel and prompts user to send photo
- style selection: validates pending photo, checks quota, sends `Bezig… ⏳`, returns mock image, then follow-up quick replies
- variation/stronger: uses last style context, rotates mock output, re-checks quota, and handles missing context fallback
- webhook parser handles echoes, text, image attachments, postbacks, and quick-reply payloads

## Notes
- webhook verification behavior remains intact and unchanged on the same route paths
- full `pnpm check` currently fails due to unrelated pre-existing TypeScript issues in client code; new Messenger modules type-check successfully via targeted `tsc` command

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c1d443de88325bde87be5e870efbe)