### PR TITLE
Fix pnpm patch ENOENT for Fly build

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,9 +110,6 @@
   },
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
-    "patchedDependencies": {
-      "wouter@3.7.1": "patches/wouter@3.7.1.patch"
-    },
     "overrides": {
       "tailwindcss>nanoid": "3.3.7"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,6 @@ settings:
 overrides:
   tailwindcss>nanoid: 3.3.7
 
-patchedDependencies:
-  wouter@3.7.1:
-    hash: 4e16e6ff3fde7d6c1024d3e0c8605dc9eb6afb690d0d49958c2f449091813072
-    path: patches/wouter@3.7.1.patch
-
 importers:
 
   .:
@@ -219,7 +214,7 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       wouter:
         specifier: 3.7.1
-        version: 3.7.1(patch_hash=4e16e6ff3fde7d6c1024d3e0c8605dc9eb6afb690d0d49958c2f449091813072)(react@19.2.3)
+        version: 3.7.1(react@19.2.3)
       zod:
         specifier: ^4.1.12
         version: 4.3.5
@@ -9534,7 +9529,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wouter@3.7.1(patch_hash=4e16e6ff3fde7d6c1024d3e0c8605dc9eb6afb690d0d49958c2f449091813072)(react@19.2.3):
+  wouter@3.7.1(react@19.2.3):
     dependencies:
       mitt: 3.0.1
       react: 19.2.3


### PR DESCRIPTION
### Motivation
- The project referenced a missing patch file via `pnpm.patchedDependencies` which causes `ENOENT` during Fly deploys because the patch `patches/wouter@3.7.1.patch` does not exist.
- The lockfile still contained patched metadata which would make `pnpm install --frozen-lockfile` look for patch data during image builds, breaking CI/CD.

### Description
- Removed the entire `pnpm.patchedDependencies` block from `package.json` while preserving the existing `pnpm.overrides` entry. (`package.json` modified)
- Cleaned the lockfile `pnpm-lock.yaml` to remove the top-level `patchedDependencies` section and removed patch hash suffixes so `wouter@3.7.1` is referenced as a normal package in the lockfile. (`pnpm-lock.yaml` modified)
- Left the `Dockerfile` and `.dockerignore` unchanged because the Docker build already uses `pnpm install --frozen-lockfile` and no required files were excluded.

### Testing
- Ran `corepack enable` and `pnpm install --frozen-lockfile` which completed successfully and accepted the updated lockfile. 
- Ran `pnpm install` which failed due to an external npm registry 403/auth restriction in this environment and not because of the project changes. 
- Verified there are no remaining references to `patchedDependencies`, `patch_hash`, or `patches/wouter@3.7.1.patch` in `package.json` or `pnpm-lock.yaml` using `rg -n "patchedDependencies|patch_hash|patches/wouter@3.7.1.patch" package.json pnpm-lock.yaml` and found none.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c286dc8888325bb744a65b2168479)