### PR TITLE
Fix Docker build: include pnpm patches + multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --frozen-lockfile
 
 COPY . .
@@ -14,9 +15,9 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 RUN pnpm install --prod --frozen-lockfile
 COPY --from=build /app/dist ./dist
-COPY --from=build /app/client ./client
 
 EXPOSE 8080
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
### Motivation
- Prevent pnpm patch `ENOENT` during image builds by ensuring `patches/` is present before `pnpm install` runs. 
- Ensure build-time tooling (e.g. `tsc`) is available by installing devDependencies in the build stage. 
- Produce a lean runtime image that only contains production deps and the built `dist/` output.

### Description
- Updated `Dockerfile` build stage to `COPY patches ./patches` before running `pnpm install --frozen-lockfile` so patched packages resolve during install. 
- Kept full dependency install in the build stage and run `pnpm run build` there to ensure dev tools are available for compilation. 
- Added `COPY patches ./patches` in the runtime stage and run `pnpm install --prod --frozen-lockfile` to install only production deps in the final image. 
- Runtime image now copies only `dist/` from the build stage and starts with `node dist/index.js`.

### Testing
- Ran `pnpm install --frozen-lockfile` on the workspace and it completed successfully. 
- Ran `pnpm run build` and the build completed successfully producing `dist/`. 
- Launched the built server with `node dist/index.js` and observed the process print `Server listening on port 8080 (0.0.0.0)`, confirming it starts. 
- Verified `.dockerignore` does not exclude `patches/`; attempted `docker build` could not be executed in this environment because the Docker CLI is not available (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c48714a7c8325b23108502a400fcc)