### PR TITLE
Photo-first onboarding and strict AWAITING_PHOTO text flow

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -40,7 +40,7 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
     { title: "Send photo", payload: "START_PHOTO" },
     { title: "What is this?", payload: "WHAT_IS_THIS" },
   ],
-  AWAITING_PHOTO: [{ title: "Send photo", payload: "SEND_PHOTO" }],
+  AWAITING_PHOTO: [],
   AWAITING_STYLE: [
     { title: "Caricature", payload: "caricature" },
     { title: "Petals", payload: "petals" },
@@ -49,8 +49,8 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
     { title: "Disco", payload: "disco" },
     { title: "Clouds", payload: "clouds" },
   ],
-  GENERATING: [],
-  SUCCESS: [
+  PROCESSING: [],
+  RESULT_READY: [
     { title: "Download HD", payload: "DOWNLOAD_HD" },
     { title: "Try another style", payload: "CHOOSE_STYLE" },
   ],
@@ -58,7 +58,6 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
     { title: "Retry {style}", payload: "RETRY_STYLE" },
     { title: "Choose another style", payload: "CHOOSE_STYLE" },
   ],
-  FAILURE: [],
 };
 
 export function getQuickRepliesForState(state: ConversationState): StateQuickReply[] {

--- a/server/messengerState.test.ts
+++ b/server/messengerState.test.ts
@@ -41,7 +41,7 @@ describe("messenger state flow", () => {
       { title: "Send photo", payload: "START_PHOTO" },
       { title: "What is this?", payload: "WHAT_IS_THIS" },
     ]);
-    expect(getQuickRepliesForState("AWAITING_PHOTO")).toEqual([{ title: "Send photo", payload: "SEND_PHOTO" }]);
+    expect(getQuickRepliesForState("AWAITING_PHOTO")).toEqual([]);
     expect(getQuickRepliesForState("AWAITING_STYLE")).toEqual([
       { title: "Caricature", payload: "caricature" },
       { title: "Petals", payload: "petals" },
@@ -50,8 +50,8 @@ describe("messenger state flow", () => {
       { title: "Disco", payload: "disco" },
       { title: "Clouds", payload: "clouds" },
     ]);
-    expect(getQuickRepliesForState("GENERATING")).toEqual([]);
-    expect(getQuickRepliesForState("SUCCESS")).toEqual([
+    expect(getQuickRepliesForState("PROCESSING")).toEqual([]);
+    expect(getQuickRepliesForState("RESULT_READY")).toEqual([
       { title: "Download HD", payload: "DOWNLOAD_HD" },
       { title: "Try another style", payload: "CHOOSE_STYLE" },
     ]);

--- a/server/messengerWebhook.greeting.test.ts
+++ b/server/messengerWebhook.greeting.test.ts
@@ -2,10 +2,17 @@ import { describe, expect, it } from "vitest";
 import { getGreetingResponse } from "./_core/messengerWebhook";
 
 describe("greeting handling by conversation state", () => {
-  it("returns processing text while GENERATING", () => {
-    expect(getGreetingResponse("GENERATING")).toEqual({
+  it("returns processing text while PROCESSING", () => {
+    expect(getGreetingResponse("PROCESSING")).toEqual({
       mode: "text",
       text: "I’m still working on it—few seconds.",
+    });
+  });
+
+  it("returns plain photo prompt while AWAITING_PHOTO", () => {
+    expect(getGreetingResponse("AWAITING_PHOTO")).toEqual({
+      mode: "text",
+      text: "Send a photo when you're ready 📷",
     });
   });
 
@@ -17,8 +24,8 @@ describe("greeting handling by conversation state", () => {
     });
   });
 
-  it("returns follow-up options while SUCCESS", () => {
-    expect(getGreetingResponse("SUCCESS")).toEqual({
+  it("returns follow-up options while RESULT_READY", () => {
+    expect(getGreetingResponse("RESULT_READY")).toEqual({
       mode: "quick_replies",
       state: "RESULT_READY",
       text: "✨ Your image is ready.",

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendImageMock, sendQuickRepliesMock, sendTextMock, safeLogMock } = vi.hoisted(() => ({
+  sendImageMock: vi.fn(async () => undefined),
+  sendQuickRepliesMock: vi.fn(async () => undefined),
+  sendTextMock: vi.fn(async () => undefined),
+  safeLogMock: vi.fn(),
+}));
+
+vi.mock("./_core/messengerApi", () => ({
+  sendImage: sendImageMock,
+  sendQuickReplies: sendQuickRepliesMock,
+  sendText: sendTextMock,
+  safeLog: safeLogMock,
+}));
+
+import { processFacebookWebhookPayload, resetMessengerEventDedupe } from "./_core/messengerWebhook";
+import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
+
+describe("photo-first onboarding", () => {
+  beforeEach(() => {
+    process.env.PRIVACY_PEPPER = "test-pepper";
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+    safeLogMock.mockClear();
+    resetStateStore();
+    resetMessengerEventDedupe();
+  });
+
+  it("handles inbound image attachment by setting pending image and sending style picker", async () => {
+    const psid = "photo-first-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-photo-first",
+                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const userState = getState(anonymizePsid(psid));
+    expect(userState?.lastPhoto).toBe("https://img.example/source.jpg");
+    expect(userState?.stage).toBe("AWAITING_STYLE");
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      "🎨 Pick a style to transform your image:",
+      expect.any(Array),
+    );
+    expect(sendTextMock).not.toHaveBeenCalled();
+  });
+
+  it("routes text-only greeting into AWAITING_PHOTO with text-only prompt", async () => {
+    const psid = "text-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: { mid: "mid-hi", text: "Hi" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const userState = getState(anonymizePsid(psid));
+    expect(userState?.stage).toBe("AWAITING_PHOTO");
+    expect(sendTextMock).toHaveBeenCalledWith(psid, "Send a photo when you're ready 📷");
+    expect(sendQuickRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("guards style payload without pending image", async () => {
+    const psid = "guard-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: { mid: "mid-style", quick_reply: { payload: "disco" } },
+            },
+          ],
+        },
+      ],
+    });
+
+    const userState = getState(anonymizePsid(psid));
+    expect(userState?.stage).toBe("AWAITING_PHOTO");
+    expect(sendTextMock).toHaveBeenCalledWith(psid, "Send a photo first 📷");
+    expect(sendQuickRepliesMock).not.toHaveBeenCalled();
+  });
+
+  it("handles DOWNLOAD_HD fallback without quick replies", async () => {
+    const psid = "download-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: { payload: "DOWNLOAD_HD" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const userState = getState(anonymizePsid(psid));
+    expect(userState?.stage).toBe("AWAITING_PHOTO");
+    expect(sendTextMock.mock.calls).toEqual([
+      [psid, "I can share HD downloads after I generate an image."],
+      [psid, "Send a photo when you're ready 📷"],
+    ]);
+    expect(sendQuickRepliesMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce friction by making photo uploads the primary entrypoint so users can send a photo immediately and get the style picker without a greeting.
- Ensure the AWAITING_PHOTO state is text-only (no quick reply pills) to avoid confused UX and accidental style selection without a pending photo.
- Provide a clear fallback for HD download requests when no generated image exists and persist last generated image for future HD downloads.

### Description
- Made inbound image attachments the primary path: `handleMessage` now stores the pending image, sets flow to `AWAITING_STYLE`, and immediately sends the style picker. (`server/_core/messengerWebhook.ts`)
- Enforced text-only `AWAITING_PHOTO` by clearing `QUICK_REPLIES_BY_STATE.AWAITING_PHOTO` and routing `START_PHOTO`/`SEND_PHOTO` to send the `PHOTO_PROMPT` via `sendText` only. (`server/_core/messengerState.ts`, `server/_core/messengerWebhook.ts`)
- Converted style-without-photo guards to reply with `PHOTO_REQUIRED_PROMPT` as plain text and set the flow to `AWAITING_PHOTO` without quick replies. (`server/_core/messengerWebhook.ts`)
- Added `DOWNLOAD_HD` fallback: if no `lastImageUrl` exists, send explanatory text, set `AWAITING_PHOTO`, and prompt with `PHOTO_PROMPT`; if `lastImageUrl` exists, return the image immediately. (`server/_core/messengerWebhook.ts`)
- Persisted generated image URL with `setLastGenerated(...)` when a generation succeeds so `DOWNLOAD_HD` can deliver an HD image later. (`server/_core/messengerWebhook.ts`)
- Simplified photo-received follow-up to reuse the style picker and removed extra quick-reply paths that could surface under `AWAITING_PHOTO`. (`server/_core/messengerWebhook.ts`)
- Updated and added tests: `server/messengerWebhook.photoFirst.test.ts` (new), adjusted `server/messengerState.test.ts` and `server/messengerWebhook.greeting.test.ts` to match the new states and text-only behavior.

### Testing
- Ran `pnpm vitest run server/messengerWebhook.photoFirst.test.ts server/messengerState.test.ts server/messengerWebhook.greeting.test.ts` and all tests passed. (3 test files, 14 tests total passed)
- Ran `pnpm vitest run server/messengerWebhook.photoFirst.test.ts` to exercise the new photo-first flows and it passed (4 tests).
- Test assertions cover: image attachment → pending image → style picker, text-only greeting → `AWAITING_PHOTO` + text-only prompt, style payload without photo → `AWAITING_PHOTO` + text-only prompt, and `DOWNLOAD_HD` fallback behavior with no quick replies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a371566c83258c315628fea107d9)