### PR TITLE
Fix Facebook webhook verification GET handler

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -174,9 +174,8 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
     const mode = req.query["hub.mode"];
     const verifyToken = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
-    const expectedVerifyToken = process.env.FB_VERIFY_TOKEN;
 
-    if (mode === "subscribe" && verifyToken === expectedVerifyToken && typeof challenge === "string") {
+    if (mode === "subscribe" && verifyToken === process.env.FB_VERIFY_TOKEN) {
       return res.status(200).type("text/plain").send(challenge);
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the server responds to Facebook/Meta webhook verification requests by reading `hub.mode`, `hub.verify_token`, and `hub.challenge` and returning the challenge when appropriate.
- Provide both an explicit `GET /webhook/facebook` route and a fallback `GET /webhook` route so verification requests reach the handler before static/landing routes.

### Description
- Updated the verification handler in `server/_core/messengerWebhook.ts` to return `200 text/plain` with the `hub.challenge` when `hub.mode === "subscribe"` and `hub.verify_token === process.env.FB_VERIFY_TOKEN`, and otherwise return `403`.
- Left both `app.get("/webhook", ...)` and `app.get("/webhook/facebook", ...)` registrations in place so the explicit and fallback endpoints are available.

### Testing
- Ran `pnpm test` which executed the test suite under `vitest` and completed successfully with all tests passing (3 test files, 13 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc64e1e7c83259a9eb5c0af9d9425)