### PR TITLE
chore: polish NL/EN Messenger UX copy

### DIFF
--- a/server/_core/i18n.ts
+++ b/server/_core/i18n.ts
@@ -29,9 +29,9 @@ type TranslationValue = string | ((params: TranslationParams) => string);
 const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
   nl: {
     flowExplanation: "Stuur een foto en ik maak er een speciale versie van in een andere stijl — het is gratis.",
-    stylePicker: "Dank je. Kies hieronder een stijl.",
-    success: "Klaar. Je kan de afbeelding opslaan door erop te tikken.",
-    processingBlocked: "Ik ben nog bezig met je vorige afbeelding.",
+    stylePicker: "Kies een stijl 👇",
+    success: "Klaar! Tik om op te slaan.",
+    processingBlocked: "Nog even — je vorige afbeelding wordt nog gemaakt.",
     styleWithoutPhoto: "Stuur eerst een foto, dan maak ik die stijl voor je.",
     textWithoutPhoto: "Stuur gerust een foto, dan kan ik een stijl voor je maken.",
     privacy: ({ link }) => [
@@ -40,7 +40,7 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
       `Hier kan je het volledige privacybeleid lezen: ${link ?? "<link>"}`,
     ].join("\n"),
     aboutLeaderbot: "Leaderbot is gemaakt door Andy. Je mag hem gerust contacteren via Facebook.\nVolledige naam op vraag: Andy Arijs.",
-    failure: "Er ging iets mis bij het maken van je afbeelding. Kies gerust opnieuw een stijl.",
+    failure: "Oeps, er ging iets mis. Kies nog een stijl.",
     missingInputImage: "Ik kon je foto niet goed lezen. Stuur ze nog eens door aub.",
     generatingPrompt: ({ styleLabel }) => `Ik maak nu je ${styleLabel ?? ""}-stijl.`,
     retryThisStyle: "Retry this style",
@@ -52,9 +52,9 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
   },
   en: {
     flowExplanation: "Send a photo and I will make a special version of it in another style for free.",
-    stylePicker: "Thanks. Choose a style below.",
-    success: "Done. You can save the image by tapping it.",
-    processingBlocked: "I am still working on your previous image.",
+    stylePicker: "Choose a style 👇",
+    success: "Done! Tap to save.",
+    processingBlocked: "One sec — I'm still finishing your previous image.",
     styleWithoutPhoto: "Send a photo first, then I can make that style for you.",
     textWithoutPhoto: "Feel free to send a photo, then I can make a style for you.",
     privacy: ({ link }) => [
@@ -63,7 +63,7 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
       `You can read the full privacy policy here: ${link ?? "<link>"}`,
     ].join("\n"),
     aboutLeaderbot: "Leaderbot was made by Andy. Feel free to contact him via Facebook.\nFull name on request: Andy Arijs.",
-    failure: "Something went wrong while making your image. Feel free to choose a style again.",
+    failure: "Oops, something went wrong. Pick another style.",
     missingInputImage: "I could not read your photo properly. Please send it again.",
     generatingPrompt: ({ styleLabel }) => `I am now making your ${styleLabel ?? ""} style.`,
     retryThisStyle: "Retry this style",


### PR DESCRIPTION
### Motivation
- Make Messenger UX copy shorter and clearer in both Dutch (`nl`) and English (`en`) for key UI messages to reduce friction and improve readability.

### Description
- Edited only `server/_core/i18n.ts` to update the `stylePicker`, `processingBlocked`, `success`, and `failure` translations for both `nl` and `en` languages. 
- Kept all translation keys and function signatures unchanged and left other strings intact.

### Testing
- Verified the updated file contents and diff of `server/_core/i18n.ts` to confirm the intended string changes. 
- Printed the modified file (`nl -ba server/_core/i18n.ts`) to validate the final text entries. 
- A local commit was created, but pushing the branch to the remote failed because no `origin` remote is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48b7101f88325859f724ce0b675f8)