### PR TITLE
Handle generation failures with contextual retry actions

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,7 +1,7 @@
 import type { StyleId } from "./messengerStyles";
 import { toUserKey } from "./privacy";
 
-export type ConversationState = "IDLE" | "AWAITING_PHOTO" | "AWAITING_STYLE" | "PROCESSING" | "RESULT_READY";
+export type ConversationState = "IDLE" | "AWAITING_PHOTO" | "AWAITING_STYLE" | "PROCESSING" | "RESULT_READY" | "FAILURE";
 export type MessengerFlowState = ConversationState;
 
 export type StateQuickReply = {
@@ -54,6 +54,7 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
     { title: "Try another style", payload: "CHOOSE_STYLE" },
     { title: "New photo", payload: "SEND_PHOTO" },
   ],
+  FAILURE: [],
 };
 
 export function getQuickRepliesForState(state: ConversationState): StateQuickReply[] {

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -20,7 +20,7 @@ import {
   resetMessengerEventDedupe,
   summarizeWebhook,
 } from "./_core/messengerWebhook";
-import { anonymizePsid, resetStateStore, setFlowState } from "./_core/messengerState";
+import { anonymizePsid, getState, resetStateStore, setFlowState } from "./_core/messengerState";
 
 
 describe("webhook summary logging", () => {
@@ -371,7 +371,16 @@ describe("messenger webhook dedupe", () => {
       ],
     });
 
-    expect(sendTextMock).toHaveBeenCalledWith("openai-missing-key-user", "AI generation isn’t enabled yet.");
+    expect(sendTextMock).toHaveBeenNthCalledWith(3, "openai-missing-key-user", "⚠️ I couldn’t generate this style right now.");
+    expect(sendTextMock).toHaveBeenNthCalledWith(4, "openai-missing-key-user", "You can try again or pick a different style.");
+    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
+      "openai-missing-key-user",
+      "Choose an option:",
+      [
+        { content_type: "text", title: "Retry Disco", payload: "RETRY_STYLE_disco" },
+        { content_type: "text", title: "Choose another style", payload: "CHOOSE_STYLE" },
+      ],
+    );
     expect(sendImageMock).not.toHaveBeenCalled();
     expect(safeLogMock).toHaveBeenCalledWith("generation_start", expect.objectContaining({ style: "disco", mode: "openai" }));
     expect(safeLogMock).toHaveBeenCalledWith("generation_fail", expect.objectContaining({ mode: "openai", errorClass: "MissingOpenAiApiKeyError" }));
@@ -419,6 +428,80 @@ describe("messenger webhook dedupe", () => {
   });
 
 
+
+
+  it("keeps failure context and retries selected style with prior photo", async () => {
+    process.env.GENERATOR_MODE = "openai";
+    delete process.env.OPENAI_API_KEY;
+
+    const psid = "retry-failure-user";
+    const userId = anonymizePsid(psid);
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-photo-retry-failure",
+                attachments: [{ type: "image", payload: { url: "https://img.example/retry.jpg" } }],
+              },
+            },
+            {
+              sender: { id: psid },
+              message: { mid: "mid-style-retry-failure", text: "gold" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const failedState = getState(userId);
+    expect(failedState?.stage).toBe("FAILURE");
+    expect(failedState?.lastPhoto).toBe("https://img.example/retry.jpg");
+    expect(failedState?.selectedStyle).toBe("gold");
+
+    sendTextMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: { payload: "RETRY_STYLE_gold" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const retriedState = getState(userId);
+    expect(retriedState?.stage).toBe("FAILURE");
+    expect(retriedState?.lastPhoto).toBe("https://img.example/retry.jpg");
+    expect(retriedState?.selectedStyle).toBe("gold");
+    expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
+      psid,
+      "What style should I use?",
+      expect.anything(),
+    );
+    expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
+      psid,
+      "Pick a style using the buttons below 🙂",
+      expect.anything(),
+    );
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      "Choose an option:",
+      [
+        { content_type: "text", title: "Retry Gold", payload: "RETRY_STYLE_gold" },
+        { content_type: "text", title: "Choose another style", payload: "CHOOSE_STYLE" },
+      ],
+    );
+    expect(safeLogMock).toHaveBeenCalledWith("generation_start", expect.objectContaining({ style: "gold", mode: "openai" }));
+  });
   it("shows timeout message when OpenAI generation exceeds timeout", async () => {
     process.env.GENERATOR_MODE = "openai";
     process.env.OPENAI_API_KEY = "dummy-key";
@@ -455,7 +538,8 @@ describe("messenger webhook dedupe", () => {
       vi.unstubAllGlobals();
     }
 
-    expect(sendTextMock).toHaveBeenCalledWith("openai-timeout-user", "This took too long — please try again.");
+    expect(sendTextMock).toHaveBeenNthCalledWith(3, "openai-timeout-user", "⚠️ I couldn’t generate this style right now.");
+    expect(sendTextMock).toHaveBeenNthCalledWith(4, "openai-timeout-user", "You can try again or pick a different style.");
     expect(safeLogMock).toHaveBeenCalledWith("generation_fail", expect.objectContaining({ mode: "openai", errorClass: "GenerationTimeoutError" }));
   });
 
@@ -520,7 +604,7 @@ describe("messenger greeting behavior", () => {
     expect(sendTextMock).toHaveBeenCalledWith("style-user", "Photo received ✅");
     expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
       "style-user",
-      "Pick a style using the buttons below 🙂",
+      "What style should I use?",
       [
         { content_type: "text", title: "Caricature", payload: "caricature" },
         { content_type: "text", title: "Petals", payload: "petals" },


### PR DESCRIPTION
### Motivation
- Provide a clearer, contextual failure flow when image generation fails instead of dropping users back to the generic style picker. 
- Preserve prior photo/style context so users can retry the same style without re-sending information. 
- Surface a simple retry action and a clear alternative to improve UX after generation errors.

### Description
- Add `FAILURE` conversation state and include it in quick-reply mappings so failures are a first-class state (`server/_core/messengerState.ts`).
- Replace the previous failure tail in `runStyleGeneration` to keep `lastPhoto` and `selectedStyle` unchanged, set flow to `FAILURE`, send two-line failure copy, and present quick replies for `Retry {SelectedStyle}` (`RETRY_STYLE_{style}`) and `Choose another style` (`CHOOSE_STYLE`) (`server/_core/messengerWebhook.ts`).
- Implement a new `RETRY_STYLE_*` payload branch in `handlePayload` that retries generation using the stored `selectedStyle` (with payload fallback) and uses the existing `lastPhoto` without requiring the user to re-enter style or photo (`server/_core/messengerWebhook.ts`).
- Fix emoji acknowledgement detection by iterating Unicode code points with `Array.from(text)` so emoji-only messages are recognized as acks (`server/_core/messengerWebhook.ts`).
- Add and update tests to assert context retention after failures, that retry uses the prior photo/style, and that no automatic fallback prompt to a generic style question occurs (`server/messengerWebhook.test.ts`).

### Testing
- Ran `pnpm vitest run server/messengerWebhook.test.ts` and all tests in that file passed (17/17). 
- Ran type checking with `pnpm run check` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19139be7483258560c11395728654)