### PR TITLE
Expose git SHA + boot timestamp at /__version and log on boot

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -9,14 +9,13 @@ import { createContext } from "./context";
 import { serveStatic } from "./vite";
 import { registerMetaWebhookRoutes } from "./messengerWebhook";
 
-const appVersion = process.env.GIT_SHA || process.env.SOURCE_VERSION || "dev";
+const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
+const bootTimestamp = new Date().toISOString();
 
 function buildVersionPayload() {
   return {
-    gitSha: process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? null,
-    nodeEnv: process.env.NODE_ENV,
-    appVersion,
-    timestamp: new Date().toISOString(),
+    gitSha,
+    timestamp: bootTimestamp,
   };
 }
 
@@ -66,7 +65,7 @@ async function startServer() {
 
     return res.status(200).json({
       name: "leaderbot-images",
-      version: appVersion,
+      version: gitSha,
       uptime_s: Math.floor(process.uptime()),
       node: process.version,
       envFlags: {


### PR DESCRIPTION
### Motivation

- Provide a stable, boot-time version payload so external systems can identify the exact git SHA and server start time. 

### Description

- Replace runtime `appVersion` with a single `gitSha` value and capture `bootTimestamp` at process start in `server/_core/index.ts`.
- `buildVersionPayload()` now returns `{ gitSha, timestamp }` and `/__version` serves that payload.
- `/debug/build` now reports the same `gitSha` for consistency and boot logs continue to print the new payload shape at startup.

### Testing

- Ran TypeScript checks with `pnpm -s check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f026c4af4832596019826d8b93312)