### PR TITLE
Improve robustness and type-safety across server core (auth, storage, map, DB, webhooks, Vite)

### DIFF
--- a/server/_core/context.ts
+++ b/server/_core/context.ts
@@ -15,7 +15,7 @@ export async function createContext(
 
   try {
     user = await sdk.authenticateRequest(opts.req);
-  } catch (error) {
+  } catch {
     // Authentication is optional for public procedures.
     user = null;
   }

--- a/server/_core/cookies.ts
+++ b/server/_core/cookies.ts
@@ -1,13 +1,5 @@
 import type { CookieOptions, Request } from "express";
 
-const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
-
-function isIpAddress(host: string) {
-  // Basic IPv4 check and IPv6 presence detection.
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return true;
-  return host.includes(":");
-}
-
 function isSecureRequest(req: Request) {
   if (req.protocol === "https") return true;
 

--- a/server/_core/dataApi.ts
+++ b/server/_core/dataApi.ts
@@ -52,7 +52,7 @@ export async function callDataApi(
     );
   }
 
-  const payload = await response.json().catch(() => ({}));
+  const payload: unknown = await response.json().catch((): unknown => ({}));
   if (payload && typeof payload === "object" && "jsonData" in payload) {
     try {
       return JSON.parse((payload as Record<string, string>).jsonData ?? "{}");

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -44,10 +44,10 @@ function getOpenAiTimeoutMs(): number {
 }
 
 class MockImageGenerator implements ImageGenerator {
-  async generate(input: { style: Style; sourceImageUrl?: string; userKey: string }): Promise<{ imageUrl: string }> {
-    return {
+  generate(input: { style: Style; sourceImageUrl?: string; userKey: string }): Promise<{ imageUrl: string }> {
+    return Promise.resolve({
       imageUrl: getMockImageForStyle(input.style),
-    };
+    });
   }
 }
 

--- a/server/_core/map.ts
+++ b/server/_core/map.ts
@@ -43,6 +43,18 @@ interface RequestOptions {
   body?: Record<string, unknown>;
 }
 
+function toQueryParamValue(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => toQueryParamValue(item)).join("|");
+  }
+
+  return JSON.stringify(value);
+}
+
 /**
  * Make authenticated requests to Google Maps APIs
  * 
@@ -67,7 +79,7 @@ export async function makeRequest<T = unknown>(
   // Add other query parameters
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== null) {
-      url.searchParams.append(key, String(value));
+      url.searchParams.append(key, toQueryParamValue(value));
     }
   });
 

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -1,4 +1,4 @@
-import type { Style, StyleId } from "./messengerStyles";
+import type { Style } from "./messengerStyles";
 import { STYLE_CONFIGS } from "./messengerStyles";
 import { toUserKey } from "./privacy";
 

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -270,10 +270,6 @@ async function sendStateQuickReplies(psid: string, state: ConversationState, tex
   await sendQuickReplies(psid, text, replies);
 }
 
-async function sendGreeting(psid: string): Promise<void> {
-  await sendStateQuickReplies(psid, "IDLE", USER_MESSAGES.flowExplanation);
-}
-
 async function sendStylePicker(psid: string): Promise<void> {
   await sendStateQuickReplies(psid, "AWAITING_STYLE", USER_MESSAGES.stylePicker);
 }
@@ -630,15 +626,13 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
       console.log("[webhook_in]", webhookInLog);
     }
 
-    const payload = req.body;
+    const payload: unknown = req.body;
     res.sendStatus(200);
 
-    setImmediate(async () => {
-      try {
-        await processFacebookWebhookPayload(payload);
-      } catch (error) {
+    setImmediate(() => {
+      void processFacebookWebhookPayload(payload).catch(error => {
         console.error("[facebook-webhook] failed to process event", error);
-      }
+      });
     });
   });
 }

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -21,29 +21,31 @@ export async function setupVite(app: Express, server: Server, createViteServer: 
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+  app.use("*", (req, res, next) => {
     const url = req.originalUrl;
 
-    try {
-      const clientTemplate = path.resolve(
-        import.meta.dirname,
-        "../..",
-        "client",
-        "index.html"
-      );
+    void (async () => {
+      try {
+        const clientTemplate = path.resolve(
+          import.meta.dirname,
+          "../..",
+          "client",
+          "index.html"
+        );
 
-      // always reload the index.html file from disk incase it changes
-      let template = await fs.promises.readFile(clientTemplate, "utf-8");
-      template = template.replace(
-        `src="/src/main.tsx"`,
-        `src="/src/main.tsx?v=${nanoid()}"`
-      );
-      const page = await vite.transformIndexHtml(url, template);
-      res.status(200).set({ "Content-Type": "text/html" }).end(page);
-    } catch (e) {
-      vite.ssrFixStacktrace(e as Error);
-      next(e);
-    }
+        // always reload the index.html file from disk incase it changes
+        let template = await fs.promises.readFile(clientTemplate, "utf-8");
+        template = template.replace(
+          `src="/src/main.tsx"`,
+          `src="/src/main.tsx?v=${nanoid()}"`
+        );
+        const page = await vite.transformIndexHtml(url, template);
+        res.status(200).set({ "Content-Type": "text/html" }).end(page);
+      } catch (e) {
+        vite.ssrFixStacktrace(e as Error);
+        next(e);
+      }
+    })();
   });
 }
 


### PR DESCRIPTION
### Motivation

- Harden server internals for varied runtime environments by improving type-safety, error handling, and response parsing. 
- Make async handlers and background work safer so unhandled promise rejections do not crash the process. 
- Normalize user login method derivation from OAuth responses and make storage / DB code tolerant of different driver return shapes. 

### Description

- Unified OAuth/user handling: added `withLoginMethod` and `UserInfoWithPlatforms` in `server/_core/sdk.ts` to consistently derive `loginMethod`, and updated `getUserInfo`/`getUserInfoWithJwt` to use it. 
- Safer background/route async usage: converted several `async` route/middleware handlers into a synchronous handler that invokes an async IIFE and uses `.catch` to surface errors (in `server/_core/oauth.ts`, `server/_core/vite.ts`, `server/_core/messengerWebhook.ts`) to avoid unhandled promise rejections. 
- Improved request payload typing and parsing: use `unknown` for parsed JSON payloads and handle `jsonData` extraction robustly in `server/_core/dataApi.ts`, and type `req.body` as `unknown` in `messengerWebhook`. 
- Maps query serialization: added `toQueryParamValue` in `server/_core/map.ts` to encode arrays and complex values before appending to `URLSearchParams`. 
- Storage robustness: added `extractUrl` to safely pull `url` from storage responses and updated `buildDownloadUrl`/`storagePut` to use it; adjusted `toFormData` blob construction to handle `Buffer`/`Uint8Array` reliably in `server/storage.ts`. 
- Database compatibility: added an async no-op `await Promise.resolve()` in `getDb` to avoid sync/async ambiguity and implemented a robust `affectedRows` extractor to support different driver return shapes in `server/db.ts`. 
- Minor cleanups: removed unused hostname/IP helper logic from cookies, simplified error handling in `server/_core/context.ts`, and changed `MockImageGenerator.generate` to return an explicit `Promise.resolve` in `server/_core/imageService.ts`.

### Testing

- Ran TypeScript build with `npm run build` to validate types and compilation, which completed successfully. 
- Ran automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a31ade2c4c8325afef8c0abe538e38)