### PR TITLE
Trace Messenger image upload failure after generation (no functional changes)

### DIFF
--- a/MESSENGER_UPLOAD_TRACE_REPORT.md
+++ b/MESSENGER_UPLOAD_TRACE_REPORT.md
@@ -1,0 +1,123 @@
+# Messenger image upload trace report (no functional changes)
+
+## 1) Send API code paths
+
+### Core Send API wrapper
+- **`sendMessage(psid, message)`** in `server/_core/messengerApi.ts` sends all outbound Messenger messages to:
+  - `POST https://graph.facebook.com/v21.0/me/messages?access_token=...`
+  - body shape:
+    ```json
+    {
+      "recipient": { "id": "<PSID>" },
+      "message": { ... }
+    }
+    ```
+
+### Message-type helpers using `sendMessage`
+- **`sendText(psid, text)`**
+  - message payload:
+    ```json
+    { "text": "..." }
+    ```
+- **`sendQuickReplies(psid, text, replies)`**
+  - message payload:
+    ```json
+    {
+      "text": "...",
+      "quick_replies": [
+        { "content_type": "text", "title": "...", "payload": "..." }
+      ]
+    }
+    ```
+- **`sendGenericTemplate(psid, elements)`**
+  - message payload:
+    ```json
+    {
+      "attachment": {
+        "type": "template",
+        "payload": {
+          "template_type": "generic",
+          "elements": [ ... ]
+        }
+      }
+    }
+    ```
+- **`sendImage(psid, imageUrl)`**
+  - message payload:
+    ```json
+    {
+      "attachment": {
+        "type": "image",
+        "payload": {
+          "url": "<imageUrl>",
+          "is_reusable": false
+        }
+      }
+    }
+    ```
+
+### Where `sendImage` is called
+- In generation success path: `runStyleGeneration(...)` after `OPENAI_CALL_SUCCESS`.
+- In `handlePayload(...)` when payload is `DOWNLOAD_HD` and `state.lastImageUrl` exists.
+
+## 2) Image-send / attachment-upload method used
+
+Only one image-send method is implemented for Messenger output:
+
+- ✅ **Method (a) Send API with `attachment.payload.url`** is used via `sendImage`.
+- ❌ **Method (b) `me/message_attachments` upload endpoint** is **not present** in server code.
+- ❌ **Method (c) direct binary multipart upload to Messenger** is **not present** in server code.
+
+So this app currently depends on Messenger fetching a URL (`payload.url`) from the internet.
+
+## 3) Happy-path call chain to first generated-image send
+
+From webhook event to generated image send:
+
+1. `POST /webhook/facebook` route receives payload and schedules async processing.
+2. `processFacebookWebhookPayload(payload)` iterates entries/events.
+3. `handleEvent(event)` routes message/postback.
+4. `handleMessage(...)` or `handlePayload(...)` resolves selected style.
+5. `handleStyleSelection(...)` logs `STYLE_SELECTED`.
+6. `runStyleGeneration(...)` logs `STATE_BEFORE_GENERATE`, `OPENAI_CALL_START`.
+7. `generator.generate(...)` returns image URL, then logs `OPENAI_CALL_SUCCESS`.
+8. `safeLog("generation_success", { mode, ... })`.
+9. **First Messenger image send call:** `sendImage(psid, imageUrl)`.
+10. `sendImage` -> `sendMessage` -> `POST /me/messages` with image attachment URL payload.
+
+## 4) Mock mode investigation
+
+- `mode: "mock"` is produced by `createImageGenerator(...)` when `GENERATOR_MODE !== "openai"`.
+- In other words, **default mode is mock** unless env var is explicitly set to `openai`.
+- Mock generator returns:
+  - `imageUrl = "${baseUrl}/demo/<style-file>.png"`
+  - `baseUrl` comes from `APP_BASE_URL` (fallback `BASE_URL`), else defaults to `http://localhost:3000`.
+- `/demo/*` files are static files under `public/demo`, served by Express static middleware in production.
+
+Reachability implications:
+- If `APP_BASE_URL` is absent/invalid, mock mode emits `http://localhost:3000/demo/...`, which is **not publicly reachable by Meta**.
+- If `APP_BASE_URL` is present and public (e.g. Fly domain), URLs are intended to be externally reachable.
+
+## 5) Most likely root causes for Messenger 400 "Bijlage uploaden is mislukt"
+
+Based on current code and payload shape:
+
+1. **Generated image URL not publicly reachable from Meta**
+   - Code always sends by URL (`payload.url`) and never uploads binary.
+   - In mock mode, fallback URL is `http://localhost:3000/...` if base URL config is missing/invalid.
+
+2. **OpenAI returned URL may be temporary/expired or inaccessible at send time**
+   - OpenAI path takes `result.data[0].url` and immediately forwards that URL to Messenger with no persistence/proxying.
+   - If URL expiry/access policy blocks Meta crawler, Messenger attachment fetch/upload can fail.
+
+3. **Resource at URL not acceptable as Messenger image fetch target (content-type/auth/redirect constraints)**
+   - Since app does not use `message_attachments` upload nor binary upload, success depends entirely on Meta being able to fetch `payload.url` as a valid image.
+   - Any non-image response, blocked redirect, signed URL policy, or inaccessible host can trigger upload failure.
+
+---
+
+## Exact line likely triggering the failure
+
+The first send attempt for the generated image is:
+- `await sendImage(psid, imageUrl);` in `runStyleGeneration(...)`.
+- That delegates to `sendMessage(...)` with `attachment.type="image"` and `payload.url=imageUrl`.


### PR DESCRIPTION
### Motivation
- Investigate Fly logs showing `OPENAI_CALL_START`/`OPENAI_CALL_SUCCESS` followed by Messenger 400 `( #100 ) Bijlage uploaden is mislukt` to locate the exact code path that sends the generated image to Meta and surface likely root causes. 
- Confirm whether images are sent via `attachment.payload.url`, the `me/message_attachments` upload endpoint, or multipart binary upload and whether mock-mode URLs are publicly reachable.

### Description
- Added `MESSENGER_UPLOAD_TRACE_REPORT.md` documenting the Send API call sites, exact outbound payload shapes, and the happy-path call chain from `STYLE_SELECTED` -> `STATE_BEFORE_GENERATE` -> `OPENAI_CALL_START` -> `OPENAI_CALL_SUCCESS` to the first Messenger send. 
- Pointed to the concrete implementation locations: `server/_core/messengerApi.ts` (`sendMessage` POST to `https://graph.facebook.com/v21.0/me/messages` and `sendImage` using `attachment.payload.url`), and `server/_core/messengerWebhook.ts` (`runStyleGeneration` -> `await sendImage(psid, imageUrl)` which is the first send after generation). 
- Documented that only method (a) is implemented (Send API with `attachment.payload.url`), and that neither `me/message_attachments` upload nor multipart/form-data binary upload flows are present. 
- Described mock-mode configuration in `server/_core/imageService.ts` (`GENERATOR_MODE` defaulting to `mock`, `APP_BASE_URL`/`BASE_URL` fallback to `http://localhost:3000`) and noted `/demo/*` static assets under `public/demo` and how a missing `APP_BASE_URL` can yield non-public `http://localhost:3000/demo/...` URLs.

### Testing
- Performed static inspections and grep searches across the codebase (`rg` queries) to locate send paths and mock-mode logic and verified file contents with `sed`/`nl` views, which completed successfully. 
- Verified demo assets exist under `public/demo/*` by listing the directory, which succeeded. 
- No runtime behavior or unit tests were modified; this is a documentation-only change so no unit test run was required. 
- The report identifies the exact likely failing line: `await sendImage(psid, imageUrl);` in `runStyleGeneration(...)`, which delegates to `sendMessage(...)` and posts `attachment.type = "image"` with `payload.url = imageUrl` to Meta.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a429407c40832587f98d4d01aeaec2)