### PR TITLE
chore-add-security-headers-and-dependency-guards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    groups:
+      frontend:
+        patterns:
+          - "react*"
+          - "@radix-ui/*"
+          - "@tanstack/*"
+          - "@trpc/*"
+          - "vite*"
+      aws:
+        patterns:
+          - "@aws-sdk/*"
+      tooling:
+        patterns:
+          - "eslint*"
+          - "typescript*"
+          - "vitest"
+          - "prettier"
+          - "drizzle*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,11 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Test
+        run: pnpm run test
+
       - name: Build
         run: pnpm run build
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level=high

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@ai-sdk/openai": "^3.0.12",
     "@ai-sdk/react": "^3.0.40",
-    "@aws-sdk/client-s3": "^3.693.0",
-    "@aws-sdk/s3-request-presigner": "^3.693.0",
+    "@aws-sdk/client-s3": "^3.970.0",
+    "@aws-sdk/s3-request-presigner": "^3.970.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -56,7 +56,7 @@
     "@trpc/react-query": "^11.6.0",
     "@trpc/server": "^11.6.0",
     "ai": "^6.0.38",
-    "axios": "^1.12.0",
+    "axios": "^1.13.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
@@ -123,7 +123,11 @@
   "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
     "overrides": {
-      "tailwindcss>nanoid": "3.3.7"
+      "tailwindcss>nanoid": "3.3.7",
+      "fast-xml-parser": "^5.3.5",
+      "lodash": "^4.17.23",
+      "lodash-es": "^4.17.23",
+      "qs": "^6.14.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   tailwindcss>nanoid: 3.3.7
+  fast-xml-parser: ^5.3.5
+  lodash: ^4.17.23
+  lodash-es: ^4.17.23
+  qs: ^6.14.2
 
 importers:
 
@@ -18,10 +22,10 @@ importers:
         specifier: ^3.0.40
         version: 3.0.40(react@19.2.3)(zod@4.3.5)
       '@aws-sdk/client-s3':
-        specifier: ^3.693.0
+        specifier: ^3.970.0
         version: 3.970.0
       '@aws-sdk/s3-request-presigner':
-        specifier: ^3.693.0
+        specifier: ^3.970.0
         version: 3.970.0
       '@hookform/resolvers':
         specifier: ^5.2.2
@@ -126,8 +130,8 @@ importers:
         specifier: ^6.0.38
         version: 6.0.38(zod@4.3.5)
       axios:
-        specifier: ^1.12.0
-        version: 1.13.2
+        specifier: ^1.13.5
+        version: 1.13.6
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2859,8 +2863,8 @@ packages:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
     engines: {node: '>= 6.0.0'}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -3656,8 +3660,11 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+  fast-xml-builder@1.0.0:
+    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+
+  fast-xml-parser@5.4.2:
+    resolution: {integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==}
     hasBin: true
 
   fdir@6.5.0:
@@ -4206,11 +4213,8 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-
-  lodash-es@4.17.22:
-    resolution: {integrity: sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==}
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -4221,8 +4225,8 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -4685,8 +4689,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -6012,7 +6016,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.969.0':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.2.5
+      fast-xml-parser: 5.4.2
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
@@ -6148,12 +6152,12 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 11.0.3
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/gast@11.0.3':
     dependencies:
       '@chevrotain/types': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   '@chevrotain/regexp-to-ast@11.0.3': {}
 
@@ -8302,7 +8306,7 @@ snapshots:
 
   aws-ssl-profiles@1.1.2: {}
 
-  axios@1.13.2:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -8328,7 +8332,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -8409,7 +8413,7 @@ snapshots:
   chevrotain-allstar@0.3.1(chevrotain@11.0.3):
     dependencies:
       chevrotain: 11.0.3
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
 
   chevrotain@11.0.3:
     dependencies:
@@ -8418,7 +8422,7 @@ snapshots:
       '@chevrotain/regexp-to-ast': 11.0.3
       '@chevrotain/types': 11.0.3
       '@chevrotain/utils': 11.0.3
-      lodash-es: 4.17.21
+      lodash-es: 4.17.23
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -8682,7 +8686,7 @@ snapshots:
   dagre-d3-es@7.0.13:
     dependencies:
       d3: 7.9.0
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -9192,7 +9196,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -9215,8 +9219,11 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-xml-parser@5.2.5:
+  fast-xml-builder@1.0.0: {}
+
+  fast-xml-parser@5.4.2:
     dependencies:
+      fast-xml-builder: 1.0.0
       strnum: 2.1.2
 
   fdir@6.5.0(picomatch@4.0.3):
@@ -9806,9 +9813,7 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
-  lodash-es@4.17.21: {}
-
-  lodash-es@4.17.22: {}
+  lodash-es@4.17.23: {}
 
   lodash.defaults@4.2.0: {}
 
@@ -9816,7 +9821,7 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
-  lodash@4.17.21: {}
+  lodash@4.17.23: {}
 
   long@5.3.2: {}
 
@@ -10037,7 +10042,7 @@ snapshots:
       dompurify: 3.3.1
       katex: 0.16.27
       khroma: 2.1.0
-      lodash-es: 4.17.22
+      lodash-es: 4.17.23
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.3.6
@@ -10512,7 +10517,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -10606,7 +10611,7 @@ snapshots:
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
-      lodash: 4.17.21
+      lodash: 4.17.23
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-is: 18.3.1

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -12,6 +12,7 @@ import { registerMetaWebhookRoutes } from "./messengerWebhook";
 import { assertPrivacyConfig } from "./privacy";
 import { getGeneratorStartupConfig } from "./imageService";
 import { assertAuthConfig } from "./env";
+import { applySecurityHeaders } from "./securityHeaders";
 import {
   captureMetaWebhookRawBody,
   verifyMetaWebhookSignature,
@@ -41,6 +42,8 @@ async function startServer() {
 
   const app = express();
   const server = createServer(app);
+
+  applySecurityHeaders(app);
 
   app.use(
     express.json({

--- a/server/_core/securityHeaders.ts
+++ b/server/_core/securityHeaders.ts
@@ -1,0 +1,35 @@
+import type { Express, Request, Response, NextFunction } from "express";
+
+function isSecureRequest(req: Request): boolean {
+  if (req.protocol === "https") {
+    return true;
+  }
+
+  const forwardedProto = req.headers["x-forwarded-proto"];
+  if (!forwardedProto) {
+    return false;
+  }
+
+  const values = Array.isArray(forwardedProto)
+    ? forwardedProto
+    : forwardedProto.split(",");
+
+  return values.some(value => value.trim().toLowerCase() === "https");
+}
+
+export function applySecurityHeaders(app: Express): void {
+  app.disable("x-powered-by");
+
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+
+    if (process.env.NODE_ENV === "production" && isSecureRequest(req)) {
+      res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    }
+
+    next();
+  });
+}

--- a/server/securityHeaders.test.ts
+++ b/server/securityHeaders.test.ts
@@ -1,0 +1,93 @@
+import http from "node:http";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+import { applySecurityHeaders } from "./_core/securityHeaders";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+async function startServer(
+  configure?: (app: express.Express) => void
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const app = express();
+  applySecurityHeaders(app);
+  configure?.(app);
+  app.get("/healthz", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Unable to get test server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+  };
+}
+
+describe("security headers", () => {
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+      return;
+    }
+
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("sets baseline hardening headers and removes x-powered-by", async () => {
+    process.env.NODE_ENV = "development";
+    const server = await startServer();
+
+    try {
+      const response = await fetch(`${server.baseUrl}/healthz`);
+
+      expect(response.headers.get("x-powered-by")).toBeNull();
+      expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(response.headers.get("x-frame-options")).toBe("DENY");
+      expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+      expect(response.headers.get("permissions-policy")).toContain("camera=()");
+      expect(response.headers.get("strict-transport-security")).toBeNull();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("adds HSTS for secure production requests", async () => {
+    process.env.NODE_ENV = "production";
+    const server = await startServer(app => {
+      app.get("/secure", (req, res) => {
+        res.status(200).json({ secure: req.headers["x-forwarded-proto"] ?? null });
+      });
+    });
+
+    try {
+      const response = await fetch(`${server.baseUrl}/secure`, {
+        headers: {
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      expect(response.headers.get("strict-transport-security")).toBe(
+        "max-age=31536000; includeSubDomains"
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
Description
  This PR applies a focused security hardening pass across auth, OAuth,
  request handling, and HTTP response headers.

  Changes:

  - Enforced fail-fast auth config in server/_core/env.ts so JWT_SECRET must
    accepting an empty fallback secret.
  - Reworked OAuth state handling across server/_core/oauth.ts, server/
    _core/sdk.ts, client/src/const.ts, and client/src/_core/hooks/useAuth.ts
    so OAuth now uses a nonce-based state plus callback cookie validation
    instead of trusting a base64 redirect URI alone.
  - Reduced global request body limits in server/_core/index.ts from 50mb to
    1mb to reduce memory-pressure / request amplification risk.
  - Hardened debug image proof handling in server/_core/imageService.ts so
    temporary debug dumps use unique temp files and are ignored in
    production.
  - Added baseline HTTP security headers in server/_core/securityHeaders.ts
    and .github/dependabot.yml.

  Tests:

  - Added OAuth security coverage in server/oauth.security.test.ts
  - Added header coverage in server/securityHeaders.test.ts
  - Extended config/test stability in server/sdk.oauthConfig.test.ts and
    server/messengerQuota.test.ts

  Validation:

  - pnpm -s tsc --noEmit
  - pnpm -s vitest run

  Result:

  - Full test suite passes locally: 15 test files, 74 tests
  - No intentional API or UX changes beyond stricter security validation