### PR TITLE
Make Messenger greetings context-aware by conversation state

### DIFF
--- a/server/messengerWebhook.greeting.test.ts
+++ b/server/messengerWebhook.greeting.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getGreetingResponse } from "./_core/messengerWebhook";
+
+describe("greeting handling by conversation state", () => {
+  it("returns processing text while PROCESSING", () => {
+    expect(getGreetingResponse("PROCESSING")).toEqual({
+      mode: "text",
+      text: "I’m still working on it—few seconds.",
+    });
+  });
+
+  it("returns style picker prompt while AWAITING_STYLE", () => {
+    expect(getGreetingResponse("AWAITING_STYLE")).toEqual({
+      mode: "quick_replies",
+      state: "AWAITING_STYLE",
+      text: "Top — kies een style hieronder 👇",
+    });
+  });
+
+  it("returns follow-up options while RESULT_READY", () => {
+    expect(getGreetingResponse("RESULT_READY")).toEqual({
+      mode: "quick_replies",
+      state: "RESULT_READY",
+      text: "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+    });
+  });
+
+  it("returns quick start welcome only in IDLE", () => {
+    expect(getGreetingResponse("IDLE")).toEqual({
+      mode: "quick_replies",
+      state: "IDLE",
+      text: "Welcome 👋 Pick a quick start.",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent greetings like “Hi” from resetting users to the generic welcome and instead respond based on the current `ConversationState` so interactions remain context-aware.
- Provide clearer, state-appropriate prompts (e.g. style picker when awaiting style, follow-up choices when results are ready, and a short processing message while generating).

### Description
- Added `getGreetingResponse(state: ConversationState)` to map conversation states to deterministic greeting responses (text vs quick replies) and exported the `GreetingResponse` type.
- Reworked `sendGreeting` to accept a `state` parameter and to send either a text message or quick replies depending on `getGreetingResponse`.
- Updated message handling so greeting messages use the anonymized user’s current `stage` (`getOrCreateState(userId).stage`) before calling `sendGreeting`.
- Added unit tests in `server/messengerWebhook.greeting.test.ts` to cover `PROCESSING`, `AWAITING_STYLE`, `RESULT_READY`, and `IDLE` behaviors and adjusted greeting copy (including localized prompts).

### Testing
- Ran the focused test suite with `pnpm test server/messengerWebhook.greeting.test.ts server/messengerState.test.ts` and both test files passed (total 8 tests passed).
- Executed type checking with `pnpm check` (`tsc --noEmit`) which completed successfully.
- Existing messenger state tests in `server/messengerState.test.ts` were run as part of the test command and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef5197da483259da4495108fd6ab7)