### PR TITLE
Fix Meta webhook signature verification without re-reading request stream

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -8,7 +8,10 @@ import { appRouter } from "../routers";
 import { createContext } from "./context";
 import { serveStatic } from "./vite";
 import { registerMetaWebhookRoutes } from "./messengerWebhook";
-import { captureRawBody, verifyMetaWebhookSignature } from "./webhookSignatureVerification";
+import {
+  captureMetaWebhookRawBody,
+  verifyMetaWebhookSignature,
+} from "./webhookSignatureVerification";
 
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
@@ -27,16 +30,12 @@ async function startServer() {
   const app = express();
   const server = createServer(app);
 
-  // Capture raw body BEFORE JSON parsing for webhook signature verification
-  app.use((req, res, next) => {
-    if (req.path === "/webhook/facebook") {
-      captureRawBody(req, res, next);
-    } else {
-      next();
-    }
-  });
-
-  app.use(express.json({ limit: "50mb" }));
+  app.use(
+    express.json({
+      limit: "50mb",
+      verify: captureMetaWebhookRawBody,
+    })
+  );
   app.use(express.urlencoded({ limit: "50mb", extended: true }));
 
   // Verify webhook signature for Facebook webhook endpoint

--- a/server/webhookSignatureVerification.test.ts
+++ b/server/webhookSignatureVerification.test.ts
@@ -1,0 +1,104 @@
+import { createHmac } from "node:crypto";
+import http from "node:http";
+import express, { type Request, type Response } from "express";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  captureMetaWebhookRawBody,
+  verifyMetaWebhookSignature,
+} from "./_core/webhookSignatureVerification";
+
+function buildSignature(body: string, secret: string): string {
+  const digest = createHmac("sha256", secret).update(body).digest("hex");
+  return `sha256=${digest}`;
+}
+
+async function postWebhook(body: string, signature: string): Promise<{ status: number; payload: string }> {
+  const app = express();
+
+  app.use(
+    express.json({
+      verify: captureMetaWebhookRawBody,
+    })
+  );
+
+  app.post("/webhook/facebook", verifyMetaWebhookSignature, (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, object: (req.body as { object?: string }).object });
+  });
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Failed to bind test server");
+  }
+
+  const result = await new Promise<{ status: number; payload: string }>((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        path: "/webhook/facebook",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+          "x-hub-signature-256": signature,
+        },
+      },
+      (response) => {
+        let payload = "";
+        response.on("data", (chunk) => {
+          payload += chunk;
+        });
+        response.on("end", () => {
+          resolve({ status: response.statusCode ?? 0, payload });
+        });
+      }
+    );
+
+    request.on("error", reject);
+    request.write(body);
+    request.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+  return result;
+}
+
+describe("Meta webhook signature verification", () => {
+  afterEach(() => {
+    delete process.env.FB_APP_SECRET;
+  });
+
+  it("accepts webhook requests with a valid signature", async () => {
+    const secret = "test-secret";
+    process.env.FB_APP_SECRET = secret;
+
+    const body = JSON.stringify({ object: "page", entry: [] });
+    const response = await postWebhook(body, buildSignature(body, secret));
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toContain('"ok":true');
+  });
+
+  it("rejects webhook requests with an invalid signature", async () => {
+    process.env.FB_APP_SECRET = "test-secret";
+
+    const body = JSON.stringify({ object: "page", entry: [] });
+    const response = await postWebhook(body, "sha256=invalid");
+
+    expect(response.status).toBe(403);
+    expect(response.payload).toContain("Signature verification failed");
+  });
+});


### PR DESCRIPTION
### Motivation
- Incoming Facebook webhook processing previously used a custom middleware that read the request stream before `express.json()`, which caused `InternalServerError: stream is not readable` when the JSON parser later attempted to read the same stream. 
- Signature verification must remain strict (fail-closed) and must compute the HMAC over the exact bytes received, while limiting raw-body capture to webhook routes for privacy and performance.

### Description
- Removed the stream-consuming `captureRawBody` middleware and switched to using the JSON parser `verify` hook by registering `express.json({ verify: captureMetaWebhookRawBody })` so raw bytes are captured during the parser's single read. (`server/_core/index.ts`)
- Implemented `captureMetaWebhookRawBody` which only stores raw bytes for requests where `req.originalUrl` starts with `/webhook`, and stores them as a `Buffer` on `req.rawBody`. (`server/_core/webhookSignatureVerification.ts`)
- Updated `verifyMetaWebhookSignature` to compute the HMAC directly from the captured `Buffer` (`req.rawBody`) instead of reconstructing a string, and kept constant-time comparison and fail-closed behavior. (`server/_core/webhookSignatureVerification.ts`)
- Added integration tests exercising `/webhook/facebook` with a valid and invalid `X-Hub-Signature-256` header to ensure verification returns `200` for valid signatures and `403` for invalid signatures. (`server/webhookSignatureVerification.test.ts`)
- Ensured no raw request bodies are logged and raw-body capture is scoped to webhook routes to preserve privacy.

### Testing
- Ran the new integration test file with `vitest`: `server/webhookSignatureVerification.test.ts` — 2 tests passed. (success)
- Ran TypeScript check: `pnpm check` — succeeded. (success)
- Ran full test suite: `pnpm test` — failed due to 3 pre-existing unrelated failures in `server/messengerWebhook.test.ts`; the webhook signature tests passed and their logs show signature verification behavior as expected. (partial)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1454917a4832598b36ff2b25fcf32)