### PR TITLE
Use local demo image attachments directly in mock Messenger flow

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,9 +1,7 @@
-import { randomUUID } from "crypto";
 import express from "express";
 import { TtlDedupeSet } from "./dedupe";
 import { sendImage, sendQuickReplies, sendText, safeLog } from "./messengerApi";
 import { STYLE_TO_DEMO_FILE, type Style } from "./messengerStyles";
-import { recordImageJob } from "./messengerJobStore";
 import {
   anonymizePsid,
   getOrCreateState,
@@ -256,25 +254,9 @@ function getMockImageForStyle(style: string): string | undefined {
   return `${getBaseUrl()}/demo/${filename}`;
 }
 
-async function waitForMockProcessing(): Promise<void> {
-  const delayMs = 2000 + Math.floor(Math.random() * 2001);
-  await new Promise(resolve => setTimeout(resolve, delayMs));
-}
-
 async function runMockGeneration(psid: string, userId: string, style: Style): Promise<void> {
   setFlowState(userId, "PROCESSING");
-  const imageJobId = randomUUID();
-
-  recordImageJob({
-    userId,
-    style,
-    imageJobId,
-    timestamp: Date.now(),
-  });
-
-  await sendText(psid, `Perfect — applying ${STYLE_LABELS[style]} style now (mock) ✨`);
-  await sendText(psid, `Job queued: ${imageJobId}`);
-  await waitForMockProcessing();
+  await sendText(psid, `Processing ${STYLE_LABELS[style]} style ✨`);
   const imageUrl = getMockImageForStyle(style);
 
   if (!imageUrl) {


### PR DESCRIPTION
### Motivation
- The mock path previously simulated a queued job and returned text like `Perfect — applying <Style> style now (mock)` and `Job queued: <uuid>` but did not deliver a demo image attachment, preventing validation of the real output path. 
- The change should make `MOCK_MODE` return a real Messenger image attachment sourced from local demo assets to fully validate the production flow without touching the real generator.

### Description
- Removed the legacy mock queue simulation including `randomUUID`, `recordImageJob`, and the artificial `waitForMockProcessing` delay in the mock branch. 
- Replaced the mock messaging with a neutral processing message (`Processing <Style> style ✨`) and immediate image delivery using the demo asset URL resolved by `getMockImageForStyle` which builds `${APP_BASE_URL}/demo/${STYLE_TO_DEMO_FILE[style]}`. 
- Sends the image via the existing `sendImage` call and then continues the UX by setting `RESULT_READY` and sending the same quick-reply follow-up. 
- Left non-mock behavior unchanged; the non-mock branch still routes to the existing placeholder real-generation branch.

### Testing
- Ran `pnpm vitest run server/messengerWebhook.test.ts` and the suite passed (`10 tests` passed). 
- Ran `pnpm check` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a032f8df7c8325a564c4b18aa57549)