### PR TITLE
Centralize messenger webhook copy, normalize English text, and update tests

### DIFF
--- a/server/messengerWebhook.greeting.test.ts
+++ b/server/messengerWebhook.greeting.test.ts
@@ -13,7 +13,7 @@ describe("greeting handling by conversation state", () => {
     expect(getGreetingResponse("AWAITING_STYLE")).toEqual({
       mode: "quick_replies",
       state: "AWAITING_STYLE",
-      text: "What style should I use?",
+      text: "🎨 Pick a style to transform your image:",
     });
   });
 
@@ -21,7 +21,7 @@ describe("greeting handling by conversation state", () => {
     expect(getGreetingResponse("RESULT_READY")).toEqual({
       mode: "quick_replies",
       state: "RESULT_READY",
-      text: "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+      text: "✨ Your image is ready.",
     });
   });
 
@@ -29,7 +29,7 @@ describe("greeting handling by conversation state", () => {
     expect(getGreetingResponse("IDLE")).toEqual({
       mode: "quick_replies",
       state: "IDLE",
-      text: "Welcome 👋 Pick a quick start.",
+      text: "✨ I turn your photos into stylized images.\nSend me a picture to get started.",
     });
   });
 });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -175,7 +175,7 @@ describe("messenger webhook dedupe", () => {
     });
 
     expect(sendTextMock).toHaveBeenCalledTimes(1);
-    expect(sendTextMock).toHaveBeenCalledWith("echo-user", "Photo received ✅");
+    expect(sendTextMock).toHaveBeenCalledWith("echo-user", "✅ Photo received");
     expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
   });
 
@@ -335,7 +335,7 @@ describe("messenger webhook dedupe", () => {
       );
       expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
         "mock-image-user",
-        "Done. What do you want next?",
+        "✨ Your image is ready.",
         [
           { content_type: "text", title: "Try another style", payload: "CHOOSE_STYLE" },
           { content_type: "text", title: "New photo", payload: "SEND_PHOTO" },
@@ -371,7 +371,7 @@ describe("messenger webhook dedupe", () => {
       ],
     });
 
-    expect(sendTextMock).toHaveBeenCalledWith("openai-missing-key-user", "AI generation isn’t enabled yet.");
+    expect(sendTextMock).toHaveBeenCalledWith("openai-missing-key-user", "⚠️ I couldn’t generate this style right now.\nYou can try again or pick a different style.");
     expect(sendImageMock).not.toHaveBeenCalled();
     expect(safeLogMock).toHaveBeenCalledWith("generation_start", expect.objectContaining({ style: "disco", mode: "openai" }));
     expect(safeLogMock).toHaveBeenCalledWith("generation_fail", expect.objectContaining({ mode: "openai", errorClass: "MissingOpenAiApiKeyError" }));
@@ -455,7 +455,7 @@ describe("messenger webhook dedupe", () => {
       vi.unstubAllGlobals();
     }
 
-    expect(sendTextMock).toHaveBeenCalledWith("openai-timeout-user", "This took too long — please try again.");
+    expect(sendTextMock).toHaveBeenCalledWith("openai-timeout-user", "⚠️ I couldn’t generate this style right now.\nYou can try again or pick a different style.");
     expect(safeLogMock).toHaveBeenCalledWith("generation_fail", expect.objectContaining({ mode: "openai", errorClass: "GenerationTimeoutError" }));
   });
 
@@ -488,7 +488,7 @@ describe("messenger greeting behavior", () => {
     expect(sendTextMock).not.toHaveBeenCalled();
     expect(sendQuickRepliesMock).toHaveBeenCalledWith(
       "idle-user",
-      "Welcome 👋 Pick a quick start.",
+      "✨ I turn your photos into stylized images.\nSend me a picture to get started.",
       expect.arrayContaining([
         { content_type: "text", title: "Send photo", payload: "START_PHOTO" },
         { content_type: "text", title: "What is this?", payload: "WHAT_IS_THIS" },
@@ -517,10 +517,10 @@ describe("messenger greeting behavior", () => {
       ],
     });
 
-    expect(sendTextMock).toHaveBeenCalledWith("style-user", "Photo received ✅");
+    expect(sendTextMock).toHaveBeenCalledWith("style-user", "✅ Photo received");
     expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
       "style-user",
-      "Pick a style using the buttons below 🙂",
+      "🎨 Pick a style to transform your image:",
       [
         { content_type: "text", title: "Caricature", payload: "caricature" },
         { content_type: "text", title: "Petals", payload: "petals" },
@@ -552,7 +552,7 @@ describe("messenger greeting behavior", () => {
 
     expect(sendQuickRepliesMock).toHaveBeenCalledWith(
       psid,
-      "Yo 👋 Wil je nog een style proberen op dezelfde foto, of een nieuwe sturen?",
+      "✨ Your image is ready.",
       [
         { content_type: "text", title: "Try another style", payload: "CHOOSE_STYLE" },
         { content_type: "text", title: "New photo", payload: "SEND_PHOTO" },


### PR DESCRIPTION
### Motivation
- Centralize user-facing message strings for the Messenger webhook flow to make copy updates easier and consistent.
- Replace uncertain/non-English prompt text with a single normalized English flow for idle, photo receipt, style selection, generating, success, and failure messages.
- Ensure emoji acknowledgement detection remains correct after string changes.

### Description
- Added a `USER_MESSAGES` constant in `server/_core/messengerWebhook.ts` and replaced inline user-facing strings to use these centralized messages.
- Replaced the ambiguous prompt (`What style should I use?`) and other locale-specific text with the requested English phrasing (idle intro, photo received, style picker, generating, success, and failure).
- Consolidated generation success/failure handling to use the new messages and updated the style-generating message to include the chosen style label via `USER_MESSAGES.generating`.
- Improved emoji acknowledgement detection to correctly recognize emoji graphemes (e.g., 👍) so ack-ignore behavior remains intact, and updated tests in `server/messengerWebhook.test.ts` and `server/messengerWebhook.greeting.test.ts` to assert the new copy.

### Testing
- Ran targeted tests with `pnpm vitest run server/messengerWebhook.test.ts server/messengerWebhook.greeting.test.ts` and observed all tests passed.
- Verified the modified test suite reports: both `server/messengerWebhook.test.ts` and `server/messengerWebhook.greeting.test.ts` passed (20 tests total).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1913bc5a88325bc50885bb9bdbdb7)