### PR TITLE
Messenger UX v1: menu + photo-first + style picker

### DIFF
--- a/server/messengerState.test.ts
+++ b/server/messengerState.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { getOrCreateState, resetStateStore, setChosenStyle, setFlowState, setPendingImage } from "./_core/messengerState";
+
+describe("messenger state flow", () => {
+  beforeEach(() => {
+    resetStateStore();
+  });
+
+  it("handles photo-first transition", () => {
+    const psid = "photo-first-user";
+
+    setPendingImage(psid, "https://img.example/pic.jpg", 1000);
+
+    const state = getOrCreateState(psid);
+    expect(state.state).toBe("awaiting_style");
+    expect(state.lastPhotoUrl).toBe("https://img.example/pic.jpg");
+  });
+
+  it("handles style-first transition", () => {
+    const psid = "style-first-user";
+
+    setFlowState(psid, "awaiting_photo", 1000);
+    setChosenStyle(psid, "Anime", 1001);
+
+    const state = getOrCreateState(psid);
+    expect(state.state).toBe("awaiting_photo");
+    expect(state.chosenStyle).toBe("Anime");
+    expect(state.lastPhotoUrl).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a simple, menu-driven Messenger UX (no AI generation yet) that supports both photo-first and style-first user journeys using an in-memory state store.
- Keep webhook route shape unchanged while enabling clear next actions and avoiding dead ends in the conversation flow.

### Description
- Add a flow state model and fields to the in-memory store in `server/_core/messengerState.ts`, including `MessengerFlowState` (`new` | `awaiting_photo` | `awaiting_style` | `processing`), `lastPhotoUrl`, `chosenStyle`, `setFlowState`, `setChosenStyle`, and `resetStateStore` while preserving legacy fields for compatibility.
- Rework `server/_core/messengerWebhook.ts` to detect text, quick replies/postbacks, and image attachments and to present a start menu (`📸 Send photo`, `✨ Choose style`, `🔥 Trending`, `❓ Help`) for first interactions or `hi`/`start`.
- Implement photo-first behavior (store photo, set awaiting_style, send style quick replies for `Disco`, `Anime`, `Gold`, `Clouds`, `Cinematic`, `Pixel`) and style-first behavior (store chosen style, ask for photo and set awaiting_photo); when both photo and style are present the bot responds `Got it — processing…`.
- Add focused unit tests `server/messengerState.test.ts` covering the photo-first and style-first state transitions.

### Testing
- Ran the focused vitest file with `pnpm test server/messengerState.test.ts`, and the tests passed (`2 tests` ✅).
- Ran `pnpm check` which failed due to pre-existing unrelated TypeScript errors in client files and not due to the webhook/state changes (these failures are outside the scope of this UX change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c38d982448325ac0cc75fa6c8e3ac)