### PR TITLE
Preserve demo assets in runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY package.json pnpm-lock.yaml ./
 COPY patches ./patches
 RUN pnpm install --prod --frozen-lockfile
 COPY --from=build /app/dist ./dist
+COPY --from=build /app/public ./public
 COPY --from=build /app/dist/public ./public
 
 EXPOSE 8080


### PR DESCRIPTION
### Motivation
- The runtime image only copied `dist/public`, which dropped repository `public/demo/*.png` files while server code still emits `/demo/...` URLs, causing broken static links in production.

### Description
- Updated the `Dockerfile` runtime stage to copy `/app/public` into `./public` before copying `/app/dist/public` so repository demo assets are preserved while Vite build output still overlays client files.

### Testing
- Ran `pnpm run build` (succeeded), verified `public/demo/05-paparazzi.png` exists via `test -f public/demo/05-paparazzi.png`, and attempted `docker build` but the Docker CLI is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16a94bb74832599e67f6d279dfa51)