### PR TITLE
Reduce production log noise and emit compact PROOF_SUMMARY logs

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -15,6 +15,7 @@ import {
   captureMetaWebhookRawBody,
   verifyMetaWebhookSignature,
 } from "./webhookSignatureVerification";
+import { isDebugLogEnabled } from "./logLevel";
 
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
@@ -59,8 +60,9 @@ async function startServer() {
         ms: Number(durationMs.toFixed(1)),
       };
 
-      // Don't log webhook paths in detail to avoid PII leakage
-      if (!req.path.startsWith("/webhook")) {
+      // Keep info logs compact: skip webhook and health checks unless debug logging is enabled.
+      const shouldLogAtInfo = !req.path.startsWith("/webhook") && req.path !== "/healthz" && req.path !== "/health";
+      if (isDebugLogEnabled() || shouldLogAtInfo) {
         console.log(JSON.stringify(log));
       }
     });

--- a/server/_core/logLevel.ts
+++ b/server/_core/logLevel.ts
@@ -1,0 +1,18 @@
+const LOG_LEVEL = (process.env.LOG_LEVEL ?? "info").toLowerCase();
+
+export function isDebugLogEnabled(): boolean {
+  return LOG_LEVEL === "debug";
+}
+
+export function isStateDumpEnabled(): boolean {
+  return process.env.DEBUG_STATE_DUMP === "1";
+}
+
+export function shouldSampleWebhookSummary(sampleRate = 20): boolean {
+  if (isDebugLogEnabled()) {
+    return true;
+  }
+
+  return Math.floor(Math.random() * sampleRate) === 0;
+}
+


### PR DESCRIPTION
### Motivation
- Reduce high-volume, multi-line logs in production while preserving a single compact proof line per generation request for observability.
- Keep deep debugging artifacts available behind explicit debug flags so production logs remain readable and free of PII.
- Ensure important failures (OpenAI call errors) remain visible at info/error levels.

### Description
- Added a `server/_core/logLevel.ts` helper to support `LOG_LEVEL` (default `info`), `DEBUG_STATE_DUMP=1` gating, and sampled webhook summaries (1/20) when not in debug mode.
- Refactored image proof handling in `server/_core/imageService.ts` so generators return a `proof` object (incoming/openai byte lengths + SHA256) instead of emitting multi-line `IMAGE_PROOF` logs, and kept deep image saves behind `DEBUG_IMAGE_PROOF=1` (now logged as `DEBUG_IMAGE_PROOF`).
- Emitted a single-line JSON `PROOF_SUMMARY` in `server/_core/messengerWebhook.ts` for both success and failure paths containing `reqId`, truncated hashed psid, `style`, incoming/openai lengths & hashes, `outputUrl`, `totalMs`, `ok`, and `errorCode` for failures, and gated `STATE_BEFORE_GENERATE` behind `DEBUG_STATE_DUMP`.
- Reduced request-log noise in `server/_core/index.ts` by suppressing info logs for `/health` and `/healthz` and webhook paths unless `LOG_LEVEL=debug`.

### Testing
- Ran type checks: `pnpm -s check` — succeeded after minor fixes to `Blob` construction.
- Ran unit tests: `pnpm -s test server/imageService.proof.test.ts server/messengerWebhook.test.ts` — all tests passed (both test files passed).
- Ran linter on modified files: `pnpm -s eslint server/_core/imageService.ts server/_core/index.ts server/_core/messengerWebhook.ts server/_core/logLevel.ts` — linter returned clean for these files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4459b576c832581348201ff1d4a4c)