### PR TITLE
Harden Meta webhook verify + structured logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Copy `.env.example` to `.env` for local development and set:
 - `FB_VERIFY_TOKEN`
 - `FB_PAGE_ACCESS_TOKEN`
 - `FB_APP_SECRET` (optional)
+- `ADMIN_TOKEN` (optional, required for `GET /debug/build`)
 
 Do not commit secrets.
 
@@ -58,11 +59,14 @@ curl https://<host>/healthz
 ## Webhook paths (unchanged)
 
 - `GET /webhook/facebook`
-  - returns `200` with `hub.challenge` if `hub.verify_token` matches `FB_VERIFY_TOKEN` (or `VERIFY_TOKEN` fallback)
+  - returns `200` with `hub.challenge` as `text/plain` if `hub.verify_token` matches `FB_VERIFY_TOKEN`
   - returns `403` otherwise
 - `POST /webhook/facebook`
   - returns `200` immediately
   - processes Messenger events asynchronously
+- `GET /debug/build`
+  - requires header `X-Admin-Token` to match `ADMIN_TOKEN`
+  - returns build/runtime metadata without secrets
 
 ## Messenger UX flow (mock image generation)
 

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -11,6 +11,26 @@ import { registerMetaWebhookRoutes } from "./messengerWebhook";
 
 const appVersion = process.env.GIT_SHA || process.env.SOURCE_VERSION || "dev";
 
+function extractWebhookEventTypes(body: unknown): string[] {
+  const unique = new Set<string>();
+  const payload = body as { entry?: Array<{ messaging?: Array<{ message?: unknown; postback?: unknown }> }> };
+  const entries = Array.isArray(payload?.entry) ? payload.entry : [];
+
+  for (const entry of entries) {
+    const events = Array.isArray(entry?.messaging) ? entry.messaging : [];
+    for (const event of events) {
+      if (event?.message) {
+        unique.add("messages");
+      }
+      if (event?.postback) {
+        unique.add("postbacks");
+      }
+    }
+  }
+
+  return Array.from(unique);
+}
+
 async function startServer() {
   const app = express();
   const server = createServer(app);
@@ -18,12 +38,59 @@ async function startServer() {
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
+  app.use((req, res, next) => {
+    const startTime = process.hrtime.bigint();
+
+    res.on("finish", () => {
+      const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
+      const log: Record<string, unknown> = {
+        method: req.method,
+        path: req.path,
+        status: res.statusCode,
+        latency_ms: Number(durationMs.toFixed(1)),
+      };
+
+      if (req.method === "POST" && req.path === "/webhook/facebook") {
+        const eventTypes = extractWebhookEventTypes(req.body);
+        if (eventTypes.length > 0) {
+          log.event_types = eventTypes;
+        }
+      }
+
+      console.log(JSON.stringify(log));
+    });
+
+    next();
+  });
+
   app.get("/healthz", (_req, res) => {
     res.status(200).json({
       ok: true,
       name: "leaderbot-images",
       version: appVersion,
       time: new Date().toISOString(),
+    });
+  });
+
+  app.get("/debug/build", (req, res) => {
+    const adminToken = process.env.ADMIN_TOKEN;
+    const providedToken = req.header("X-Admin-Token");
+
+    if (!adminToken || providedToken !== adminToken) {
+      return res.sendStatus(403);
+    }
+
+    return res.status(200).json({
+      name: "leaderbot-images",
+      version: appVersion,
+      uptime_s: Math.floor(process.uptime()),
+      node: process.version,
+      envFlags: {
+        hasFbVerifyToken: Boolean(process.env.FB_VERIFY_TOKEN),
+        hasFbPageAccessToken: Boolean(process.env.FB_PAGE_ACCESS_TOKEN),
+        hasFbAppSecret: Boolean(process.env.FB_APP_SECRET),
+        hasAdminToken: Boolean(process.env.ADMIN_TOKEN),
+      },
     });
   });
 

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -183,10 +183,10 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
     const mode = req.query["hub.mode"];
     const token = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
-    const verifyToken = process.env.FB_VERIFY_TOKEN || process.env.VERIFY_TOKEN;
+    const verifyToken = process.env.FB_VERIFY_TOKEN;
 
     if (mode === "subscribe" && token === verifyToken && typeof challenge === "string") {
-      return res.status(200).send(challenge);
+      return res.status(200).type("text/plain").send(challenge);
     }
 
     return res.sendStatus(403);


### PR DESCRIPTION
### Motivation
- Ensure Meta webhook verification is strict and returns the raw challenge in the expected format so callbacks are reliably validated.
- Make request/endpoint activity observable with compact, structured JSON logs while avoiding sensitive payloads.
- Provide an admin-only build/debug endpoint for lightweight runtime metadata without exposing secrets.

### Description
- Hardened `GET /webhook/facebook` to read `hub.mode`, `hub.verify_token`, and `hub.challenge`, require `hub.mode === "subscribe"` and `hub.verify_token` to match `FB_VERIFY_TOKEN`, and return the raw `hub.challenge` as `text/plain` on success, otherwise return `403` (`server/_core/messengerWebhook.ts`).
- Added structured request logging middleware that emits one-line JSON per request with `method`, `path`, `status`, and `latency_ms`, and enriches `POST /webhook/facebook` logs with inferred `event_types` (e.g. `messages`, `postbacks`) without logging full payloads (`server/_core/index.ts`).
- Added `GET /debug/build` protected by header `X-Admin-Token` matching `ADMIN_TOKEN` that returns non-secret metadata `{ name, version, uptime_s, node, envFlags }` (`server/_core/index.ts`).
- Updated `README.md` to document the new `ADMIN_TOKEN` env var and the slightly revised webhook verification behavior, and made a small compatibility change to use `Array.from` for set iteration to satisfy older TS targets (`server/_core/index.ts`, `README.md`).

### Testing
- Ran static type checks via `pnpm check` (`tsc --noEmit`) and addressed a server-side iteration compatibility issue by switching to `Array.from`.
- `pnpm check` still exits non-zero due to pre-existing unrelated TypeScript errors in client files (`client/src/components/AIChatBox.tsx`, `client/src/components/Markdown.tsx`, `client/src/pages/ComponentShowcase.tsx`), which were not introduced by these changes.
- No automated server tests were added; server-side changes were kept minimal and limited to request handling and logging logic to reduce risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c38b7dacc8325b13b87cf081c4a12)