### PR TITLE
Prevent concurrent style generation requests in Messenger webhook

### DIFF
--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -319,6 +319,13 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
 
 async function handleStyleSelection(psid: string, userId: string, style: Style): Promise<void> {
   const state = getOrCreateState(userId);
+
+  if (state.stage === "PROCESSING") {
+    const statusStyle = STYLE_LABELS[style];
+    await sendText(psid, `✨ Creating your ${statusStyle} version… This takes a few seconds.`);
+    return;
+  }
+
   setChosenStyle(userId, style);
   safeLog("style_selected", { user: toLogUser(userId), selectedStyle: style });
 
@@ -334,6 +341,7 @@ async function handleStyleSelection(psid: string, userId: string, style: Style):
 async function handlePayload(psid: string, userId: string, payload: string): Promise<void> {
   const selectedStyle = stylePayloadToStyle(payload);
   if (selectedStyle) {
+    getOrCreateState(userId);
     await handleStyleSelection(psid, userId, selectedStyle);
     return;
   }
@@ -394,6 +402,7 @@ async function handleMessage(psid: string, userId: string, event: FacebookWebhoo
 
   const styleFromText = parseStyle(trimmedText);
   if (styleFromText) {
+    getOrCreateState(userId);
     await handleStyleSelection(psid, userId, styleFromText);
     return;
   }


### PR DESCRIPTION
### Motivation
- Prevent starting a second image generation for the same user when a style change is received while a generation is already in progress.
- Ensure the code reads the current per-user state before reacting to style quick-reply payloads or text style inputs so the guard behaves correctly.
- Provide a clear, single status response to the user when a style-change is attempted during an active generation.

### Description
- Added an in-progress guard in `handleStyleSelection` that checks `getOrCreateState(userId)` and, if `state.stage === "PROCESSING"`, sends `✨ Creating your {Style} version… This takes a few seconds.` and returns without starting a new generation. (file: `server/_core/messengerWebhook.ts`)
- Hydrated user state explicitly by calling `getOrCreateState(userId)` before processing style quick-reply payloads and parsed style text inputs to ensure the guard sees the current state. (file: `server/_core/messengerWebhook.ts`)
- Added regression tests to `server/messengerWebhook.test.ts` that assert: a style quick-reply during generation does not start a second run, and a text-style change during generation returns only the single in-progress status message. (file: `server/messengerWebhook.test.ts`)

### Testing
- Ran the two new targeted tests with `pnpm vitest run server/messengerWebhook.test.ts -t "style click during generation does not start a second run|returns only in-progress status message for style changes while generating"`, which passed. 
- Ran `pnpm check` (`tsc --noEmit`), which passed. 
- Ran the full `server/messengerWebhook.test.ts` suite; the new tests passed but there are three unrelated failing assertions in existing acknowledgement/greeting tests in the same file (these pre-existing failures are not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1913f55e483258bea7a3571b50bde)