### PR TITLE
Switch generator to OpenAI + persist images to public URLs for Messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ HD version preserves full quality.
 Preview = instant dopamine.
 HD download = full ownership.
 
+For production Messenger delivery (`attachment.payload.url`), generated OpenAI PNG output is persisted to `public/generated/<id>.png` and sent as `${APP_BASE_URL}/generated/<id>.png`. `APP_BASE_URL` must be a public URL in OpenAI mode so Meta can fetch the image from the internet.
+
 📦 Core Endpoints
 Endpoint	Purpose
 /healthz	Health check

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -9,6 +9,7 @@ import { createContext } from "./context";
 import { serveStatic } from "./vite";
 import { registerMetaWebhookRoutes } from "./messengerWebhook";
 import { assertPrivacyConfig } from "./privacy";
+import { getGeneratorStartupConfig } from "./imageService";
 import {
   captureMetaWebhookRawBody,
   verifyMetaWebhookSignature,
@@ -27,6 +28,8 @@ function buildVersionPayload() {
 async function startServer() {
   console.log("BOOT", { pid: process.pid });
   console.log("VERSION", buildVersionPayload());
+  const generatorStartupConfig = getGeneratorStartupConfig();
+  console.log("GENERATOR_STARTUP_CONFIG", generatorStartupConfig);
   assertPrivacyConfig();
 
   const app = express();

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -6,6 +6,7 @@ import {
   createImageGenerator,
   GenerationTimeoutError,
   InvalidGenerationInputError,
+  MissingAppBaseUrlError,
   MissingOpenAiApiKeyError,
   OpenAiGenerationError,
 } from "./imageService";
@@ -355,6 +356,7 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
     console.log("OPENAI_CALL_SUCCESS", { psid });
 
     safeLog("generation_success", { mode, ms: Date.now() - startedAt });
+    console.log("MESSENGER_SEND_IMAGE", { psid, imageUrl });
     await sendImage(psid, imageUrl);
     setLastGenerated(userId, style, imageUrl);
     setFlowState(userId, "RESULT_READY");
@@ -369,7 +371,7 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
     safeLog("generation_fail", { mode, errorClass, ms: Date.now() - startedAt });
 
     let failureText = "I couldn’t generate that image right now.";
-    if (error instanceof MissingOpenAiApiKeyError) {
+    if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
       safeLog("openai_not_configured", { mode });
       failureText = "AI generation isn’t enabled yet.";
     } else if (error instanceof GenerationTimeoutError) {


### PR DESCRIPTION
### Motivation
- Messenger Send API requires a publicly reachable `attachment.payload.url`, and OpenAI image models return base64 data rather than a hosted URL, so generated PNGs must be persisted and served from our domain for Meta to fetch them.
- Ensure production behavior by defaulting to the OpenAI generator unless `GENERATOR_MODE=mock` is explicitly set and surface generator startup info for observability.

### Description
- Use OpenAI Images (`gpt-image-1`) PNG output by reading `b64_json` and converting to a `Buffer`. (`server/_core/imageService.ts`).
- Persist generated PNGs to `public/generated/<timestamp>-<uuid>.png`, verify file size is non-zero, and return a public URL built from `APP_BASE_URL` (with validation and `MissingAppBaseUrlError`). (`server/_core/imageService.ts`).
- Default generator selection to OpenAI unless `GENERATOR_MODE=mock` is set, and expose startup info via `getGeneratorStartupConfig()` which is logged at server boot as `GENERATOR_STARTUP_CONFIG`. (`server/_core/imageService.ts`, `server/_core/index.ts`).
- Log the exact URL sent to Messenger with `console.log("MESSENGER_SEND_IMAGE", { psid, imageUrl })` immediately before calling `sendImage`. Treat missing `APP_BASE_URL` as an OpenAI-not-configured condition (graceful failure path). (`server/_core/messengerWebhook.ts`).
- Update tests to simulate OpenAI `b64_json` responses and assert the produced URL matches the expected `${APP_BASE_URL}/generated/*.png` pattern, and add a short README note documenting the persisted URL requirement. (`server/messengerWebhook.test.ts`, `README.md`).

### Testing
- Ran the webhook unit tests with `pnpm vitest run server/messengerWebhook.test.ts`, which finished with all tests passing (`21 passed`).
- During development the changed tests were iteratively updated and executed locally until the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42cc6aa148325a9b147bbb684ded3)