### PR TITLE
Lazy-load Vite in dev only to prevent prod crash

### DIFF
--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -3,10 +3,13 @@ import fs from "fs";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
 import path from "path";
-import { createServer as createViteServer } from "vite";
-import viteConfig from "../../vite.config";
 
 export async function setupVite(app: Express, server: Server) {
+  const [{ createServer: createViteServer }, { default: viteConfig }] = await Promise.all([
+    import("vite"),
+    import("../../vite.config"),
+  ]);
+
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },


### PR DESCRIPTION
### Motivation
- Production startup failed with `ERR_MODULE_NOT_FOUND: 'vite'` because `vite` and `vite.config` were imported at module top-level, forcing a runtime dependency on dev-only packages.
- The intent is to ensure production does not require Vite and to only enable Vite middleware in development, while keeping static asset serving and `/healthz` behavior intact.

### Description
- Removed top-level imports of `vite` and `vite.config` and changed `setupVite` to dynamically import both at runtime using `await import(...)` in `server/_core/vite.ts`.
- Kept `serveStatic` and the production code path unchanged so built static assets are served without Vite.
- The dev-only Vite setup is still gated by `NODE_ENV === "development"` in `server/_core/index.ts`.

### Testing
- Ran `pnpm run build` and the client/server build completed successfully.
- Created an isolated prod runtime (`pnpm install --prod --frozen-lockfile` in a temporary directory) and verified `vite` is not present in production deps.
- Launched the built server with `NODE_ENV=production node dist/index.js` against the prod-only deps and verified `GET /healthz` returned `200` with body `ok`.
- Attempted `docker build` and `fly deploy` but the respective CLIs were unavailable in this environment, so those steps could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d996775ac83258f8c6ab5728a0c5f)