### PR TITLE
Fix production landing build + static serving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY package.json pnpm-lock.yaml ./
 COPY patches ./patches
 RUN pnpm install --prod --frozen-lockfile
 COPY --from=build /app/dist ./dist
-COPY --from=build /app/public ./public
+COPY --from=build /app/dist/public ./public
 
 EXPOSE 8080
 CMD ["node", "dist/index.js"]

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -47,12 +47,20 @@ export async function setupVite(app: Express, server: Server, createViteServer: 
   });
 }
 
-export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "..", "public");
-  if (!fs.existsSync(distPath)) {
+export function serveStatic(app: Express, staticRoot?: string) {
+  const distPathCandidates = staticRoot
+    ? [path.resolve(staticRoot)]
+    : [
+        path.resolve(import.meta.dirname, "public"),
+        path.resolve(import.meta.dirname, "..", "public"),
+      ];
+  const distPath = distPathCandidates.find((candidate) => fs.existsSync(candidate));
+
+  if (!distPath) {
     console.error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`
+      `Could not find a build directory. Tried: ${distPathCandidates.join(", ")}. Make sure to build the client first.`
     );
+    return;
   }
 
   app.use(express.static(distPath));

--- a/server/serveStatic.production.test.ts
+++ b/server/serveStatic.production.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { serveStatic } from "./_core/vite";
+
+const tempDirs: string[] = [];
+
+function createTempBuild() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaderbot-static-"));
+  tempDirs.push(dir);
+  fs.writeFileSync(path.join(dir, "index.html"), "<html><body><h1>Landing UI</h1></body></html>");
+  fs.mkdirSync(path.join(dir, "assets"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "assets", "app.js"), "console.log('ok');");
+  return dir;
+}
+
+async function listen(app: express.Express) {
+  return await new Promise<{
+    baseUrl: string;
+    close: () => Promise<void>;
+  }>((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Unable to get test server address");
+      }
+
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}`,
+        close: () =>
+          new Promise<void>((closeResolve, closeReject) => {
+            server.close((err) => {
+              if (err) {
+                closeReject(err);
+                return;
+              }
+              closeResolve();
+            });
+          }),
+      });
+    });
+  });
+}
+
+describe("serveStatic production mode", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("serves index.html for root while keeping healthz and webhook routes working", async () => {
+    const app = express();
+    const staticDir = createTempBuild();
+
+    app.get("/healthz", (_req, res) => {
+      res.status(200).send("ok");
+    });
+
+    app.post("/webhook", (_req, res) => {
+      res.status(200).json({ received: true });
+    });
+
+    serveStatic(app, staticDir);
+
+    const server = await listen(app);
+
+    try {
+      const rootResponse = await fetch(`${server.baseUrl}/`);
+      expect(rootResponse.status).toBe(200);
+      const rootHtml = await rootResponse.text();
+      expect(rootHtml).toContain("Landing UI");
+
+      const healthResponse = await fetch(`${server.baseUrl}/healthz`);
+      expect(healthResponse.status).toBe(200);
+      expect(await healthResponse.text()).toBe("ok");
+
+      const webhookResponse = await fetch(`${server.baseUrl}/webhook`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ test: true }),
+      });
+      expect(webhookResponse.status).toBe(200);
+      expect(await webhookResponse.json()).toEqual({ received: true });
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- The production server and Docker runtime were not consistently serving the Vite-built client output (`dist/public`), which could produce `ENOENT /app/public/index.html` on Fly and prevent the landing SPA from being returned at `/`.
- The change ensures the built SPA is included in the runtime image and the server serves the actual build artifacts while preserving webhook and health endpoints.

### Description
- Updated `serveStatic` in `server/_core/vite.ts` to accept an optional `staticRoot`, probe candidate build locations (prefer the Vite output location), and fail gracefully with clear logging if none are found.
- Modified `Dockerfile` runtime stage to copy the built client assets from `/app/dist/public` into the runtime `./public` so the runtime image contains the real build output.
- Added a minimal production-style smoke test `server/serveStatic.production.test.ts` that verifies `GET /` returns built HTML and that `/healthz` and `POST /webhook` still respond as expected.

### Testing
- Ran `pnpm run build` and confirmed Vite emits the client bundle to `dist/public` successfully.
- Started the production server (`NODE_ENV=production node dist/index.js`) and validated with `curl` that `/` returned HTTP 200 and HTML, `/healthz` returned 200, and `POST /webhook` returned 200.
- Ran the targeted unit test `pnpm vitest run server/serveStatic.production.test.ts` and it passed.
- Ran the full test suite `pnpm run test` and observed three unrelated failures in `server/messengerWebhook.test.ts` (existing webhook acknowledgement assertions), while the new static-serving test passed within that run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a150f746e48325b58e19a3faff4075)