### PR TITLE
Stabilize Docker build output and start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN pnpm install --frozen-lockfile
 FROM deps AS build
 COPY . .
 RUN pnpm run build
+RUN node -e "require('fs').existsSync('dist/index.js') || process.exit(1)"
 
 FROM node:20-bookworm-slim AS runtime
 WORKDIR /app
@@ -21,4 +22,4 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/client ./client
 
 EXPOSE 8080
-CMD ["pnpm", "start"]
+CMD ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch server/_core/index.ts",
-    "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc --noEmit",
     "format": "prettier --write .",


### PR DESCRIPTION
### Motivation
- Ensure the container build reliably produces `dist/index.js` that matches the runtime start command so the app can be started deterministically in production.

### Description
- Updated `package.json` `build` to emit the server bundle explicitly to `dist/index.js` with `esbuild --outfile=dist/index.js`, added a minimal Docker build-stage sanity check `node -e "require('fs').existsSync('dist/index.js') || process.exit(1)"`, and changed the runtime image `CMD` to `node dist/index.js` so container startup does not depend on a package manager script.

### Testing
- Ran `pnpm run build` which completed successfully and produced `dist/index.js`.
- Ran the sanity check `node -e "require('fs').existsSync('dist/index.js') || process.exit(1)"` which returned success.
- Attempted `docker build -t leaderbot-fb-image-gen:test .` but the `docker` CLI is unavailable in this execution environment, so image build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c292819a483258f6cb4902341309a)