### PR TITLE
Keep one Fly machine always running

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,9 @@ primary_region = "ams"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [[http_service.checks]]


### PR DESCRIPTION
### Motivation
- Prevent the Fly app from going to sleep by ensuring at least one machine remains active.

### Description
- Updated `fly.toml` to set `auto_stop_machines = "off"` and `min_machines_running = 1` so one instance is always kept running.

### Testing
- Verified the configuration and commit by running `cat fly.toml`, `nl -ba fly.toml | sed -n '1,40p'`, and `git show --stat --oneline HEAD`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc68ac18883259bcb500e7a59033c)