### PR TITLE
Make Messenger greetings context-aware by conversation state

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -47,8 +47,8 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
   ],
   PROCESSING: [],
   RESULT_READY: [
-    { title: "Choose style", payload: "CHOOSE_STYLE" },
-    { title: "Send new photo", payload: "SEND_PHOTO" },
+    { title: "Try another style", payload: "CHOOSE_STYLE" },
+    { title: "New photo", payload: "SEND_PHOTO" },
   ],
 };
 

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -85,16 +85,41 @@ async function sendStateQuickReplies(psid: string, state: ConversationState, tex
 }
 
 async function sendGreeting(psid: string): Promise<void> {
-  await sendText(psid, "Hey 👋");
-  await sendStateQuickReplies(psid, "IDLE", "Send me a photo and I’ll transform it into something special.");
+  await sendStateQuickReplies(psid, "IDLE", "Welcome 👋 Pick a quick start.");
 }
 
 async function sendStylePicker(psid: string): Promise<void> {
-  await sendStateQuickReplies(psid, "AWAITING_STYLE", "Nice, got it. What style should I use?");
+  await sendStateQuickReplies(psid, "AWAITING_STYLE", "Top — kies een style hieronder 👇");
 }
 
 async function explainFlow(psid: string): Promise<void> {
   await sendStateQuickReplies(psid, "IDLE", "I turn photos into stylized images. Send me a picture to start.");
+}
+
+async function handleGreeting(psid: string, userId: string): Promise<void> {
+  const state = getOrCreateState(userId);
+
+  switch (state.stage) {
+    case "PROCESSING":
+      await sendText(psid, "I’m still working on it—few seconds.");
+      return;
+    case "AWAITING_STYLE":
+      await sendStylePicker(psid);
+      return;
+    case "RESULT_READY":
+      await sendStateQuickReplies(
+        psid,
+        "RESULT_READY",
+        "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?"
+      );
+      return;
+    case "AWAITING_PHOTO":
+      await sendStateQuickReplies(psid, "AWAITING_PHOTO", "Send a photo when you’re ready 📸");
+      return;
+    case "IDLE":
+    default:
+      await sendGreeting(psid);
+  }
 }
 
 async function runMockGeneration(psid: string, userId: string, style: string): Promise<void> {
@@ -182,7 +207,7 @@ async function handleMessage(psid: string, userId: string, event: FacebookWebhoo
   }
 
   if (GREETINGS.has(text.toLowerCase())) {
-    await sendGreeting(psid);
+    await handleGreeting(psid, userId);
     return;
   }
 

--- a/server/messengerState.test.ts
+++ b/server/messengerState.test.ts
@@ -47,8 +47,8 @@ describe("messenger state flow", () => {
     ]);
     expect(getQuickRepliesForState("PROCESSING")).toEqual([]);
     expect(getQuickRepliesForState("RESULT_READY")).toEqual([
-      { title: "Choose style", payload: "CHOOSE_STYLE" },
-      { title: "Send new photo", payload: "SEND_PHOTO" },
+      { title: "Try another style", payload: "CHOOSE_STYLE" },
+      { title: "New photo", payload: "SEND_PHOTO" },
     ]);
   });
 

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -13,7 +13,7 @@ vi.mock("./_core/messengerApi", () => ({
 }));
 
 import { processFacebookWebhookPayload, resetMessengerEventDedupe } from "./_core/messengerWebhook";
-import { resetStateStore } from "./_core/messengerState";
+import { anonymizePsid, resetStateStore, setFlowState } from "./_core/messengerState";
 
 describe("messenger webhook dedupe", () => {
   beforeEach(() => {
@@ -67,5 +67,120 @@ describe("messenger webhook dedupe", () => {
     await processFacebookWebhookPayload(payload);
 
     expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("messenger greeting behavior", () => {
+  beforeEach(() => {
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+    resetStateStore();
+    resetMessengerEventDedupe();
+  });
+
+  it("shows welcome quick start in IDLE", async () => {
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "idle-user" },
+              message: { mid: "mid-idle-1", text: "Hi" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendTextMock).not.toHaveBeenCalled();
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      "idle-user",
+      "Welcome 👋 Pick a quick start.",
+      [{ content_type: "text", title: "Send photo", payload: "SEND_PHOTO" }]
+    );
+  });
+
+  it("keeps users in AWAITING_STYLE when they send a greeting", async () => {
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "style-user" },
+              message: {
+                mid: "mid-style-1",
+                attachments: [{ type: "image", payload: { url: "https://img.example/style.jpg" } }],
+              },
+            },
+            {
+              sender: { id: "style-user" },
+              message: { mid: "mid-style-2", text: "Hi" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendTextMock).not.toHaveBeenCalled();
+    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
+      "style-user",
+      "Top — kies een style hieronder 👇",
+      [
+        { content_type: "text", title: "Disco", payload: "STYLE_DISCO" },
+        { content_type: "text", title: "Gold", payload: "STYLE_GOLD" },
+        { content_type: "text", title: "Anime", payload: "STYLE_ANIME" },
+        { content_type: "text", title: "Clouds", payload: "STYLE_CLOUDS" },
+      ]
+    );
+  });
+
+  it("offers follow-up quick actions when state is RESULT_READY", async () => {
+    const psid = "result-user";
+    const userId = anonymizePsid(psid);
+    setFlowState(userId, "RESULT_READY");
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: { mid: "mid-result-1", text: "Hey" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+      [
+        { content_type: "text", title: "Try another style", payload: "CHOOSE_STYLE" },
+        { content_type: "text", title: "New photo", payload: "SEND_PHOTO" },
+      ]
+    );
+  });
+
+  it("does not reset while PROCESSING and asks user to wait", async () => {
+    const psid = "processing-user";
+    const userId = anonymizePsid(psid);
+    setFlowState(userId, "PROCESSING");
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: { mid: "mid-processing-1", text: "Yo" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendQuickRepliesMock).not.toHaveBeenCalled();
+    expect(sendTextMock).toHaveBeenCalledWith(psid, "I’m still working on it—few seconds.");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the bot from resetting to the generic welcome flow whenever the user says a greeting, and make greetings context-aware based on the current `ConversationState`.
- Provide clearer, state-appropriate prompts for users in `PROCESSING`, `AWAITING_STYLE`, `RESULT_READY`, and only show the full welcome in `IDLE`.

### Description
- Introduced a new `handleGreeting` function that inspects `getOrCreateState(userId).stage` and branches for `PROCESSING`, `AWAITING_STYLE`, `RESULT_READY`, `AWAITING_PHOTO`, and `IDLE`.
- Replaced the previous unconditional greeting behavior in `handleMessage` to call `handleGreeting` when a greeting is detected.
- Updated copy for `sendGreeting` and `sendStylePicker` to the new UX strings and made `sendGreeting` send the `IDLE` quick replies using `sendStateQuickReplies`.
- Changed `RESULT_READY` quick-reply labels in `server/_core/messengerState.ts` from `Choose style` / `Send new photo` to `Try another style` / `New photo`.
- Added/updated tests in `server/messengerWebhook.test.ts` and `server/messengerState.test.ts` to cover greeting behavior for `IDLE`, `AWAITING_STYLE`, `RESULT_READY`, and `PROCESSING`, and to assert the new `RESULT_READY` quick-reply labels.

### Testing
- Ran `pnpm vitest run server/messengerWebhook.test.ts server/messengerState.test.ts`, which executed 2 test files and all tests passed (10 tests total).
- The updated tests verify the new greeting responses and quick-reply mappings and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ef56ce22c8325b2fa11d484a2980b)