### PR TITLE
Make analytics script injection runtime-safe

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -17,10 +17,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script
-      defer
-      src="%VITE_ANALYTICS_ENDPOINT%/umami"
-      data-website-id="%VITE_ANALYTICS_WEBSITE_ID%"></script>
   </body>
 
 </html>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,6 +8,25 @@ import App from "./App";
 import { getLoginUrl } from "./const";
 import "./index.css";
 
+const injectAnalytics = () => {
+  if (typeof document === "undefined") return;
+
+  const analyticsEndpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT?.trim();
+  const analyticsWebsiteId = import.meta.env.VITE_ANALYTICS_WEBSITE_ID?.trim();
+
+  if (!analyticsEndpoint) return;
+
+  const analyticsScript = document.createElement("script");
+  analyticsScript.defer = true;
+  analyticsScript.src = `${analyticsEndpoint.replace(/\/$/, "")}/umami`;
+
+  if (analyticsWebsiteId) {
+    analyticsScript.dataset.websiteId = analyticsWebsiteId;
+  }
+
+  document.head.appendChild(analyticsScript);
+};
+
 const queryClient = new QueryClient();
 
 const redirectToLoginIfUnauthorized = (error: unknown) => {
@@ -51,6 +70,8 @@ const trpcClient = trpc.createClient({
     }),
   ],
 });
+
+injectAnalytics();
 
 createRoot(document.getElementById("root")!).render(
   <trpc.Provider client={trpcClient} queryClient={queryClient}>


### PR DESCRIPTION
### Motivation
- Prevent malformed URI errors caused by literal `%VITE_ANALYTICS_*%` placeholders remaining in built HTML when `VITE_ANALYTICS_ENDPOINT` is undefined.
- Ensure the app and dev server load cleanly with analytics remaining optional.

### Description
- Removed the hardcoded analytics script tag containing `%VITE_ANALYTICS_ENDPOINT%` and `%VITE_ANALYTICS_WEBSITE_ID%` from `client/index.html`.
- Added a runtime injector `injectAnalytics` in `client/src/main.tsx` that reads `import.meta.env.VITE_ANALYTICS_ENDPOINT` and `VITE_ANALYTICS_WEBSITE_ID` and appends the analytics script only when the endpoint is present.
- Normalized trailing slash on the endpoint before appending `/umami` and only sets `data-website-id` if a website ID is provided.
- Ensured the injector runs in browser context only (checks `document`) so no placeholders are emitted into static HTML.

### Testing
- Ran `rg -n "%VITE_ANALYTICS_(ENDPOINT|WEBSITE_ID)%" client` and confirmed no matches, validating placeholders were removed from tracked HTML/templates.
- Ran `pnpm check` which failed due to pre-existing TypeScript errors in unrelated files, and those failures are not introduced by this change.
- Attempted `pnpm dev` and `pnpm install` in this environment; `pnpm dev` failed because `cross-env` is not available and `pnpm install` is blocked by a `403` from the registry, so full runtime verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c74b2bea48325a48cbda73bb473d3)