### PR TITLE
Simplify ack logging payload and update messenger webhook tests

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -380,7 +380,7 @@ async function handleMessage(psid: string, userId: string, event: FacebookWebhoo
   const text = message.text;
   const ack = detectAck(text);
   if (ack) {
-    safeLog("ack_ignored", { ack, text: "redacted" });
+    safeLog("ack_ignored", { ack });
     return;
   }
 

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -577,7 +577,7 @@ describe("acknowledgement edgecases", () => {
     expect(detectAck("disco")).toBeNull();
   });
 
-  it("ignores legacy like (y)", async () => {
+  it("ignores (y) without sending text or quick replies", async () => {
     await processFacebookWebhookPayload({
       entry: [
         {
@@ -593,20 +593,17 @@ describe("acknowledgement edgecases", () => {
 
     expect(sendTextMock).not.toHaveBeenCalled();
     expect(sendQuickRepliesMock).not.toHaveBeenCalled();
-    expect(safeLogMock).toHaveBeenCalledWith("ack_ignored", expect.objectContaining({ ack: "like" }));
+    expect(safeLogMock).toHaveBeenCalledWith("ack_ignored", { ack: "like" });
   });
 
-  it("ignores ack text in RESULT_READY without extra replies", async () => {
-    const psid = "ack-noop-user";
-    setFlowState(anonymizePsid(psid), "RESULT_READY");
-
+  it("ignores 👍 without sending text or quick replies", async () => {
     await processFacebookWebhookPayload({
       entry: [
         {
           messaging: [
             {
-              sender: { id: psid },
-              message: { mid: "mid-ack-noop", text: "thanks" },
+              sender: { id: "ack-emoji-user" },
+              message: { mid: "mid-ack-emoji", text: "👍" },
             },
           ],
         },
@@ -615,6 +612,6 @@ describe("acknowledgement edgecases", () => {
 
     expect(sendTextMock).not.toHaveBeenCalled();
     expect(sendQuickRepliesMock).not.toHaveBeenCalled();
-    expect(safeLogMock).toHaveBeenCalledWith("ack_ignored", expect.objectContaining({ ack: "thanks" }));
+    expect(safeLogMock).toHaveBeenCalledWith("ack_ignored", { ack: "emoji" });
   });
 });


### PR DESCRIPTION
### Motivation

- Reduce stored/logged data when detecting simple acknowledgement messages by removing the redundant `text` field from the logging payload for `ack_ignored` events.
- Make tests assert the exact logged payload shape and cover emoji acknowledgement detection explicitly.

### Description

- Removed the `text: "redacted"` property from the `safeLog` call in `handleMessage`, so `safeLog("ack_ignored", { ack })` is used instead of including a `text` field.
- Updated tests in `server/messengerWebhook.test.ts` to expect the exact object `{ ack: ... }` when `safeLog` is called and adjusted test names and inputs to explicitly cover `(y)` and `👍` acknowledgement cases.
- Removed an obsolete flow state setup in the emoji acknowledgement test and clarified test descriptions to assert that no text or quick replies are sent for those acknowledgements.

### Testing

- Ran the unit tests for the messenger webhook suite and related tests in `server/messengerWebhook.test.ts` which passed after the changes.
- Confirmed that `safeLog` assertions now match the simplified payload shape and that message/quick-reply sending mocks are not invoked for the ack cases.
- No new integration or e2e tests were added or required for this small logging and test update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a074b3ea18832592c4b586ef77cd91)