### PR TITLE
chore: ignore client/public/** in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,10 +6,11 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   {
     ignores: [
-      "build/**",
       "dist/**",
-      "node_modules/**",
+      "build/**",
       "coverage/**",
+      "node_modules/**",
+      "client/public/**",
       "**/*.test.ts",
       "**/*.test.tsx",
     ],


### PR DESCRIPTION
### Motivation
- Prevent ESLint from linting generated/static public assets by adding `client/public/**` to the top-level ignores in `eslint.config.mjs` and align the core ignore entries.

### Description
- Updated the top-level `ignores` array in `eslint.config.mjs` to include `client/public/**` and reordered entries while keeping the existing test-file ignores (`**/*.test.ts`, `**/*.test.tsx`).

### Testing
- Ran `npm run -s lint`, which failed in this environment because the ESLint dependency `@eslint/js` is not installed, so lint could not be executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2d547b9088325bb30d6ed4c2d1531)