### PR TITLE
Introduce ImageGenerator abstraction (no behavior change)

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -1,14 +1,36 @@
-import { getStyleById, type StyleId } from "./messengerStyles";
+import { STYLE_TO_DEMO_FILE, type Style } from "./messengerStyles";
 
-export function getMockGeneratedImage(styleId: StyleId, cursor = 0): { imageUrl: string; nextCursor: number } {
-  const style = getStyleById(styleId);
-  const index = cursor % style.mockResultUrls.length;
-
-  return {
-    imageUrl: style.mockResultUrls[index],
-    nextCursor: cursor + 1,
-  };
+export interface ImageGenerator {
+  generate(input: {
+    style: Style;
+    sourceImageUrl?: string;
+    psid: string;
+  }): Promise<{ imageUrl: string }>;
 }
 
-// Future integration point:
-// Replace getMockGeneratedImage with OpenAI/real generation logic and keep the webhook UX unchanged.
+function getBaseUrl(): string {
+  const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
+
+  if (configuredBaseUrl && /^https?:\/\//.test(configuredBaseUrl)) {
+    return configuredBaseUrl;
+  }
+
+  return "http://localhost:3000";
+}
+
+function getMockImageForStyle(style: Style): string {
+  const filename = STYLE_TO_DEMO_FILE[style];
+  return `${getBaseUrl()}/demo/${filename}`;
+}
+
+class MockImageGenerator implements ImageGenerator {
+  async generate(input: { style: Style; sourceImageUrl?: string; psid: string }): Promise<{ imageUrl: string }> {
+    return {
+      imageUrl: getMockImageForStyle(input.style),
+    };
+  }
+}
+
+export function createImageGenerator(): ImageGenerator {
+  return new MockImageGenerator();
+}


### PR DESCRIPTION
### Motivation
- Separate image generation concerns from the Messenger conversation/state-machine to make future provider swaps (e.g. OpenAI) straightforward while preserving current UX.

### Description
- Added an `ImageGenerator` interface and a `MockImageGenerator` implementation in `server/_core/imageService.ts` with `generate({ style, sourceImageUrl?, psid }) => { imageUrl }` and a `createImageGenerator()` factory.
- Replaced the in-file mock image helpers in `server/_core/messengerWebhook.ts` with a single `imageGenerator = createImageGenerator()` instance and routed mock generation through the new `generate` API while keeping state transitions and messages unchanged.
- Kept the non-mock path untouched (`MOCK_MODE=false` still shows the existing placeholder flow).
- Applied a small TypeScript compatibility tweak (`lastPhoto ?? undefined`) to match the new generator signature.

### Testing
- Ran `pnpm check` (TypeScript compilation) which passed after the type tweak.
- Ran the webhook unit tests with `pnpm vitest run server/messengerWebhook.test.ts`, and all tests passed (10/10).
- Verified `pnpm check && pnpm vitest run server/messengerWebhook.test.ts` succeeded end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03763f17c832597334256714b7bcd)