### PR TITLE
Handle Messenger mid dedupe and context-aware greeting/smalltalk

### DIFF
--- a/server/messengerWebhook.greeting.test.ts
+++ b/server/messengerWebhook.greeting.test.ts
@@ -13,7 +13,7 @@ describe("greeting handling by conversation state", () => {
     expect(getGreetingResponse("AWAITING_STYLE")).toEqual({
       mode: "quick_replies",
       state: "AWAITING_STYLE",
-      text: "Top — kies een style hieronder 👇",
+      text: "What style should I use?",
     });
   });
 


### PR DESCRIPTION
### Motivation
- Prevent Messenger echo events from consuming `message.mid` dedupe keys and ensure real user messages are processed idempotently by `mid` (with sender+timestamp fallback).
- Make greeting and common smalltalk responses respect the current conversation state so they don't reset flows (e.g. moving users back to `AWAITING_PHOTO`).

### Description
- Ignore echo events early at the event boundary so `is_echo` messages are dropped before the TTL dedupe check. (`server/_core/messengerWebhook.ts`)
- Preserve `message.mid` as the primary dedupe key with the existing `fallback:sender:timestamp` behavior when `mid` is missing via `getEventDedupeKey` and the `TtlDedupeSet` instance. (`server/_core/messengerWebhook.ts`)
- Add a `getGreetingResponse` helper that returns state-aware responses and refactor `handleGreeting` to reuse it so greetings/smalltalk reply appropriately for `PROCESSING`, `AWAITING_STYLE`, `RESULT_READY`, `AWAITING_PHOTO`, and `IDLE`. (`server/_core/messengerWebhook.ts`)
- Expand smalltalk detection (`thanks`, `thank you`, `how are you`, etc.) and route smalltalk through the same state-aware greeting path instead of resetting the flow. (`server/_core/messengerWebhook.ts`)
- Update and add unit tests to validate `mid` dedupe behavior, echo-ignore behavior that doesn't poison dedupe, and that smalltalk/greetings do not reset an `AWAITING_STYLE`/`RESULT_READY` flow. (modified `server/messengerWebhook.test.ts` and `server/messengerWebhook.greeting.test.ts`)

### Testing
- Ran `pnpm -s vitest run server/messengerWebhook.test.ts server/messengerWebhook.greeting.test.ts` and all tests in those files passed. 
- Ran `pnpm -s vitest run server/messengerState.test.ts` and the state tests passed. 
- Tests exercise `mid` idempotency, echo handling, greeting/smalltalk routing, and quick-reply payload flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f028ce2ec8325a98c1b1f3e104662)