### PR TITLE
Configure Fly prod keep-alive settings and document verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ fly secrets list -a groepsscore
 fly logs -a groepsscore
 ```
 
+### prod keep-alive settings
+
+Set in `fly.toml` under `[http_service]`:
+
+- `auto_stop_machines = false`
+- `min_machines_running = 1`
+
+Verify active config:
+
+```bash
+fly config show -a groepsscore
+```
+
 Health check:
 
 ```bash

--- a/fly.toml
+++ b/fly.toml
@@ -11,7 +11,7 @@ primary_region = "ams"
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = "off"
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]


### PR DESCRIPTION
### Motivation

- Ensure the Fly app remains running to avoid cold starts by enabling keep-alive and guaranteeing at least one machine is always running with `auto_stop_machines = false` and `min_machines_running = 1` under `[http_service]` in `fly.toml`.
- Provide an operator-visible verification step in the repository so production configuration can be checked easily with `fly config show -a groepsscore`.

### Description

- Update `fly.toml` under the `[http_service]` table to set `auto_stop_machines = false` (previously the string "off") and `min_machines_running = 1`.
- Add a `prod keep-alive settings` section to `README.md` documenting the two settings and the verification command `fly config show -a groepsscore`.
- Verified that both settings appear under the `[http_service]` table in the edited `fly.toml` file.

### Testing

- Ran a content search with `rg -n "\[http_service\]|auto_stop_machines|min_machines_running|prod keep-alive settings|fly config show" fly.toml README.md` which located the updated entries and documentation, and it succeeded.
- Printed the updated files with `nl` to visually confirm the `fly.toml` entries and the new README section, and it succeeded.
- Attempted `fly deploy -a groepsscore` but the command failed in this environment because the `fly` CLI is not installed (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd67fbea483259bc03d1405fddb6c)