### PR TITLE
Serve local /demo assets on Fly and use them for MOCK_MODE (remove picsum)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@ FB_VERIFY_TOKEN=replace_with_verify_token
 FB_PAGE_ACCESS_TOKEN=replace_with_page_access_token
 # Optional: used to verify the X-Hub-Signature-256 header
 FB_APP_SECRET=optional_app_secret
+
+# Optional: absolute base URL used for mock Messenger image attachments
+APP_BASE_URL=http://localhost:3000
+# Optional: set to false to disable mock image generation
+MOCK_MODE=true

--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -176,7 +176,7 @@ Total: 13 tests passed, 0 failures
 
 ### Image Generation Integration
 
-**Current:** Mock images from `picsum.photos`  
+**Current:** Mock images now use local `/demo/*` assets  
 **Future:** Replace `getMockGeneratedImage()` in `imageService.ts`
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Copy `.env.example` to `.env` for local development and set:
 - `FB_PAGE_ACCESS_TOKEN`
 - `FB_APP_SECRET` (optional)
 - `ADMIN_TOKEN` (optional, required for `GET /debug/build`)
+- `APP_BASE_URL` (optional, defaults to `http://localhost:3000`; used for mock Messenger image attachments)
+- `MOCK_MODE` (optional, defaults to `true`)
 
 Do not commit secrets.
 

--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -15,62 +15,75 @@ export const STYLE_TO_DEMO_FILE: Record<Style, string> = {
   clouds: "06-clouds.png",
 };
 
-export type StyleId = "STYLE_DISCO" | "STYLE_CINEMATIC" | "STYLE_ANIME" | "STYLE_MEME";
+export type StyleId =
+  | "STYLE_CARICATURE"
+  | "STYLE_PETALS"
+  | "STYLE_GOLD"
+  | "STYLE_CINEMATIC"
+  | "STYLE_DISCO"
+  | "STYLE_CLOUDS";
 
 export type StyleConfig = {
   id: StyleId;
   payload: StyleId;
+  style: Style;
   label: string;
   demoThumbnailUrl: string;
   mockResultUrls: string[];
 };
 
-const baseMockUrl = "https://picsum.photos";
+function getLocalDemoUrl(style: Style): string {
+  return `/demo/${STYLE_TO_DEMO_FILE[style]}`;
+}
 
 export const STYLE_CONFIGS: StyleConfig[] = [
   {
+    id: "STYLE_CARICATURE",
+    payload: "STYLE_CARICATURE",
+    style: "caricature",
+    label: "🎨 Caricature",
+    demoThumbnailUrl: getLocalDemoUrl("caricature"),
+    mockResultUrls: [getLocalDemoUrl("caricature")],
+  },
+  {
+    id: "STYLE_PETALS",
+    payload: "STYLE_PETALS",
+    style: "petals",
+    label: "🌸 Petals",
+    demoThumbnailUrl: getLocalDemoUrl("petals"),
+    mockResultUrls: [getLocalDemoUrl("petals")],
+  },
+  {
+    id: "STYLE_GOLD",
+    payload: "STYLE_GOLD",
+    style: "gold",
+    label: "✨ Gold",
+    demoThumbnailUrl: getLocalDemoUrl("gold"),
+    mockResultUrls: [getLocalDemoUrl("gold")],
+  },
+  {
     id: "STYLE_DISCO",
     payload: "STYLE_DISCO",
+    style: "disco",
     label: "🪩 Disco Glow",
-    demoThumbnailUrl: `${baseMockUrl}/seed/disco-demo/640/640`,
-    mockResultUrls: [
-      `${baseMockUrl}/seed/disco-result-1/1024/1024`,
-      `${baseMockUrl}/seed/disco-result-2/1024/1024`,
-      `${baseMockUrl}/seed/disco-result-3/1024/1024`,
-    ],
+    demoThumbnailUrl: getLocalDemoUrl("disco"),
+    mockResultUrls: [getLocalDemoUrl("disco")],
   },
   {
     id: "STYLE_CINEMATIC",
     payload: "STYLE_CINEMATIC",
+    style: "cinematic",
     label: "🎬 Cinematic",
-    demoThumbnailUrl: `${baseMockUrl}/seed/cinematic-demo/640/640`,
-    mockResultUrls: [
-      `${baseMockUrl}/seed/cinematic-result-1/1024/1024`,
-      `${baseMockUrl}/seed/cinematic-result-2/1024/1024`,
-      `${baseMockUrl}/seed/cinematic-result-3/1024/1024`,
-    ],
+    demoThumbnailUrl: getLocalDemoUrl("cinematic"),
+    mockResultUrls: [getLocalDemoUrl("cinematic")],
   },
   {
-    id: "STYLE_ANIME",
-    payload: "STYLE_ANIME",
-    label: "🌸 Anime",
-    demoThumbnailUrl: `${baseMockUrl}/seed/anime-demo/640/640`,
-    mockResultUrls: [
-      `${baseMockUrl}/seed/anime-result-1/1024/1024`,
-      `${baseMockUrl}/seed/anime-result-2/1024/1024`,
-      `${baseMockUrl}/seed/anime-result-3/1024/1024`,
-    ],
-  },
-  {
-    id: "STYLE_MEME",
-    payload: "STYLE_MEME",
-    label: "😂 Meme",
-    demoThumbnailUrl: `${baseMockUrl}/seed/meme-demo/640/640`,
-    mockResultUrls: [
-      `${baseMockUrl}/seed/meme-result-1/1024/1024`,
-      `${baseMockUrl}/seed/meme-result-2/1024/1024`,
-      `${baseMockUrl}/seed/meme-result-3/1024/1024`,
-    ],
+    id: "STYLE_CLOUDS",
+    payload: "STYLE_CLOUDS",
+    style: "clouds",
+    label: "☁️ Clouds",
+    demoThumbnailUrl: getLocalDemoUrl("clouds"),
+    mockResultUrls: [getLocalDemoUrl("clouds")],
   },
 ];
 
@@ -91,5 +104,5 @@ export function getStyleById(styleId: StyleId): StyleConfig {
 }
 
 export function getDemoThumbnailUrl(style: Style): string {
-  return `/demo/${STYLE_TO_DEMO_FILE[style]}`;
+  return getLocalDemoUrl(style);
 }

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -231,7 +231,7 @@ function isMockModeEnabled(): boolean {
 }
 
 function getBaseUrl(): string {
-  const configuredBaseUrl = process.env.BASE_URL?.trim();
+  const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
 
   if (configuredBaseUrl && /^https?:\/\//.test(configuredBaseUrl)) {
     return configuredBaseUrl;

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -48,10 +48,7 @@ export async function setupVite(app: Express, server: Server, createViteServer: 
 }
 
 export function serveStatic(app: Express) {
-  const distPath =
-    process.env.NODE_ENV === "development"
-      ? path.resolve(import.meta.dirname, "../..", "dist", "public")
-      : path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname, "..", "public");
   if (!fs.existsSync(distPath)) {
     console.error(
       `Could not find the build directory: ${distPath}, make sure to build the client first`

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -241,7 +241,6 @@ describe("messenger webhook dedupe", () => {
 
         const [[, imageUrl]] = sendImageMock.mock.calls as [[string, string]];
         expect(imageUrl).toBe(`http://localhost:3000/demo/${filename}`);
-        expect(imageUrl).not.toContain("https://picsum.photos");
       }
     } finally {
       randomSpy.mockRestore();


### PR DESCRIPTION
### Motivation

- Ensure mock Messenger image attachments are real, local files (no external picsum) and reachable in production builds on Fly.
- Make base URL configurable so mock attachments use the app's public domain instead of a hardcoded host.
- Keep canonical style keys mapped end-to-end to specific demo images for reliable tests and Messenger flows.

### Description

- Serve production static files from `dist/public` by changing `serveStatic` to resolve `../public`, ensuring `/demo/*` is available in Fly runtime (`server/_core/vite.ts`).
- Replace `picsum.photos` mock configuration with explicit canonical style mappings and local demo URLs in `server/_core/messengerStyles.ts`, adding `StyleId` entries and mapping: `caricature -> 01-caricature.png`, `petals -> 02-petals.png`, `gold -> 03-gold.png`, `cinematic -> 04-crayon.png`, `disco -> 05-paparazzi.png`, `clouds -> 06-clouds.png`.
- Use `APP_BASE_URL` (falling back to `BASE_URL`) as the preferred base for mock image attachments and continue to return attachments at `${base}/demo/<file>` in `server/_core/messengerWebhook.ts`.
- Update environment docs and `.env.example` to document `APP_BASE_URL` and `MOCK_MODE`, and update `AUDIT_REPORT.md`/`README.md` to reflect local demo usage.
- Adjust tests to assert local `/demo/*` URLs and remove leftover `picsum` expectation (`server/messengerWebhook.test.ts`).

### Testing

- Ran unit tests: `pnpm test -- --run server/messengerStyles.test.ts server/messengerWebhook.test.ts`, all tests passed.
- Performed full build: `pnpm build`, which succeeded.
- Launched the built server and validated demo assets return `200` via `curl -I` checks for `/demo/01-caricature.png`, `/demo/04-crayon.png`, and `/demo/05-paparazzi.png`, all returned `200 OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0272db654832589897fd8e86aceff)