### PR TITLE
Fix static image routes before SPA fallback

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 import express from "express";
+import path from "path";
 import { createServer } from "http";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
 import { registerOAuthRoutes } from "./oauth";
@@ -225,6 +226,17 @@ async function startServer() {
       createContext,
     })
   );
+
+  const publicDir = path.join(process.cwd(), "public");
+  app.use(
+    "/demo",
+    express.static(path.join(publicDir, "demo"), { fallthrough: false })
+  );
+  app.use(
+    "/generated",
+    express.static(path.join(publicDir, "generated"), { fallthrough: false })
+  );
+  app.use(express.static(publicDir));
 
   if (process.env.NODE_ENV !== "production") {
     const [{ setupVite }, { createServer }] = await Promise.all([


### PR DESCRIPTION
### Motivation
- Static image requests under `/demo/*.png` and `/generated/*.png` were being intercepted by the SPA fallback and returning HTML, preventing Messenger from fetching images.

### Description
- Import `path` and add explicit static mounts in `server/_core/index.ts` for `/demo` and `/generated` that point to `public/demo` and `public/generated` respectively.
- Configure these static handlers with `fallthrough: false` so missing files return `404` instead of falling through to SPA HTML.
- Mount a general `public` static folder with `app.use(express.static(publicDir))` and register the static middleware before calling `setupVite` / `serveStatic` to ensure static assets are resolved first.

### Testing
- Ran `pnpm run check` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a434c5fdd08325b914eb70bbe24542)