### PR TITLE
Include /public assets in runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY package.json pnpm-lock.yaml ./
 COPY patches ./patches
 RUN pnpm install --prod --frozen-lockfile
 COPY --from=build /app/dist ./dist
+COPY --from=build /app/public ./public
 
 EXPOSE 8080
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
### Motivation
- The runtime image contained `/app/dist` but not `/app/public`, causing static demo assets to 404 or produce `ENOENT` when serving `/demo/*` endpoints.

### Description
- Add `COPY --from=build /app/public ./public` to the final runtime stage of `Dockerfile` so `/app/public` from the builder stage is present in the runtime image, and keep the existing multi-stage build and builder alias (`build`) unchanged.

### Testing
- Attempted `docker build -t leaderbot-fb-image-gen:test .` failed because the `docker` CLI is not available in this environment (build could not be executed here).
- Static verification commands succeeded: inspected `Dockerfile` to confirm the new `COPY --from=build /app/public ./public` line and inspected `.dockerignore` to confirm `public/` is not excluded; the repository contains the `public/demo` files listed by the workspace scan.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a02e9434f08325be06d2acc0d81992)