### PR TITLE
Add type-aware ESLint setup, scoped lint scripts, and CI lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Build
+        run: pnpm run build

--- a/README.md
+++ b/README.md
@@ -230,3 +230,24 @@ High quality
 Frictionless
 
 Everything else is optional.
+
+
+## 🧹 Linting
+
+ESLint is configured with type-aware TypeScript rules using the root `tsconfig.json` so issues are caught early in `client`, `shared`, and `server` code.
+
+- Run lint checks:
+  ```bash
+  pnpm run lint
+  ```
+- Auto-fix safe issues:
+  ```bash
+  pnpm run lint:fix
+  ```
+
+Why ESLint was added:
+
+- catches real TypeScript/runtime pitfalls (for example unhandled promises)
+- keeps code quality consistent across server/client/shared modules
+- stays conflict-free with Prettier by disabling stylistic overlap
+

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,35 @@
+import js from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier";
+import importPlugin from "eslint-plugin-import";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "build/**",
+      "dist/**",
+      "node_modules/**",
+      "coverage/**",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+    },
+  },
+  eslintConfigPrettier,
+);

--- a/package.json
+++ b/package.json
@@ -4,14 +4,16 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development tsx watch server/_core/index.ts",
     "build": "vite build && esbuild server/_core/index.ts --platform=node --packages=external --bundle --format=esm --outfile=dist/index.js",
-    "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc --noEmit",
-    "format": "prettier --write .",
-    "test": "vitest run",
     "db:push": "drizzle-kit generate && drizzle-kit migrate",
-    "debug:image-url": "tsx server/_core/debugImageUrl.ts"
+    "debug:image-url": "tsx server/_core/debugImageUrl.ts",
+    "dev": "cross-env NODE_ENV=development tsx watch server/_core/index.ts",
+    "format": "prettier --write .",
+    "lint": "eslint client shared server",
+    "lint:fix": "eslint client shared server --fix",
+    "start": "cross-env NODE_ENV=production node dist/index.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.12",
@@ -86,6 +88,7 @@
   },
   "devDependencies": {
     "@builder.io/vite-plugin-jsx-loc": "^0.1.1",
+    "@eslint/js": "^9.36.0",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/express": "4.17.21",
@@ -99,6 +102,9 @@
     "cross-env": "^7.0.3",
     "drizzle-kit": "^0.31.4",
     "esbuild": "^0.25.0",
+    "eslint": "^9.36.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
     "pnpm": "^10.15.1",
     "postcss": "^8.4.47",
     "prettier": "^3.6.2",
@@ -106,6 +112,7 @@
     "tsx": "^4.19.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "5.9.3",
+    "typescript-eslint": "^8.44.1",
     "vite": "^7.1.7",
     "vite-plugin-manus-runtime": "^0.0.57",
     "vitest": "^2.1.4"


### PR DESCRIPTION
## Summary
- Added a flat `eslint.config.mjs` using type-aware `typescript-eslint` config with `project: true` and `tsconfigRootDir: import.meta.dirname`
- Scoped linting to application code (`client`, `shared`, `server`) via `lint` and `lint:fix` scripts in `package.json`
- Ignored build/output and test files (`build`, `dist`, `node_modules`, `coverage`, `**/*.test.ts(x)`) to reduce noise
- Enabled a concrete type-aware rule: `@typescript-eslint/no-floating-promises`
- Added CI workflow at `.github/workflows/ci.yml` to run `pnpm run lint` before `pnpm run build`
- Documented lint usage and rationale in `README.md`

## Validation
- Attempted `pnpm run lint` locally; command currently fails in this environment because `@eslint/js` is not installed.
- Installing the new ESLint dependencies was blocked by registry access (`ERR_PNPM_FETCH_403`), so dependency installation could not be completed here.

## Notes
- Once dependencies can be installed (`pnpm install` with registry access), `pnpm run lint`/`pnpm run lint:fix` should work with the committed configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2ca87849c8325bad0b96768d43596)