### PR TITLE
Fix TypeScript typing for persist-fn, composition hook, chart tooltip styles, and messenger state style type

### DIFF
--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -293,9 +293,9 @@ function ChartTooltipContent({
                             }
                           )}
                           style={{
-                            "--color-bg": indicatorColor,
-                            "--color-border": indicatorColor,
-                          }}
+                            ["--color-bg" as string]: indicatorColor,
+                            ["--color-border" as string]: indicatorColor,
+                          } as React.CSSProperties & Record<string, string | undefined>}
                         />
                       )
                     )}

--- a/client/src/hooks/useComposition.ts
+++ b/client/src/hooks/useComposition.ts
@@ -33,7 +33,10 @@ export function useComposition<
   const timer = useRef<TimerResponse | null>(null);
   const timer2 = useRef<TimerResponse | null>(null);
 
-  const onCompositionStart = usePersistFn((e: React.CompositionEvent<T>) => {
+  const onCompositionStart = usePersistFn<
+    [React.CompositionEvent<T>],
+    void
+  >((e) => {
     if (timer.current) {
       clearTimeout(timer.current);
       timer.current = null;
@@ -46,7 +49,10 @@ export function useComposition<
     originalOnCompositionStart?.(e);
   });
 
-  const onCompositionEnd = usePersistFn((e: React.CompositionEvent<T>) => {
+  const onCompositionEnd = usePersistFn<
+    [React.CompositionEvent<T>],
+    void
+  >((e) => {
     // 使用两层 setTimeout 来处理 Safari 浏览器中 compositionEnd 先于 onKeyDown 触发的问题
     timer.current = setTimeout(() => {
       timer2.current = setTimeout(() => {
@@ -56,7 +62,7 @@ export function useComposition<
     originalOnCompositionEnd?.(e);
   });
 
-  const onKeyDown = usePersistFn((e: React.KeyboardEvent<T>) => {
+  const onKeyDown = usePersistFn<[React.KeyboardEvent<T>], void>((e) => {
     // 在 composition 状态下，阻止 ESC 和 Enter（非 shift+Enter）事件的冒泡
     if (
       c.current &&

--- a/client/src/hooks/usePersistFn.ts
+++ b/client/src/hooks/usePersistFn.ts
@@ -1,21 +1,23 @@
 import { useRef } from "react";
 
-type GenericFunction = (...args: unknown[]) => unknown;
+type GenericFunction<TArgs extends unknown[] = unknown[], TResult = unknown> = (
+  ...args: TArgs
+) => TResult;
 
 /**
  * usePersistFn instead of useCallback to reduce cognitive load
  */
-export function usePersistFn<T extends GenericFunction>(
-  fn: T,
-): (...args: Parameters<T>) => ReturnType<T> {
-  const fnRef = useRef<T>(fn);
+export function usePersistFn<TArgs extends unknown[], TResult>(
+  fn: GenericFunction<TArgs, TResult>,
+): GenericFunction<TArgs, TResult> {
+  const fnRef = useRef<GenericFunction<TArgs, TResult>>(fn);
   fnRef.current = fn;
 
-  const persistFnRef = useRef<((...args: Parameters<T>) => ReturnType<T>) | null>(null);
+  const persistFnRef = useRef<GenericFunction<TArgs, TResult> | null>(null);
 
   if (persistFnRef.current === null) {
-    persistFnRef.current = (...args: Parameters<T>) => {
-      return fnRef.current(...args) as ReturnType<T>;
+    persistFnRef.current = (...args: TArgs) => {
+      return fnRef.current(...args);
     };
   }
 

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,4 +1,4 @@
-import type { StyleId } from "./messengerStyles";
+import type { Style, StyleId } from "./messengerStyles";
 import { STYLE_CONFIGS } from "./messengerStyles";
 import { toUserKey } from "./privacy";
 
@@ -26,7 +26,7 @@ export type MessengerUserState = {
   pendingImageUrl?: string;
   pendingImageAt?: number;
   lastImageUrl?: string;
-  lastStyle?: StyleId;
+  lastStyle?: Style;
   lastGeneratedAt?: number;
   lastVariantCursor?: number;
   quota: QuotaState;
@@ -119,7 +119,7 @@ export function setChosenStyle(userId: string, style: string, now = Date.now()):
   state.updatedAt = now;
 }
 
-export function setLastGenerated(userId: string, style: StyleId, resultImageUrl: string, now = Date.now()): void {
+export function setLastGenerated(userId: string, style: Style, resultImageUrl: string, now = Date.now()): void {
   const state = getOrCreateState(userId);
   state.lastStyle = style;
   state.lastImageUrl = resultImageUrl;


### PR DESCRIPTION
### Motivation

- Prevent TypeScript typing errors and improve type-safety for persisted functions and composition event handlers by adding explicit generic signatures.
- Fix typing for inline CSS custom properties used in the chart tooltip to satisfy React's `style` typing.
- Align the messenger user state `lastStyle` and related API to use the `Style` type instead of `StyleId` to reflect stored style objects.

### Description

- Generalized `usePersistFn` to accept typed argument and return generics and updated internal refs to use the new `GenericFunction<TArgs, TResult>` signature.  
- Updated `useComposition` handlers to call `usePersistFn` with explicit generic parameter types for composition and keyboard event handlers.  
- Changed chart tooltip inline `style` to use bracketed string keys for CSS custom properties and cast the object to `React.CSSProperties & Record<string, string | undefined>` to satisfy TS.  
- Switched messenger state imports and types to use `Style` where `lastStyle` and `setLastGenerated` expect a full `Style` object instead of `StyleId`.

### Testing

- Ran TypeScript checks with `tsc --noEmit` and the project type-check passed.  
- Executed unit tests with `yarn test` and all tests succeeded.  
- Performed a development build with `yarn build` to verify compilation and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f27744188325b69bc88b32587b7c)