### PR TITLE
fix: correct webhook verification route order

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -170,18 +170,21 @@ async function handleEvent(event: FacebookWebhookEvent): Promise<void> {
 }
 
 export function registerMetaWebhookRoutes(app: express.Express): void {
-  app.get("/webhook/facebook", (req, res) => {
+  const handleVerification: express.RequestHandler = (req, res) => {
     const mode = req.query["hub.mode"];
-    const token = req.query["hub.verify_token"];
+    const verifyToken = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
-    const verifyToken = process.env.FB_VERIFY_TOKEN;
+    const expectedVerifyToken = process.env.FB_VERIFY_TOKEN;
 
-    if (mode === "subscribe" && token === verifyToken && typeof challenge === "string") {
+    if (mode === "subscribe" && verifyToken === expectedVerifyToken && typeof challenge === "string") {
       return res.status(200).type("text/plain").send(challenge);
     }
 
     return res.sendStatus(403);
-  });
+  };
+
+  app.get("/webhook", handleVerification);
+  app.get("/webhook/facebook", handleVerification);
 
   app.post("/webhook/facebook", (req, res) => {
     const payload = req.body;


### PR DESCRIPTION
### Motivation
- The Meta webhook verification requests were being served the homepage or static assets because there was no dedicated `GET /webhook` handler registered early, causing verification to fail.
- The goal is to ensure the verification path is handled explicitly and does not fall through to static middleware or a catch-all route.

### Description
- Added a shared verification handler `handleVerification` that reads `req.query["hub.mode"]`, `req.query["hub.verify_token"]`, and `req.query["hub.challenge"]` and compares the token against `process.env.FB_VERIFY_TOKEN`.
- The handler returns status `200` with the `hub.challenge` as `text/plain` when `mode === "subscribe"` and the verify token matches, otherwise it returns `403`.
- Registered the handler on both `GET /webhook` and `GET /webhook/facebook` via `app.get("/webhook", handleVerification)` and `app.get("/webhook/facebook", handleVerification)` so verification no longer falls through to static/homepage handlers, while leaving the `POST /webhook/facebook` processing unchanged.

### Testing
- Ran `pnpm check` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db6b499d48325ba2ffd6d78469232)