### PR TITLE
Introduce ImageGenerator abstraction and OpenAI image generation path

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -1,14 +1,118 @@
-import { getStyleById, type StyleId } from "./messengerStyles";
+import { STYLE_TO_DEMO_FILE, type Style } from "./messengerStyles";
 
-export function getMockGeneratedImage(styleId: StyleId, cursor = 0): { imageUrl: string; nextCursor: number } {
-  const style = getStyleById(styleId);
-  const index = cursor % style.mockResultUrls.length;
+export type GeneratorMode = "mock" | "openai";
 
-  return {
-    imageUrl: style.mockResultUrls[index],
-    nextCursor: cursor + 1,
-  };
+export interface ImageGenerator {
+  generate(input: {
+    style: Style;
+    sourceImageUrl?: string;
+    psid: string;
+  }): Promise<{ imageUrl: string }>;
 }
 
-// Future integration point:
-// Replace getMockGeneratedImage with OpenAI/real generation logic and keep the webhook UX unchanged.
+export class InvalidGenerationInputError extends Error {}
+export class MissingOpenAiApiKeyError extends Error {}
+export class GenerationTimeoutError extends Error {}
+export class OpenAiGenerationError extends Error {}
+
+function getBaseUrl(): string {
+  const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
+
+  if (configuredBaseUrl && /^https?:\/\//.test(configuredBaseUrl)) {
+    return configuredBaseUrl;
+  }
+
+  return "http://localhost:3000";
+}
+
+function getMockImageForStyle(style: Style): string {
+  const filename = STYLE_TO_DEMO_FILE[style];
+  return `${getBaseUrl()}/demo/${filename}`;
+}
+
+function getGeneratorMode(): GeneratorMode {
+  return process.env.GENERATOR_MODE === "openai" ? "openai" : "mock";
+}
+
+function getOpenAiTimeoutMs(): number {
+  const raw = Number.parseInt(process.env.OPENAI_IMAGE_TIMEOUT_MS ?? "", 10);
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+
+  return 60_000;
+}
+
+class MockImageGenerator implements ImageGenerator {
+  async generate(input: { style: Style; sourceImageUrl?: string; psid: string }): Promise<{ imageUrl: string }> {
+    return {
+      imageUrl: getMockImageForStyle(input.style),
+    };
+  }
+}
+
+export class OpenAiImageGenerator implements ImageGenerator {
+  async generate(input: { style: Style; sourceImageUrl?: string; psid: string }): Promise<{ imageUrl: string }> {
+    if (!input.style) {
+      throw new InvalidGenerationInputError("Style is required");
+    }
+
+    if (!input.sourceImageUrl) {
+      throw new InvalidGenerationInputError("sourceImageUrl is required");
+    }
+
+    if (!process.env.OPENAI_API_KEY) {
+      throw new MissingOpenAiApiKeyError("OPENAI_API_KEY is missing");
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, getOpenAiTimeoutMs());
+
+    try {
+      const response = await fetch("https://api.openai.com/v1/images/generations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-image-1",
+          prompt: `Apply ${input.style} style to this photo URL: ${input.sourceImageUrl}`,
+          size: "1024x1024",
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new OpenAiGenerationError(`OpenAI request failed (${response.status} ${response.statusText})`);
+      }
+
+      const result = (await response.json()) as { data?: Array<{ url?: string }> };
+      const imageUrl = result.data?.[0]?.url;
+
+      if (!imageUrl) {
+        throw new OpenAiGenerationError("OpenAI response did not include an image URL");
+      }
+
+      return { imageUrl };
+    } catch (error) {
+      if ((error as { name?: string })?.name === "AbortError") {
+        throw new GenerationTimeoutError("OpenAI generation timed out");
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+export function createImageGenerator(mode: GeneratorMode = getGeneratorMode()): { mode: GeneratorMode; generator: ImageGenerator } {
+  if (mode === "openai") {
+    return { mode, generator: new OpenAiImageGenerator() };
+  }
+
+  return { mode: "mock", generator: new MockImageGenerator() };
+}


### PR DESCRIPTION
### Motivation
- Provide a pluggable image generation layer so the app can run in mock mode or call OpenAI for real image synthesis. 
- Surface clear, user-facing errors and timeouts when remote generation is unavailable or slow. 
- Centralize environment-driven configuration like base URL, generator mode, and OpenAI timeouts. 

### Description
- Add an `ImageGenerator` interface and concrete implementations `MockImageGenerator` and `OpenAiImageGenerator`, plus error classes for specific failure cases. 
- Add `createImageGenerator()` and `getGeneratorMode()` to select `mock` or `openai` modes driven by `GENERATOR_MODE`, and add `OPENAI_IMAGE_TIMEOUT_MS` and improved `getBaseUrl()` handling. 
- Replace the previous mock-only generation flow in `messengerWebhook` with the pluggable generator, including detailed `safeLog` events and user-facing messages for missing API key, timeouts, and generation failures. 
- Update tests to cover the OpenAI path, missing API key behavior, and timeout behavior, and adjust test setup to set `GENERATOR_MODE` and clear `OPENAI_API_KEY` as needed. 

### Testing
- Ran the messenger webhook test suite including new cases for missing OpenAI key, successful OpenAI response (fetch stubbed), and OpenAI timeout (fetch throws `AbortError`), and they passed. 
- Existing webhook dedupe and mock-generation tests were run and remained passing with `GENERATOR_MODE=mock`. 
- Tests stubbed global `fetch` where appropriate and verified `safeLog`, `sendText`, and `sendImage` calls; stubs were torn down after each test and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a03763f17c832597334256714b7bcd)