### PR TITLE
Classify webhook events as read/delivery/postback/message in summarizeWebhook

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -69,8 +69,15 @@ export function summarizeWebhook(body: unknown): WebhookSummary {
         .map(attachment => attachment?.type)
         .filter((type): type is string => typeof type === "string");
 
+      const type =
+        event.read ? "read" :
+        event.delivery ? "delivery" :
+        event.postback ? "postback" :
+        event.message ? "message" :
+        "other";
+
       summary.events.push({
-        type: event.postback ? "postback" : event.message ? "message" : "other",
+        type,
         hasText: typeof event.message?.text === "string",
         attachmentTypes,
         isEcho: Boolean(event.message?.is_echo),

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -34,7 +34,11 @@ describe("webhook summary logging", () => {
             },
             {
               postback: { payload: "STYLE_DISCO" },
+            },
+            {
               read: { watermark: 1 },
+            },
+            {
               delivery: { mids: ["mid-1"] },
             },
           ],
@@ -60,9 +64,27 @@ describe("webhook summary logging", () => {
           hasText: false,
           attachmentTypes: [],
           isEcho: false,
-          hasRead: true,
-          hasDelivery: true,
+          hasRead: false,
+          hasDelivery: false,
           hasPostback: true,
+        },
+        {
+          type: "read",
+          hasText: false,
+          attachmentTypes: [],
+          isEcho: false,
+          hasRead: true,
+          hasDelivery: false,
+          hasPostback: false,
+        },
+        {
+          type: "delivery",
+          hasText: false,
+          attachmentTypes: [],
+          isEcho: false,
+          hasRead: false,
+          hasDelivery: true,
+          hasPostback: false,
         },
       ],
     });


### PR DESCRIPTION
### Motivation
- Webhook summaries were labeling `read` and `delivery` events as `other`, which made logs harder to interpret.
- The change makes the human-readable `type` align with actual event flags for clearer debugging and observability.
- Tests were adjusted to validate each event kind independently.

### Description
- Compute a `type` constant in `summarizeWebhook` with priority `read` → `delivery` → `postback` → `message` → `other`, and use it when pushing into the summary in `server/_core/messengerWebhook.ts`.
- Update the unit test fixture in `server/messengerWebhook.test.ts` to include distinct `postback`, `read`, and `delivery` events and assert the new `type` labels and flags.
- Preserve the existing boolean metadata fields (`hasRead`, `hasDelivery`, `hasPostback`, `hasText`, `isEcho`) while improving the readable `type` label.

### Testing
- Ran `pnpm test server/messengerWebhook.test.ts` and the test suite passed with all tests succeeding (`7 passed`).
- The updated test verifies the `type` values for `message`, `postback`, `read`, and `delivery` events as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a00ab6c3d88325bc82132478640498)