### PR TITLE
Docs: pnpm workflow + Fly build notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,32 @@
 # leaderbot-fb-image-gen
 
+## Package manager (pnpm)
+
+This project uses **pnpm** via **Corepack** (not npm).
+
+### Local development
+
+```bash
+corepack enable
+pnpm install
+pnpm dev
+```
+
+### Build
+
+```bash
+pnpm build
+```
+
+### If you accidentally ran `npm install`
+
+- Delete `package-lock.json` (if it was created).
+- Run pnpm commands again (`pnpm install`, then `pnpm dev` or `pnpm build`).
+
+### Fly build note
+
+Fly build runs with `pnpm --frozen-lockfile` and will fail if `pnpm-lock.yaml` is not in sync with `package.json`.
+
 Deploy this repository to the existing Fly app **groepsscore** so the Meta callback URL remains unchanged:
 
 - https://groepsscore.fly.dev/webhook/facebook


### PR DESCRIPTION
### Motivation
- Reduce confusion for local development on Windows by documenting that the project uses `pnpm` via Corepack and by clarifying local dev and build workflows.

### Description
- Add a new README section that states the project uses `pnpm` (Corepack) and documents local development commands (`corepack enable`, `pnpm install`, `pnpm dev`), the build command (`pnpm build`), recovery steps if `npm install` was run (delete `package-lock.json` and return to `pnpm`), and a note that Fly builds run with `pnpm --frozen-lockfile` and will fail if `pnpm-lock.yaml` is out of sync.

### Testing
- Documentation-only change so no runtime tests were required, and the README update was validated by inspecting the diff with `git diff -- README.md` and printing the file with `nl -ba README.md | sed -n '1,120p'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c2a83d7ac8325823eb6210edcf0d2)