### PR TITLE
Enforce image-to-image flow with proof hashing and no fallback generation

### DIFF
--- a/server/_core/imageProof.ts
+++ b/server/_core/imageProof.ts
@@ -1,0 +1,9 @@
+import { createHash } from "crypto";
+
+export function sha256(buf: Buffer): string {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+export function safeLen(buf?: Buffer): number {
+  return buf?.length ?? 0;
+}

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OpenAiImageGenerator } from "./_core/imageService";
+import { sha256 } from "./_core/imageProof";
+
+describe("OpenAi image-to-image proof", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.APP_BASE_URL;
+  });
+
+  it("sends the original image bytes in OpenAI edits request", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const fixture = Buffer.alloc(7000, 9);
+    const fixtureHash = sha256(fixture);
+    const generatedImageBytes = Buffer.from("fake-png").toString("base64");
+
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      expect(url).toBe("https://api.openai.com/v1/images/edits");
+      const formData = init?.body as FormData;
+      expect(formData).toBeInstanceOf(FormData);
+      const imageBlob = formData.get("image");
+      expect(imageBlob).toBeInstanceOf(Blob);
+      const imageBuffer = Buffer.from(await (imageBlob as Blob).arrayBuffer());
+      expect(sha256(imageBuffer)).toBe(fixtureHash);
+      expect(formData.get("prompt")).toContain("Apply disco style to this photo");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: generatedImageBytes }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    const result = await generator.generate({
+      style: "disco",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.png$/);
+  });
+
+  it("hard-fails before OpenAI call when input image is too small", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const tinyFixture = Buffer.alloc(1024, 1);
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => tinyFixture,
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: Buffer.from("fake-png").toString("base64") }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-2",
+      }),
+    ).rejects.toThrow("Source image too small");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+});


### PR DESCRIPTION
### Motivation
- Users reported stylized outputs that did not appear to be based on the uploaded photo, so we need objective end-to-end proof that the exact input bytes are forwarded to OpenAI and to prevent silent prompt-only fallbacks.
- Make it impossible for the app to generate a generic text-to-image result when the input image is missing or invalid by hard-failing early.

### Description
- Added `server/_core/imageProof.ts` with `sha256(buf: Buffer)` and `safeLen(buf?: Buffer)` helpers for non-sensitive fingerprinting of images.
- Reworked the OpenAI image flow in `server/_core/imageService.ts` to download the source image bytes, log structured proof entries for `proof_stage=incoming` and `proof_stage=openai_input` (including `reqId`, `byte_len`, `sha256`), optionally save `/tmp/leaderbot_incoming.<ext>` when `DEBUG_IMAGE_PROOF=1`, and send the image as multipart to `v1/images/edits` (removing the prompt-only fallback path). A `MissingInputImageError` and a 5KB minimum input guard were added to hard-fail on bad input.
- Propagated a per-request correlation id `reqId` (created as `${psid}-${Date.now()}`) through `server/_core/messengerWebhook.ts` into the generator so incoming/openai logs share the same `reqId`.
- Updated webhook error handling so missing/invalid input triggers a user-facing message `"Ik kon je foto niet goed lezen. Stuur ze nog eens door aub."` and returns to `AWAITING_PHOTO` without calling OpenAI.
- Added `server/imageService.proof.test.ts` which asserts the OpenAI edits request contains the same image bytes (hash matches fixture) and that a too-small image hard-fails before any OpenAI call; adjusted `server/messengerWebhook.test.ts` mocks to account for the two-fetch behavior (download + OpenAI request).

### Testing
- Ran `pnpm -s vitest run server/imageService.proof.test.ts` which passed (2 tests).
- Ran `pnpm -s vitest run server/messengerWebhook.test.ts server/imageService.proof.test.ts` which passed (23 tests total across both files).
- All modified and new tests passed locally (`vitest`), demonstrating: proof logs are emitted, hashes match, and the system hard-fails on too-small/missing input rather than falling back to prompt-only generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a43becc9908325b1cd6afc3be68fec)