### PR TITLE
Update Messenger flow states to GENERATING/SUCCESS/FAILURE

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,7 +1,13 @@
 import type { StyleId } from "./messengerStyles";
 import { toUserKey } from "./privacy";
 
-export type ConversationState = "IDLE" | "AWAITING_PHOTO" | "AWAITING_STYLE" | "PROCESSING" | "RESULT_READY";
+export type ConversationState =
+  | "IDLE"
+  | "AWAITING_PHOTO"
+  | "AWAITING_STYLE"
+  | "GENERATING"
+  | "SUCCESS"
+  | "FAILURE";
 export type MessengerFlowState = ConversationState;
 
 export type StateQuickReply = {
@@ -49,10 +55,14 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
     { title: "Disco", payload: "disco" },
     { title: "Clouds", payload: "clouds" },
   ],
-  PROCESSING: [],
-  RESULT_READY: [
+  GENERATING: [],
+  SUCCESS: [
+    { title: "Download HD", payload: "DOWNLOAD_HD" },
     { title: "Try another style", payload: "CHOOSE_STYLE" },
-    { title: "New photo", payload: "SEND_PHOTO" },
+  ],
+  FAILURE: [
+    { title: "Retry {style}", payload: "RETRY_STYLE" },
+    { title: "Choose another style", payload: "CHOOSE_STYLE" },
   ],
 };
 

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -153,15 +153,21 @@ type GreetingResponse =
 
 export function getGreetingResponse(state: ConversationState): GreetingResponse {
   switch (state) {
-    case "PROCESSING":
+    case "GENERATING":
       return { mode: "text", text: "I’m still working on it—few seconds." };
     case "AWAITING_STYLE":
       return { mode: "quick_replies", state: "AWAITING_STYLE", text: "What style should I use?" };
-    case "RESULT_READY":
+    case "SUCCESS":
       return {
         mode: "quick_replies",
-        state: "RESULT_READY",
+        state: "SUCCESS",
         text: "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+      };
+    case "FAILURE":
+      return {
+        mode: "quick_replies",
+        state: "FAILURE",
+        text: "That one failed. Want to retry or pick another style?",
       };
     case "AWAITING_PHOTO":
       return { mode: "quick_replies", state: "AWAITING_PHOTO", text: "Send a photo when you’re ready 📸" };
@@ -218,10 +224,7 @@ export function detectAck(raw: string | undefined | null): AckKind | null {
     return "thanks";
   }
 
-  // Check if text is primarily emoji/pictographic characters
-  // Using a simpler approach that doesn't require ES2018+ Unicode flag
-  const emojiPattern = /[\u{1F300}-\u{1F9FF}]/u;
-  if (text.length > 0 && text.split("").every(char => /[\u{1F300}-\u{1F9FF}\s]/u.test(char))) {
+  if (/^(?:\p{Extended_Pictographic}|\s)+$/u.test(text)) {
     return "emoji";
   }
 
@@ -275,7 +278,7 @@ async function handleGreeting(psid: string, userId: string): Promise<void> {
 async function runStyleGeneration(psid: string, userId: string, style: Style): Promise<void> {
   const { mode, generator } = createImageGenerator();
 
-  setFlowState(userId, "PROCESSING");
+  setFlowState(userId, "GENERATING");
   await sendText(
     psid,
     mode === "mock"
@@ -295,8 +298,8 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
 
     safeLog("generation_success", { mode, ms: Date.now() - startedAt });
     await sendImage(psid, imageUrl);
-    setFlowState(userId, "RESULT_READY");
-    await sendStateQuickReplies(psid, "RESULT_READY", "Done. What do you want next?");
+    setFlowState(userId, "SUCCESS");
+    await sendStateQuickReplies(psid, "SUCCESS", "Done. What do you want next?");
   } catch (error) {
     const errorClass = error instanceof Error ? error.constructor.name : "UnknownError";
     safeLog("generation_fail", { mode, errorClass, ms: Date.now() - startedAt });
@@ -312,8 +315,8 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
       await sendText(psid, "I couldn’t generate that image right now. Please try again.");
     }
 
-    setFlowState(userId, "AWAITING_STYLE");
-    await sendStylePicker(psid);
+    setFlowState(userId, "FAILURE");
+    await sendStateQuickReplies(psid, "FAILURE", "I couldn’t finish that style. What do you want to do?");
   }
 }
 
@@ -339,6 +342,20 @@ async function handlePayload(psid: string, userId: string, payload: string): Pro
   }
 
   if (payload === "CHOOSE_STYLE") {
+    setFlowState(userId, "AWAITING_STYLE");
+    await sendStylePicker(psid);
+    return;
+  }
+
+  if (payload === "RETRY_STYLE") {
+    const chosenStyle = getOrCreateState(userId).selectedStyle;
+    const retryStyle = chosenStyle ? parseStyle(chosenStyle) : undefined;
+
+    if (retryStyle) {
+      await handleStyleSelection(psid, userId, retryStyle);
+      return;
+    }
+
     setFlowState(userId, "AWAITING_STYLE");
     await sendStylePicker(psid);
     return;

--- a/server/messengerState.test.ts
+++ b/server/messengerState.test.ts
@@ -50,10 +50,14 @@ describe("messenger state flow", () => {
       { title: "Disco", payload: "disco" },
       { title: "Clouds", payload: "clouds" },
     ]);
-    expect(getQuickRepliesForState("PROCESSING")).toEqual([]);
-    expect(getQuickRepliesForState("RESULT_READY")).toEqual([
+    expect(getQuickRepliesForState("GENERATING")).toEqual([]);
+    expect(getQuickRepliesForState("SUCCESS")).toEqual([
+      { title: "Download HD", payload: "DOWNLOAD_HD" },
       { title: "Try another style", payload: "CHOOSE_STYLE" },
-      { title: "New photo", payload: "SEND_PHOTO" },
+    ]);
+    expect(getQuickRepliesForState("FAILURE")).toEqual([
+      { title: "Retry {style}", payload: "RETRY_STYLE" },
+      { title: "Choose another style", payload: "CHOOSE_STYLE" },
     ]);
   });
 

--- a/server/messengerWebhook.greeting.test.ts
+++ b/server/messengerWebhook.greeting.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getGreetingResponse } from "./_core/messengerWebhook";
 
 describe("greeting handling by conversation state", () => {
-  it("returns processing text while PROCESSING", () => {
-    expect(getGreetingResponse("PROCESSING")).toEqual({
+  it("returns processing text while GENERATING", () => {
+    expect(getGreetingResponse("GENERATING")).toEqual({
       mode: "text",
       text: "I’m still working on it—few seconds.",
     });
@@ -17,11 +17,19 @@ describe("greeting handling by conversation state", () => {
     });
   });
 
-  it("returns follow-up options while RESULT_READY", () => {
-    expect(getGreetingResponse("RESULT_READY")).toEqual({
+  it("returns follow-up options while SUCCESS", () => {
+    expect(getGreetingResponse("SUCCESS")).toEqual({
       mode: "quick_replies",
-      state: "RESULT_READY",
+      state: "SUCCESS",
       text: "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+    });
+  });
+
+  it("returns recovery options while FAILURE", () => {
+    expect(getGreetingResponse("FAILURE")).toEqual({
+      mode: "quick_replies",
+      state: "FAILURE",
+      text: "That one failed. Want to retry or pick another style?",
     });
   });
 


### PR DESCRIPTION
### Motivation

- Replace legacy `PROCESSING`/`RESULT_READY` states with clearer terminal and in-progress states (`GENERATING`, `SUCCESS`, `FAILURE`) to better represent generation lifecycle and UX actions. 

### Description

- Change `ConversationState` / `MessengerFlowState` to include `GENERATING`, `SUCCESS`, and `FAILURE` and remove `PROCESSING` / `RESULT_READY` in `server/_core/messengerState.ts`. 
- Update `QUICK_REPLIES_BY_STATE` so `GENERATING` has no quick replies, `SUCCESS` exposes `Download HD` and `Try another style`, and `FAILURE` exposes `Retry {style}` and `Choose another style`. 
- Refactor webhook flow in `server/_core/messengerWebhook.ts` to set `GENERATING` when a style starts, transition to `SUCCESS` on generation success, and transition to `FAILURE` on generation error (without jumping back to `AWAITING_STYLE`). 
- Add handling for `RETRY_STYLE` payload to retry the previously selected style when available and adjust greeting messages and emoji acknowledgement detection accordingly; update tests to assert new state names and quick replies. 

### Testing

- Ran unit tests with `pnpm vitest run server/messengerState.test.ts server/messengerWebhook.greeting.test.ts server/messengerWebhook.test.ts` and all tests passed (`26` tests across the three files). 
- Ran typecheck with `pnpm check` (`tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1912f2a888325b1f1e1280aed2ae7)