### PR TITLE
Add public Terms page at /terms

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,10 +5,12 @@ import { Route, Switch } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import Home from "./pages/Home";
+import Terms from "./pages/Terms";
 
 function Router() {
   return (
     <Switch>
+      <Route path={"/terms"} component={Terms} />
       <Route path={"/:?"} component={Home} />
       <Route path={"/404"} component={NotFound} />
       {/* Final fallback route */}

--- a/client/src/pages/Terms.tsx
+++ b/client/src/pages/Terms.tsx
@@ -1,0 +1,14 @@
+export default function Terms() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 flex items-center justify-center px-4">
+      <div className="max-w-2xl bg-white rounded-lg border border-slate-200 p-8">
+        <h1 className="text-3xl font-bold text-slate-900 mb-4">Terms of Service</h1>
+        <p className="text-slate-700 leading-relaxed">
+          By using Leaderbot, you agree that uploaded images are processed to generate stylized
+          versions. Images are not permanently stored. The service is provided as-is without
+          warranty.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a public Terms of Service page so users can view the service terms at `https://leaderbot-fb-image-gen.fly.dev/terms`.

### Description
- Added a new React page component at `client/src/pages/Terms.tsx` containing the provided terms copy.
- Registered a `/terms` route in `client/src/App.tsx` and placed it before the catch-all home route so the path resolves correctly.
- Page uses existing app layout styles to match the site appearance.

### Testing
- Ran type checks with `pnpm run check` which succeeded.
- Ran linting with `pnpm run lint` which succeeded.
- Started the dev server and used an automated Playwright script to load `/terms` and capture a screenshot, confirming the page renders as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a44cec9b808325ae42ee877cc7419d)