### PR TITLE
Refactor Messenger webhook to state-driven image/style flow

### DIFF
--- a/server/_core/messengerJobStore.ts
+++ b/server/_core/messengerJobStore.ts
@@ -1,0 +1,20 @@
+export type MessengerImageJob = {
+  userId: string;
+  style: string;
+  imageJobId: string;
+  timestamp: number;
+};
+
+const jobs: MessengerImageJob[] = [];
+
+export function recordImageJob(job: MessengerImageJob): void {
+  jobs.push(job);
+}
+
+export function listImageJobs(): MessengerImageJob[] {
+  return [...jobs];
+}
+
+export function resetImageJobs(): void {
+  jobs.length = 0;
+}

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,6 +1,7 @@
+import { createHash } from "crypto";
 import type { StyleId } from "./messengerStyles";
 
-export type MessengerFlowState = "new" | "awaiting_photo" | "awaiting_style" | "processing";
+export type MessengerFlowState = "idle" | "awaiting_style" | "processing";
 
 type QuotaState = {
   dayKey: string;
@@ -8,10 +9,13 @@ type QuotaState = {
 };
 
 export type MessengerUserState = {
+  stage: MessengerFlowState;
+  lastPhoto: string | null;
+  selectedStyle: string | null;
+  // legacy fields kept to avoid breaking current modules
   state: MessengerFlowState;
   lastPhotoUrl?: string;
   chosenStyle?: string;
-  // legacy fields kept to avoid breaking current modules
   pendingImageUrl?: string;
   pendingImageAt?: number;
   lastImageUrl?: string;
@@ -23,14 +27,20 @@ export type MessengerUserState = {
 };
 
 const DEFAULT_DAY_KEY = "1970-01-01";
-const stateByPsid = new Map<string, MessengerUserState>();
+const DEFAULT_HASH_SALT = "local-dev-salt";
+const stateByUserId = new Map<string, MessengerUserState>();
+
+export function anonymizePsid(psid: string): string {
+  const salt = process.env.MESSENGER_PSID_SALT ?? DEFAULT_HASH_SALT;
+  return createHash("sha256").update(`${psid}${salt}`).digest("hex");
+}
 
 export function getDayKey(now = Date.now()): string {
   return new Date(now).toISOString().slice(0, 10);
 }
 
-export function getOrCreateState(psid: string): MessengerUserState {
-  const existing = stateByPsid.get(psid);
+export function getOrCreateState(userId: string): MessengerUserState {
+  const existing = stateByUserId.get(userId);
 
   if (existing) {
     existing.updatedAt = Date.now();
@@ -38,7 +48,10 @@ export function getOrCreateState(psid: string): MessengerUserState {
   }
 
   const created: MessengerUserState = {
-    state: "new",
+    stage: "idle",
+    state: "idle",
+    lastPhoto: null,
+    selectedStyle: null,
     quota: {
       dayKey: DEFAULT_DAY_KEY,
       count: 0,
@@ -46,52 +59,56 @@ export function getOrCreateState(psid: string): MessengerUserState {
     updatedAt: Date.now(),
   };
 
-  stateByPsid.set(psid, created);
+  stateByUserId.set(userId, created);
   return created;
 }
 
-export function setFlowState(psid: string, nextState: MessengerFlowState, now = Date.now()): MessengerUserState {
-  const state = getOrCreateState(psid);
+export function setFlowState(userId: string, nextState: MessengerFlowState, now = Date.now()): MessengerUserState {
+  const state = getOrCreateState(userId);
+  state.stage = nextState;
   state.state = nextState;
   state.updatedAt = now;
   return state;
 }
 
-export function setPendingImage(psid: string, imageUrl: string, now = Date.now()): void {
-  const state = getOrCreateState(psid);
+export function setPendingImage(userId: string, imageUrl: string, now = Date.now()): void {
+  const state = getOrCreateState(userId);
+  state.lastPhoto = imageUrl;
   state.lastPhotoUrl = imageUrl;
   state.pendingImageUrl = imageUrl;
   state.pendingImageAt = now;
+  state.stage = "awaiting_style";
   state.state = "awaiting_style";
   state.updatedAt = now;
 }
 
-export function setChosenStyle(psid: string, style: string, now = Date.now()): void {
-  const state = getOrCreateState(psid);
+export function setChosenStyle(userId: string, style: string, now = Date.now()): void {
+  const state = getOrCreateState(userId);
+  state.selectedStyle = style;
   state.chosenStyle = style;
   state.updatedAt = now;
 }
 
-export function setLastGenerated(psid: string, style: StyleId, resultImageUrl: string, now = Date.now()): void {
-  const state = getOrCreateState(psid);
+export function setLastGenerated(userId: string, style: StyleId, resultImageUrl: string, now = Date.now()): void {
+  const state = getOrCreateState(userId);
   state.lastStyle = style;
   state.lastImageUrl = resultImageUrl;
   state.lastGeneratedAt = now;
   state.updatedAt = now;
 }
 
-export function getState(psid: string): MessengerUserState | undefined {
-  return stateByPsid.get(psid);
+export function getState(userId: string): MessengerUserState | undefined {
+  return stateByUserId.get(userId);
 }
 
 export function pruneOldState(maxAgeMs = 1000 * 60 * 60 * 24 * 7, now = Date.now()): void {
-  for (const [psid, state] of Array.from(stateByPsid.entries())) {
+  for (const [userId, state] of Array.from(stateByUserId.entries())) {
     if (now - state.updatedAt > maxAgeMs) {
-      stateByPsid.delete(psid);
+      stateByUserId.delete(userId);
     }
   }
 }
 
 export function resetStateStore(): void {
-  stateByPsid.clear();
+  stateByUserId.clear();
 }

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "crypto";
 import express from "express";
 import { sendQuickReplies, sendText, safeLog } from "./messengerApi";
-import { pruneOldState, setChosenStyle, setFlowState, setPendingImage, getOrCreateState } from "./messengerState";
+import { recordImageJob } from "./messengerJobStore";
+import { anonymizePsid, getOrCreateState, pruneOldState, setChosenStyle, setFlowState, setPendingImage } from "./messengerState";
 
 type FacebookWebhookEvent = {
   sender?: { id?: string };
@@ -16,8 +18,9 @@ type FacebookWebhookEvent = {
   };
 };
 
-const STYLE_OPTIONS = ["Disco", "Anime", "Gold", "Clouds", "Cinematic", "Pixel"] as const;
+const STYLE_OPTIONS = ["Disco", "Gold", "Anime", "Clouds"] as const;
 const STYLE_PAYLOAD_PREFIX = "STYLE_";
+const GREETINGS = new Set(["hi", "hello", "hey", "yo", "hola"]);
 
 function stylePayloadToLabel(payload: string): string | undefined {
   if (!payload.startsWith(STYLE_PAYLOAD_PREFIX)) {
@@ -28,96 +31,71 @@ function stylePayloadToLabel(payload: string): string | undefined {
   return STYLE_OPTIONS.find(style => style.toLowerCase() === name);
 }
 
-async function sendStartMenu(psid: string): Promise<void> {
-  await sendQuickReplies(psid, "Welcome 👋 Pick a quick start:", [
-    { content_type: "text", title: "📸 Send photo", payload: "SEND_PHOTO" },
-    { content_type: "text", title: "✨ Choose style", payload: "CHOOSE_STYLE" },
-    { content_type: "text", title: "🔥 Trending", payload: "TRENDING" },
-    { content_type: "text", title: "❓ Help", payload: "HELP" },
-  ]);
+function parseStyle(text: string): string | undefined {
+  const normalized = text.trim().toLowerCase();
+  return STYLE_OPTIONS.find(style => style.toLowerCase() === normalized);
+}
+
+async function sendGreeting(psid: string): Promise<void> {
+  await sendText(psid, "Hey 👋");
+  await sendText(psid, "Send me a photo and I’ll transform it into something special.");
+  await sendText(psid, "Or tell me what vibe you want (disco, gold, anime, clouds…).");
 }
 
 async function sendStylePicker(psid: string): Promise<void> {
-  await sendQuickReplies(psid, "Pick a style:", STYLE_OPTIONS.map(style => ({
+  await sendQuickReplies(psid, "Nice, got it. What style should I use?", STYLE_OPTIONS.map(style => ({
     content_type: "text" as const,
     title: style,
     payload: `${STYLE_PAYLOAD_PREFIX}${style.toUpperCase()}`,
   })));
 }
 
-async function sendTrending(psid: string): Promise<void> {
-  await sendText(psid, "Trending now: Disco, Anime, Gold.");
-  await sendText(psid, "Send a photo and I’ll apply your pick.");
+async function explainFlow(psid: string): Promise<void> {
+  await sendText(psid, "I turn photos into stylized images.");
+  await sendText(psid, "Send me a picture and choose a vibe.");
 }
 
-async function sendHelp(psid: string): Promise<void> {
-  await sendText(psid, "Quick flow: send a photo, pick a style, get your result.");
-  await sendQuickReplies(psid, "What do you want to do next?", [
-    { content_type: "text", title: "📸 Send photo", payload: "SEND_PHOTO" },
-    { content_type: "text", title: "✨ Choose style", payload: "CHOOSE_STYLE" },
-  ]);
+async function runMockGeneration(psid: string, userId: string, style: string): Promise<void> {
+  setFlowState(userId, "processing");
+  const imageJobId = randomUUID();
+
+  recordImageJob({
+    userId,
+    style,
+    imageJobId,
+    timestamp: Date.now(),
+  });
+
+  await sendText(psid, `Perfect — applying ${style} style now (mock) ✨`);
+  await sendText(psid, `Job queued: ${imageJobId}`);
+  await sendText(psid, "You can send another photo any time.");
+
+  setFlowState(userId, "idle");
 }
 
-async function handleStyleSelection(psid: string, style: string): Promise<void> {
-  const state = getOrCreateState(psid);
-  setChosenStyle(psid, style);
+async function handleStyleSelection(psid: string, userId: string, style: string): Promise<void> {
+  const state = getOrCreateState(userId);
+  setChosenStyle(userId, style);
 
-  if (!state.lastPhotoUrl) {
-    setFlowState(psid, "awaiting_photo");
-    await sendText(psid, `Nice choice: ${style}. Now send a photo 📸`);
+  if (!state.lastPhoto) {
+    await sendText(psid, `Nice choice: ${style}. Send me a photo first 📸`);
     return;
   }
 
-  setFlowState(psid, "processing");
-  await sendText(psid, "Got it — processing…");
-  await sendQuickReplies(psid, "Want to try another style too?", [
-    { content_type: "text", title: "✨ Choose style", payload: "CHOOSE_STYLE" },
-    { content_type: "text", title: "📸 Send new photo", payload: "SEND_PHOTO" },
-  ]);
+  await runMockGeneration(psid, userId, style);
 }
 
-async function handlePayload(psid: string, payload: string): Promise<void> {
-  if (payload === "SEND_PHOTO") {
-    setFlowState(psid, "awaiting_photo");
-    await sendText(psid, "Great — send your photo now 📸");
-    return;
-  }
-
-  if (payload === "CHOOSE_STYLE") {
-    const state = getOrCreateState(psid);
-    if (!state.lastPhotoUrl) {
-      setFlowState(psid, "awaiting_photo");
-      await sendStylePicker(psid);
-      await sendText(psid, "Pick any style, then send your photo 📸");
-      return;
-    }
-
-    setFlowState(psid, "awaiting_style");
-    await sendStylePicker(psid);
-    return;
-  }
-
-  if (payload === "TRENDING") {
-    setFlowState(psid, "awaiting_photo");
-    await sendTrending(psid);
-    return;
-  }
-
-  if (payload === "HELP") {
-    await sendHelp(psid);
-    return;
-  }
-
+async function handlePayload(psid: string, userId: string, payload: string): Promise<void> {
   const selectedStyle = stylePayloadToLabel(payload);
   if (selectedStyle) {
-    await handleStyleSelection(psid, selectedStyle);
+    await handleStyleSelection(psid, userId, selectedStyle);
     return;
   }
 
-  safeLog("unknown_payload", { psid, payload });
+  safeLog("unknown_payload", { userId, payload });
 }
 
-async function handleMessage(psid: string, event: FacebookWebhookEvent): Promise<void> {
+async function handleMessage(psid: string, userId: string, event: FacebookWebhookEvent): Promise<void> {
   const message = event.message;
 
   if (!message || message.is_echo) {
@@ -126,33 +104,34 @@ async function handleMessage(psid: string, event: FacebookWebhookEvent): Promise
 
   const quickPayload = message.quick_reply?.payload;
   if (quickPayload) {
-    await handlePayload(psid, quickPayload);
+    await handlePayload(psid, userId, quickPayload);
     return;
   }
 
   const imageAttachment = message.attachments?.find(att => att.type === "image" && att.payload?.url);
   if (imageAttachment?.payload?.url) {
-    setPendingImage(psid, imageAttachment.payload.url);
-    await sendText(psid, "Photo received ✅");
+    setPendingImage(userId, imageAttachment.payload.url);
     await sendStylePicker(psid);
     return;
   }
 
-  const text = message.text?.trim().toLowerCase();
+  const text = message.text?.trim();
   if (!text) {
     return;
   }
 
-  const state = getOrCreateState(psid);
-  if (state.state === "new" || text === "start" || text === "hi") {
-    await sendStartMenu(psid);
+  const styleFromText = parseStyle(text);
+  if (styleFromText) {
+    await handleStyleSelection(psid, userId, styleFromText);
     return;
   }
 
-  await sendQuickReplies(psid, "Next step:", [
-    { content_type: "text", title: "📸 Send photo", payload: "SEND_PHOTO" },
-    { content_type: "text", title: "✨ Choose style", payload: "CHOOSE_STYLE" },
-  ]);
+  if (GREETINGS.has(text.toLowerCase())) {
+    await sendGreeting(psid);
+    return;
+  }
+
+  await explainFlow(psid);
 }
 
 async function handleEvent(event: FacebookWebhookEvent): Promise<void> {
@@ -161,12 +140,14 @@ async function handleEvent(event: FacebookWebhookEvent): Promise<void> {
     return;
   }
 
+  const userId = anonymizePsid(psid);
+
   if (event.postback?.payload) {
-    await handlePayload(psid, event.postback.payload);
+    await handlePayload(psid, userId, event.postback.payload);
     return;
   }
 
-  await handleMessage(psid, event);
+  await handleMessage(psid, userId, event);
 }
 
 export function registerMetaWebhookRoutes(app: express.Express): void {


### PR DESCRIPTION
## Summary
- rewrote the Messenger webhook flow to be state-driven based on whether a user has sent a photo and/or selected a style
- updated conversation behavior for three scenarios:
  - greeting text opens with a natural prompt
  - image-first flow asks for style with quick replies
  - random text explains how the bot works
- removed dependency on keyword-triggered behavior and parse style directly from text/quick-reply payloads
- added anonymous user identity handling by hashing PSID with SHA-256 + salt before in-memory state storage/logging
- introduced a minimal in-memory image job recorder that stores only `userId` (hashed), `style`, `imageJobId`, and `timestamp`

## Files changed
- `server/_core/messengerWebhook.ts`
- `server/_core/messengerState.ts`
- `server/_core/messengerJobStore.ts` (new)
- `server/messengerState.test.ts`

## Notes
- this keeps outbound Messenger sends using raw PSID (required by Graph API), while internal state persistence uses anonymized IDs
- flow currently performs mock generation and queues a mock job id as requested

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ed5caca308325a26db0ec1d18e5b4)