### PR TITLE
Fix canonical style-to-demo filename mapping

### DIFF
--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -1,3 +1,20 @@
+export type Style =
+  | "caricature"
+  | "gold"
+  | "petals"
+  | "clouds"
+  | "cinematic"
+  | "disco";
+
+export const STYLE_TO_DEMO_FILE: Record<Style, string> = {
+  caricature: "01-caricature.png",
+  petals: "02-petals.png",
+  gold: "03-gold.png",
+  cinematic: "04-crayon.png",
+  disco: "05-paparazzi.png",
+  clouds: "06-clouds.png",
+};
+
 export type StyleId = "STYLE_DISCO" | "STYLE_CINEMATIC" | "STYLE_ANIME" | "STYLE_MEME";
 
 export type StyleConfig = {
@@ -71,4 +88,8 @@ export function getStyleById(styleId: StyleId): StyleConfig {
   }
 
   return style;
+}
+
+export function getDemoThumbnailUrl(style: Style): string {
+  return `/demo/${STYLE_TO_DEMO_FILE[style]}`;
 }

--- a/server/messengerStyles.test.ts
+++ b/server/messengerStyles.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { STYLE_TO_DEMO_FILE, getDemoThumbnailUrl, type Style } from "./_core/messengerStyles";
+
+describe("STYLE_TO_DEMO_FILE", () => {
+  it("maps canonical styles to the expected demo files", () => {
+    const expected: Record<Style, string> = {
+      caricature: "01-caricature.png",
+      petals: "02-petals.png",
+      gold: "03-gold.png",
+      cinematic: "04-crayon.png",
+      disco: "05-paparazzi.png",
+      clouds: "06-clouds.png",
+    };
+
+    expect(STYLE_TO_DEMO_FILE).toEqual(expected);
+  });
+
+  it("builds demo thumbnail URLs from mapped files", () => {
+    expect(getDemoThumbnailUrl("cinematic")).toBe("/demo/04-crayon.png");
+    expect(getDemoThumbnailUrl("disco")).toBe("/demo/05-paparazzi.png");
+  });
+});


### PR DESCRIPTION
### Motivation

- Enforce a canonical `Style` type with the six spec-approved keys and ensure demo filenames in `/public/demo` map deterministically to those keys to resolve existing mismatches.

### Description

- Added a `Style` union type with the exact keys `"caricature" | "gold" | "petals" | "clouds" | "cinematic" | "disco"` in `server/_core/messengerStyles.ts`.
- Added a deterministic mapping table `STYLE_TO_DEMO_FILE: Record<Style, string>` that implements the exact filename mapping required by the spec.
- Added a helper `getDemoThumbnailUrl(style: Style)` that builds stable `/demo/<filename>` URLs from the mapping table.
- Added unit tests in `server/messengerStyles.test.ts` to lock the mapping and URL derivation behavior.

### Testing

- Ran `pnpm vitest run server/messengerStyles.test.ts` and the file-level tests passed (2 tests passed).
- Ran the full suite with `pnpm vitest run` and all tests completed successfully (29 tests passed across 6 test files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a020901bb88325a24d189f18d5092f)