### PR TITLE
Fix Fly crash loop by removing dev-plugin import from runtime bundle

### DIFF
--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -5,10 +5,9 @@ import { nanoid } from "nanoid";
 import path from "path";
 
 export async function setupVite(app: Express, server: Server) {
-  const [{ createServer: createViteServer }, { default: viteConfig }] = await Promise.all([
-    import("vite"),
-    import("../../vite.config"),
-  ]);
+  const { createServer: createViteServer } = await import("vite");
+
+  const configFile = path.resolve(import.meta.dirname, "../..", "vite.config.ts");
 
   const serverOptions = {
     middlewareMode: true,
@@ -17,8 +16,7 @@ export async function setupVite(app: Express, server: Server) {
   };
 
   const vite = await createViteServer({
-    ...viteConfig,
-    configFile: false,
+    configFile,
     server: serverOptions,
     appType: "custom",
   });


### PR DESCRIPTION
### Motivation
- The production server bundle was importing `vite.config` which caused dev-only plugins (e.g. `@builder.io/vite-plugin-jsx-loc`) to be referenced from `dist/index.js`, triggering `ERR_MODULE_NOT_FOUND` at runtime when only production deps are installed.

### Description
- Change `server/_core/vite.ts` so `setupVite` only imports Vite itself and passes the config path via `configFile` instead of importing `../../vite.config` as a module.
- This prevents esbuild from bundling `vite.config.ts` and any dev-only plugins into the server `dist/index.js` used in production.
- File modified: `server/_core/vite.ts` (removed module import of `vite.config` and switched to `configFile` usage).

### Testing
- Ran `pnpm run build` and the build completed successfully.
- Installed production dependencies with `pnpm install --prod --frozen-lockfile` which succeeded.
- Launched the server with `NODE_ENV=production node dist/index.js` and verified `GET /healthz` returned `200` with body `ok` (server started successfully under production deps).
- Attempts to run `docker build` and `fly logs`/deploy could not be executed in this environment because `docker` and the `fly` CLI were unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9d8991208325ae870d902b65719e)