### PR TITLE
Persist OpenAI PNG outputs to public/generated, expose /generated, and require APP_BASE_URL in OpenAI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ HD version preserves full quality.
 Preview = instant dopamine.
 HD download = full ownership.
 
+For production Messenger delivery (`attachment.payload.url`), generated OpenAI PNG output is persisted to `public/generated/<id>.png` and sent as `${APP_BASE_URL}/generated/<id>.png`. `APP_BASE_URL` must be a public URL in OpenAI mode so Meta can fetch the image from the internet.
+
 📦 Core Endpoints
 Endpoint	Purpose
 /healthz	Health check

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -9,6 +9,7 @@ import { createContext } from "./context";
 import { serveStatic } from "./vite";
 import { registerMetaWebhookRoutes } from "./messengerWebhook";
 import { assertPrivacyConfig } from "./privacy";
+import { getGeneratorStartupConfig } from "./imageService";
 import {
   captureMetaWebhookRawBody,
   verifyMetaWebhookSignature,
@@ -27,6 +28,8 @@ function buildVersionPayload() {
 async function startServer() {
   console.log("BOOT", { pid: process.pid });
   console.log("VERSION", buildVersionPayload());
+  const generatorStartupConfig = getGeneratorStartupConfig();
+  console.log("GENERATOR_STARTUP_CONFIG", generatorStartupConfig);
   assertPrivacyConfig();
 
   const app = express();

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -6,6 +6,7 @@ import {
   createImageGenerator,
   GenerationTimeoutError,
   InvalidGenerationInputError,
+  MissingAppBaseUrlError,
   MissingOpenAiApiKeyError,
   OpenAiGenerationError,
 } from "./imageService";
@@ -355,6 +356,7 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
     console.log("OPENAI_CALL_SUCCESS", { psid });
 
     safeLog("generation_success", { mode, ms: Date.now() - startedAt });
+    console.log("MESSENGER_SEND_IMAGE", { psid, imageUrl });
     await sendImage(psid, imageUrl);
     setLastGenerated(userId, style, imageUrl);
     setFlowState(userId, "RESULT_READY");
@@ -369,7 +371,7 @@ async function runStyleGeneration(psid: string, userId: string, style: Style): P
     safeLog("generation_fail", { mode, errorClass, ms: Date.now() - startedAt });
 
     let failureText = "I couldn’t generate that image right now.";
-    if (error instanceof MissingOpenAiApiKeyError) {
+    if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
       safeLog("openai_not_configured", { mode });
       failureText = "AI generation isn’t enabled yet.";
     } else if (error instanceof GenerationTimeoutError) {

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -49,7 +49,7 @@ export async function setupVite(app: Express, server: Server, createViteServer: 
   });
 }
 
-export function serveStatic(app: Express, staticRoot?: string) {
+export function serveStatic(app: Express, staticRoot?: string, generatedRoot?: string) {
   const distPathCandidates = staticRoot
     ? [path.resolve(staticRoot)]
     : [
@@ -63,6 +63,15 @@ export function serveStatic(app: Express, staticRoot?: string) {
       `Could not find a build directory. Tried: ${distPathCandidates.join(", ")}. Make sure to build the client first.`
     );
     return;
+  }
+
+  const generatedPathCandidates = generatedRoot
+    ? [path.resolve(generatedRoot)]
+    : [path.resolve(process.cwd(), "public", "generated")];
+  const generatedPath = generatedPathCandidates.find((candidate) => fs.existsSync(candidate));
+
+  if (generatedPath) {
+    app.use("/generated", express.static(generatedPath));
   }
 
   app.use(express.static(distPath));


### PR DESCRIPTION
### Motivation

- Ensure generated images from OpenAI are delivered reliably to Messenger by persisting PNG output under the public webroot and returning a public URL for Meta to fetch.
- Make OpenAI image generation use base64 PNG output rather than remote URLs so the app controls hosting and privacy.

### Description

- Add base64 PNG handling in the OpenAiImageGenerator by requesting `output_format: "png"`, decoding `b64_json`, persisting files to `public/generated/<id>.png`, and returning a public URL built from `APP_BASE_URL`.
- Add helper functions `getConfiguredBaseUrl`, `getRequiredPublicBaseUrl`, `persistGeneratedPng`, and export `getGeneratorStartupConfig`; add `MissingAppBaseUrlError` when `APP_BASE_URL` is required but missing.
- Change generator mode default to `openai` unless `GENERATOR_MODE` is explicitly `mock`, and log generator startup config in server boot.
- Serve persisted generated assets via a new `/generated` static route from `serveStatic`, with `serveStatic` accepting an optional `generatedRoot` path and tests to verify image content serving.
- Update README to document persisted PNG delivery and requirement that `APP_BASE_URL` is a public URL when using OpenAI mode, and add various test and webhook logging/behavior tweaks and error handling in messenger webhook flow.

### Testing

- Ran unit tests with `pnpm test` (Vitest) including updated `messengerWebhook.test.ts` and `serveStatic.production.test.ts`, and all tests passed.
- Exercised OpenAI flow in tests by stubbing global `fetch` to return `b64_json` and verified that the webhook sends an image URL matching the configured `APP_BASE_URL` and that timeout and error paths behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42cc6aa148325a9b147bbb684ded3)