### PR TITLE
feat: add /privacy route serving HTML privacy policy

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -89,6 +89,31 @@ async function startServer() {
     });
   });
 
+  app.get("/privacy", (_req, res) => {
+    res.type("html").send(`
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Privacy Policy – Leaderbot</title>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <style>
+        body { font-family: Arial, sans-serif; max-width: 700px; margin: 40px auto; line-height: 1.6; padding: 0 20px; }
+        h1 { color: #222; }
+      </style>
+    </head>
+    <body>
+      <h1>Privacy Policy – Leaderbot</h1>
+      <p>Leaderbot processes user-submitted images solely for AI-based image transformation.</p>
+      <p>We do not sell, store long-term, or share user data with third parties.</p>
+      <p>Images are processed temporarily and deleted after transformation.</p>
+      <p>We only access messaging data required to provide this service.</p>
+      <p>For questions, contact: shortcutcomputerguy@gmail.com</p>
+    </body>
+    </html>
+  `);
+  });
+
   registerMetaWebhookRoutes(app);
 
   registerOAuthRoutes(app);


### PR DESCRIPTION
### Motivation
- Provide a public privacy policy page required for Meta app submission and to inform users about how Leaderbot processes images and messaging data.

### Description
- Add a new `GET /privacy` route in `server/_core/index.ts` that responds with the requested HTML privacy policy (inline CSS and the provided content) and place it before the server startup without modifying existing route registrations.

### Testing
- Ran `pnpm check` (which runs `tsc --noEmit`) and it failed due to a pre-existing TypeScript overload error at `server.listen(PORT, HOST, ...)` where `PORT` is `string | number` and does not match the expected parameter type.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dae2c0fd48325ac354c1c4a4073c7)