### PR TITLE
Add /__version debug endpoint and boot version logging

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -11,8 +11,18 @@ import { registerMetaWebhookRoutes } from "./messengerWebhook";
 
 const appVersion = process.env.GIT_SHA || process.env.SOURCE_VERSION || "dev";
 
+function buildVersionPayload() {
+  return {
+    gitSha: process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? null,
+    nodeEnv: process.env.NODE_ENV,
+    appVersion,
+    timestamp: new Date().toISOString(),
+  };
+}
+
 async function startServer() {
   console.log("BOOT", { pid: process.pid });
+  console.log("VERSION", buildVersionPayload());
 
   const app = express();
   const server = createServer(app);
@@ -40,6 +50,10 @@ async function startServer() {
 
   app.get("/healthz", (_req, res) => {
     res.status(200).send("ok");
+  });
+
+  app.get("/__version", (_req, res) => {
+    res.status(200).json(buildVersionPayload());
   });
 
   app.get("/debug/build", (req, res) => {


### PR DESCRIPTION
### Motivation
- Expose lightweight, non-secret runtime metadata for debugging and deploy traceability via an HTTP endpoint and a one-time boot log.

### Description
- Add a `buildVersionPayload()` helper and log it on boot with `console.log("VERSION", buildVersionPayload())`, and add `GET /__version` that returns JSON with `gitSha: process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? null`, `nodeEnv: process.env.NODE_ENV`, `appVersion` (existing constant), and `timestamp: new Date().toISOString()` without exposing any secrets.

### Testing
- Ran `pnpm check` (TypeScript `tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f0163f8a083258b3670b8784fe8ed)