### PR TITLE
Capture Meta webhook raw body via express.json verify, conditional OAuth init, and add tests

### DIFF
--- a/server/_core/oauth.ts
+++ b/server/_core/oauth.ts
@@ -2,7 +2,6 @@ import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import type { Express, Request, Response } from "express";
 import * as db from "../db";
 import { getSessionCookieOptions } from "./cookies";
-import { sdk } from "./sdk";
 
 function getQueryParam(req: Request, key: string): string | undefined {
   const value = req.query[key];
@@ -20,6 +19,7 @@ export function registerOAuthRoutes(app: Express) {
     }
 
     try {
+      const { sdk } = await import("./sdk");
       const tokenResponse = await sdk.exchangeCodeForToken(code, state);
       const userInfo = await sdk.getUserInfo(tokenResponse.accessToken);
 

--- a/server/_core/sdk.ts
+++ b/server/_core/sdk.ts
@@ -30,12 +30,12 @@ const GET_USER_INFO_WITH_JWT_PATH = `/webdev.v1.WebDevAuthPublicService/GetUserI
 
 class OAuthService {
   constructor(private client: ReturnType<typeof axios.create>) {
-    console.log("[OAuth] Initialized with baseURL:", ENV.oAuthServerUrl);
-    if (!ENV.oAuthServerUrl) {
-      console.error(
-        "[OAuth] ERROR: OAUTH_SERVER_URL is not configured! Set OAUTH_SERVER_URL environment variable."
-      );
+    if (ENV.oAuthServerUrl) {
+      console.log("[OAuth] Initialized with baseURL:", ENV.oAuthServerUrl);
+      return;
     }
+
+    console.info("[OAuth] OAUTH_SERVER_URL not set, OAuth client calls are disabled until configured");
   }
 
   private decodeState(state: string): string {

--- a/server/sdk.oauthConfig.test.ts
+++ b/server/sdk.oauthConfig.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("OAuth SDK configuration guard", () => {
+  const originalOAuthUrl = process.env.OAUTH_SERVER_URL;
+
+  afterEach(() => {
+    if (originalOAuthUrl === undefined) {
+      delete process.env.OAUTH_SERVER_URL;
+    } else {
+      process.env.OAUTH_SERVER_URL = originalOAuthUrl;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("does not log an OAuth error when OAUTH_SERVER_URL is missing", async () => {
+    delete process.env.OAUTH_SERVER_URL;
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    vi.resetModules();
+    await import("./_core/sdk");
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("OAUTH_SERVER_URL is not configured")
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      "[OAuth] OAUTH_SERVER_URL not set, OAuth client calls are disabled until configured"
+    );
+  });
+
+  it("logs OAuth initialization when OAUTH_SERVER_URL is provided", async () => {
+    process.env.OAUTH_SERVER_URL = "https://oauth.example.com";
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    vi.resetModules();
+    await import("./_core/sdk");
+
+    expect(logSpy).toHaveBeenCalledWith(
+      "[OAuth] Initialized with baseURL:",
+      "https://oauth.example.com"
+    );
+  });
+});

--- a/server/webhookSignatureVerification.test.ts
+++ b/server/webhookSignatureVerification.test.ts
@@ -1,0 +1,104 @@
+import { createHmac } from "node:crypto";
+import http from "node:http";
+import express, { type Request, type Response } from "express";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  captureMetaWebhookRawBody,
+  verifyMetaWebhookSignature,
+} from "./_core/webhookSignatureVerification";
+
+function buildSignature(body: string, secret: string): string {
+  const digest = createHmac("sha256", secret).update(body).digest("hex");
+  return `sha256=${digest}`;
+}
+
+async function postWebhook(body: string, signature: string): Promise<{ status: number; payload: string }> {
+  const app = express();
+
+  app.use(
+    express.json({
+      verify: captureMetaWebhookRawBody,
+    })
+  );
+
+  app.post("/webhook/facebook", verifyMetaWebhookSignature, (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, object: (req.body as { object?: string }).object });
+  });
+
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Failed to bind test server");
+  }
+
+  const result = await new Promise<{ status: number; payload: string }>((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        path: "/webhook/facebook",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+          "x-hub-signature-256": signature,
+        },
+      },
+      (response) => {
+        let payload = "";
+        response.on("data", (chunk) => {
+          payload += chunk;
+        });
+        response.on("end", () => {
+          resolve({ status: response.statusCode ?? 0, payload });
+        });
+      }
+    );
+
+    request.on("error", reject);
+    request.write(body);
+    request.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+  return result;
+}
+
+describe("Meta webhook signature verification", () => {
+  afterEach(() => {
+    delete process.env.FB_APP_SECRET;
+  });
+
+  it("accepts webhook requests with a valid signature", async () => {
+    const secret = "test-secret";
+    process.env.FB_APP_SECRET = secret;
+
+    const body = JSON.stringify({ object: "page", entry: [] });
+    const response = await postWebhook(body, buildSignature(body, secret));
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toContain('"ok":true');
+  });
+
+  it("rejects webhook requests with an invalid signature", async () => {
+    process.env.FB_APP_SECRET = "test-secret";
+
+    const body = JSON.stringify({ object: "page", entry: [] });
+    const response = await postWebhook(body, "sha256=invalid");
+
+    expect(response.status).toBe(403);
+    expect(response.payload).toContain("Signature verification failed");
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure reliable and secure Meta (Facebook) webhook signature verification by capturing the raw request body in a way compatible with `express.json()` and the verify hook. 
- Avoid initializing or error-logging OAuth client code when `OAUTH_SERVER_URL` is not configured, and only register OAuth routes when the URL is provided. 
- Add unit tests to validate webhook signature handling and the OAuth SDK configuration guard.

### Description
- Reworked raw-body capture for Meta webhooks by renaming and adapting `captureRawBody` to `captureMetaWebhookRawBody` and using it as the `verify` hook on `express.json({ verify: captureMetaWebhookRawBody })` so raw bytes are available for signature verification. 
- Updated `verifyMetaWebhookSignature` to expect a `rawBody` buffer on the request and use it directly when computing the HMAC, plus added a typed `MetaWebhookRequest`. 
- Replaced the ad-hoc middleware that listened to request streams with the `express.json` `verify` implementation and limited raw-body capture to webhook paths. 
- Made OAuth initialization conditional: `registerOAuthRoutes` is only called if `OAUTH_SERVER_URL` is set, and `oauth.ts` now dynamically imports `sdk` inside the callback handler. 
- Adjusted `OAuthService` constructor logging to only log the `baseURL` when `ENV.oAuthServerUrl` is present and to otherwise log an informational message that OAuth calls are disabled. 
- Added unit tests `server/webhookSignatureVerification.test.ts` and `server/sdk.oauthConfig.test.ts` that exercise signature verification behavior and OAuth SDK configuration logging respectively.

### Testing
- Ran the new unit tests `server/webhookSignatureVerification.test.ts` which post HTTP requests to an Express test server to verify successful acceptance and rejection of webhook requests, and they passed. 
- Ran the new unit tests `server/sdk.oauthConfig.test.ts` which validate logging behavior with and without `OAUTH_SERVER_URL` and they passed. 
- Ran the existing test suite (unit tests) after changes and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1454917a4832598b36ff2b25fcf32)