### PR TITLE
Add webhook dedupe for duplicate Messenger message events

### DIFF
--- a/server/_core/dedupe.ts
+++ b/server/_core/dedupe.ts
@@ -1,0 +1,65 @@
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_MAX_ENTRIES = 5000;
+
+export class TtlDedupeSet {
+  private readonly entries = new Map<string, number>();
+
+  constructor(
+    private readonly ttlMs: number = DEFAULT_TTL_MS,
+    private readonly maxEntries: number = DEFAULT_MAX_ENTRIES
+  ) {}
+
+  has(key: string, now = Date.now()): boolean {
+    this.prune(now);
+
+    const expiresAt = this.entries.get(key);
+    if (!expiresAt) {
+      return false;
+    }
+
+    if (expiresAt <= now) {
+      this.entries.delete(key);
+      return false;
+    }
+
+    return true;
+  }
+
+  add(key: string, now = Date.now()): void {
+    this.prune(now);
+
+    this.entries.delete(key);
+    this.entries.set(key, now + this.ttlMs);
+
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.entries.delete(oldestKey);
+    }
+  }
+
+  seen(key: string, now = Date.now()): boolean {
+    if (this.has(key, now)) {
+      return true;
+    }
+
+    this.add(key, now);
+    return false;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private prune(now: number): void {
+    this.entries.forEach((expiresAt, key) => {
+      if (expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    });
+  }
+}
+
+export { DEFAULT_MAX_ENTRIES, DEFAULT_TTL_MS };

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendQuickRepliesMock, sendTextMock, safeLogMock } = vi.hoisted(() => ({
+  sendQuickRepliesMock: vi.fn(async () => undefined),
+  sendTextMock: vi.fn(async () => undefined),
+  safeLogMock: vi.fn(),
+}));
+
+vi.mock("./_core/messengerApi", () => ({
+  sendQuickReplies: sendQuickRepliesMock,
+  sendText: sendTextMock,
+  safeLog: safeLogMock,
+}));
+
+import { processFacebookWebhookPayload, resetMessengerEventDedupe } from "./_core/messengerWebhook";
+import { resetStateStore } from "./_core/messengerState";
+
+describe("messenger webhook dedupe", () => {
+  beforeEach(() => {
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+    resetStateStore();
+    resetMessengerEventDedupe();
+  });
+
+  it("processes a message.mid only once", async () => {
+    const payload = {
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "psid-123" },
+              message: {
+                mid: "m_abc123",
+                attachments: [{ type: "image", payload: { url: "https://img.example/a.jpg" } }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    await processFacebookWebhookPayload(payload);
+    await processFacebookWebhookPayload(payload);
+
+    expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to sender+timestamp dedupe when mid is missing", async () => {
+    const payload = {
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "psid-456" },
+              timestamp: 1730000000000,
+              message: {
+                attachments: [{ type: "image", payload: { url: "https://img.example/b.jpg" } }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    await processFacebookWebhookPayload(payload);
+    await processFacebookWebhookPayload(payload);
+
+    expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent duplicate bot replies when the same Messenger webhook event is delivered more than once by deduping on the Messenger `message.mid` (or falling back to `sender + timestamp`).
- Make webhook processing easier to unit-test and safer by short-circuiting duplicate events before any reply logic runs.

### Description
- Added a reusable TTL/LRU-style helper `TtlDedupeSet` with bounded size and expiry semantics at `server/_core/dedupe.ts` and used a 10-minute default window.
- Updated `server/_core/messengerWebhook.ts` to read `message.mid` and `timestamp`, derive a dedupe key via `getEventDedupeKey`, and skip processing when an event key was seen, logging duplicates with `safeLog`.
- Extracted payload handling into `processFacebookWebhookPayload(payload)` and exported `resetMessengerEventDedupe()` to make dedupe behavior testable and to keep route handlers thin.
- Added unit tests in `server/messengerWebhook.test.ts` that mock `messengerApi`, replay the same payload twice, and assert only a single reply is produced for both `mid` and fallback dedupe scenarios.

### Testing
- Ran `pnpm check` (`tsc --noEmit`) and it completed successfully after minor adjustments to iteration/prune logic.
- Ran the test suite with `pnpm test` and all tests passed, including the new `server/messengerWebhook.test.ts` (total: 17 tests across 4 files).
- The tests assert the dedupe behavior by replaying identical payloads and verifying only one reply call was made in each case.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef46890f88325b32d8778a18f61c7)