### PR TITLE
Add BOOT startup log in production entrypoint

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -12,6 +12,8 @@ import { registerMetaWebhookRoutes } from "./messengerWebhook";
 const appVersion = process.env.GIT_SHA || process.env.SOURCE_VERSION || "dev";
 
 async function startServer() {
+  console.log("BOOT", { pid: process.pid });
+
   const app = express();
   const server = createServer(app);
 


### PR DESCRIPTION
### Motivation
- Confirm that the Fly production process runs `node dist/index.js`, which is bundled from `server/_core/index.ts`, and add a one-time boot marker so new builds can be identified in logs.

### Description
- Inserted a one-time startup log `console.log("BOOT", { pid: process.pid })` at the top of `server/_core/index.ts` so the runtime emits a clear boot marker when `dist/index.js` starts.
- Verified the existing request-logger middleware remains mounted before route registration (so incoming requests like `/webhook/facebook` will be logged).
- No changes to routing or middleware ordering were needed beyond adding the boot log.

### Testing
- Ran `pnpm run check` (`tsc --noEmit`) and it completed successfully.
- Attempted `fly deploy`, but the Fly CLI is not available in this environment and `fly` installer failed due to outbound network restrictions, so remote deploy and live `/webhook/facebook` log verification could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e87065228832597d06101f9c233db)