### PR TITLE
fix: serve generated images as jpeg for universal compatibility

### DIFF
--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
 import { OpenAiImageGenerator } from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
+
+const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
 
 describe("OpenAi image-to-image proof", () => {
   afterEach(() => {
@@ -15,7 +19,7 @@ describe("OpenAi image-to-image proof", () => {
 
     const fixture = Buffer.alloc(7000, 9);
     const fixtureHash = sha256(fixture);
-    const generatedImageBytes = Buffer.from("fake-png").toString("base64");
+    const generatedImageBytes = GENERATED_IMAGE_BASE64;
 
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (url === "https://img.example/source.jpg") {
@@ -34,6 +38,7 @@ describe("OpenAi image-to-image proof", () => {
       const imageBuffer = Buffer.from(await (imageBlob as Blob).arrayBuffer());
       expect(sha256(imageBuffer)).toBe(fixtureHash);
       expect(formData.get("prompt")).toContain("Apply disco style to this photo");
+      expect(formData.get("output_format")).toBe("jpeg");
 
       return {
         ok: true,
@@ -52,7 +57,7 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.png$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
     expect(result.metrics.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
@@ -74,7 +79,7 @@ describe("OpenAi image-to-image proof", () => {
 
       return {
         ok: true,
-        json: async () => ({ data: [{ b64_json: Buffer.from("fake-png").toString("base64") }] }),
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
       } as Response;
     });
 
@@ -98,7 +103,7 @@ describe("OpenAi image-to-image proof", () => {
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
 
     const fixture = Buffer.alloc(7000, 9);
-    const generatedImageBytes = Buffer.from("fake-png").toString("base64");
+    const generatedImageBytes = GENERATED_IMAGE_BASE64;
     const fetchMock = vi.fn(async (url: string) => {
       if (url === "https://img.example/source.jpg" && fetchMock.mock.calls.length === 1) {
         throw new TypeError("temporary network failure");
@@ -129,8 +134,45 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.png$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("removes leftover generated webp files", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const generatedDir = path.resolve(process.cwd(), "public", "generated");
+    await fs.mkdir(generatedDir, { recursive: true });
+    await fs.writeFile(path.join(generatedDir, "old-artifact.webp"), Buffer.from("webp"));
+
+    const fixture = Buffer.alloc(7000, 9);
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "disco",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-4",
+    });
+
+    await expect(fs.access(path.join(generatedDir, "old-artifact.webp"))).rejects.toThrow();
   });
 
 });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -435,7 +435,7 @@ describe("messenger webhook dedupe", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(sendImageMock).toHaveBeenCalledWith(
       "openai-success-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.png$/),
+      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-[a-z0-9-]+-\d+\.jpg$/),
     );
   });
 

--- a/server/serveStatic.production.test.ts
+++ b/server/serveStatic.production.test.ts
@@ -21,7 +21,7 @@ function createTempBuild() {
 function createGeneratedAssets() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaderbot-generated-"));
   tempDirs.push(dir);
-  fs.writeFileSync(path.join(dir, "sample.png"), Buffer.from([137,80,78,71,13,10,26,10]));
+  fs.writeFileSync(path.join(dir, "sample.jpg"), Buffer.from([255, 216, 255, 224]));
   return dir;
 }
 async function listen(app: express.Express) {
@@ -97,7 +97,7 @@ describe("serveStatic production mode", () => {
     }
   });
 
-  it("serves generated PNGs from /generated with image content type", async () => {
+  it("serves generated JPGs from /generated with image content type", async () => {
     const app = express();
     const staticDir = createTempBuild();
     const generatedDir = createGeneratedAssets();
@@ -107,11 +107,11 @@ describe("serveStatic production mode", () => {
     const server = await listen(app);
 
     try {
-      const generatedResponse = await fetch(`${server.baseUrl}/generated/sample.png`);
+      const generatedResponse = await fetch(`${server.baseUrl}/generated/sample.jpg`);
       expect(generatedResponse.status).toBe(200);
-      expect(generatedResponse.headers.get("content-type")).toContain("image/png");
+      expect(generatedResponse.headers.get("content-type")).toContain("image/jpeg");
 
-      const missingGeneratedResponse = await fetch(`${server.baseUrl}/generated/missing.png`);
+      const missingGeneratedResponse = await fetch(`${server.baseUrl}/generated/missing.jpg`);
       expect(missingGeneratedResponse.status).toBe(200);
       expect(missingGeneratedResponse.headers.get("content-type")).toContain("text/html");
     } finally {


### PR DESCRIPTION
### Motivation

- Ensure all generated images are universally shareable and directly openable on Android and iOS by producing JPEG outputs instead of WebP.
- Prevent any .webp artifacts from being saved or served from the `public/generated` directory.
- Keep changes limited to the image generation / output layer and avoid touching webhook flow, UX copy, or quota logic.
- Produce predictable, human-readable filenames instead of UUID-only names.

### Description

- Force OpenAI edits requests to request `output_format = "jpeg"` when calling `https://api.openai.com/v1/images/edits`.
- Add `ensureJpegBuffer` which dynamically imports `sharp` if available and converts non-JPEG bytes to JPEG with `jpeg({ quality: 90 })`, and use it before persisting generated output.
- Replace random-UUID `.png` persistence with `persistGeneratedJpg` which writes files as `leaderbot-{style}-{timestamp}.jpg` and returns `/generated/{filename}` URLs.
- Add `removeGeneratedWebpArtifacts` to delete any existing `.webp` files in `public/generated` before writing the new JPEG and simplify inbound debug proof extension logic to only produce `.png` or `.jpg`.
- Update tests and expectations to assert `output_format` set to `jpeg`, generated URL filenames ending with `.jpg`, static serve content-type `image/jpeg`, and an added cleanup test that ensures leftover `.webp` artifacts are removed.

### Testing

- Ran unit tests for the image layer and static serving with `pnpm vitest run server/imageService.proof.test.ts server/serveStatic.production.test.ts` and both test files passed.
- Running the broader set `pnpm vitest run server/imageService.proof.test.ts server/messengerWebhook.test.ts server/serveStatic.production.test.ts` failed due to existing webhook test helper issues (`summarizeWebhook` / `resetMessengerEventDedupe` not found) unrelated to the image output changes.
- Type-check succeeded via `pnpm check` (ran `tsc --noEmit`) and the production build succeeded via `pnpm build`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54a5565d483259c84e2e07e45ab91)