### PR TITLE
Add image URL probe CLI and improve Messenger image logging/validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "tsc --noEmit",
     "format": "prettier --write .",
     "test": "vitest run",
-    "db:push": "drizzle-kit generate && drizzle-kit migrate"
+    "db:push": "drizzle-kit generate && drizzle-kit migrate",
+    "debug:image-url": "tsx server/_core/debugImageUrl.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.12",

--- a/server/_core/debugImageUrl.ts
+++ b/server/_core/debugImageUrl.ts
@@ -13,7 +13,8 @@ export async function probeImageUrlForMessenger(
   url: string
 ): Promise<ImageUrlProbeResult> {
   const { stdout } = await execFileAsync("curl", [
-    "-I",
+    "-X",
+    "GET",
     "-L",
     "-A",
     "facebookexternalhit/1.1",

--- a/server/_core/debugImageUrl.ts
+++ b/server/_core/debugImageUrl.ts
@@ -1,0 +1,109 @@
+import { execFile } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type ImageUrlProbeResult = {
+  statusCode: number;
+  contentType: string;
+};
+
+export async function probeImageUrlForMessenger(
+  url: string
+): Promise<ImageUrlProbeResult> {
+  const { stdout } = await execFileAsync("curl", [
+    "-I",
+    "-L",
+    "-A",
+    "facebookexternalhit/1.1",
+    "-sS",
+    "-o",
+    "/dev/null",
+    "-w",
+    "%{http_code}\n%{content_type}\n",
+    url,
+  ]);
+
+  const [rawStatus = "", rawContentType = ""] = stdout.trim().split("\n");
+  const statusCode = Number.parseInt(rawStatus.trim(), 10);
+  const contentType = rawContentType.trim().toLowerCase();
+
+  if (!Number.isFinite(statusCode)) {
+    throw new Error(
+      `Could not parse HTTP status code from curl output: ${JSON.stringify(stdout)}`
+    );
+  }
+
+  return {
+    statusCode,
+    contentType,
+  };
+}
+
+export async function assertMessengerImageUrl(
+  url: string
+): Promise<ImageUrlProbeResult> {
+  const result = await probeImageUrlForMessenger(url);
+
+  if (result.statusCode !== 200) {
+    throw new Error(
+      `Expected status 200, got ${result.statusCode} for URL: ${url}`
+    );
+  }
+
+  if (!result.contentType.startsWith("image/")) {
+    throw new Error(
+      `Expected Content-Type to start with image/, got ${result.contentType || "(empty)"} for URL: ${url}`
+    );
+  }
+
+  return result;
+}
+
+async function runCli(): Promise<void> {
+  const url = process.argv
+    .slice(2)
+    .find(arg => arg !== "--")
+    ?.trim();
+
+  if (!url) {
+    console.error("Usage: pnpm debug:image-url -- <url>");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await assertMessengerImageUrl(url);
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        url,
+        statusCode: result.statusCode,
+        contentType: result.contentType,
+      },
+      null,
+      2
+    )
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  runCli().catch(error => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(
+      JSON.stringify(
+        {
+          ok: false,
+          error: message,
+        },
+        null,
+        2
+      )
+    );
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
### Motivation
- Provide a small CLI to verify that image URLs are suitable for Facebook Messenger (status 200 and image Content-Type) and help debug failures.
- Avoid logging sensitive tokens and reduce noise by redacting full image URLs while surfacing likely problematic HTML page URLs (e.g. Wikimedia /wiki pages) before sending to Messenger.

### Description
- Add `server/_core/debugImageUrl.ts` which implements `probeImageUrlForMessenger`, `assertMessengerImageUrl`, and a CLI entry that calls `curl` to check HTTP status and Content-Type for a given URL.
- Add a `debug:image-url` script to `package.json` to run the new CLI via `tsx` (`pnpm debug:image-url -- <url>`).
- Update `server/_core/messengerApi.ts` to redact image URLs in logs via `redactImageUrlForLog`, detect likely HTML page image URLs via `isLikelyHtmlPageUrl`, and emit a warning log when such URLs are detected before calling the Messenger Send API.
- Keep `safeLog` redaction behavior for tokens and maintain the existing `sendImage` behavior while adding pre-send logging and heuristic checks.

### Testing
- Ran type checks with `pnpm run check` (`tsc --noEmit`) which completed successfully.
- Ran automated tests with `pnpm test` (Vitest) and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07e2dd4a083259373f47380b84398)