### PR TITLE
Normalize legacy messenger state keys for Redis-backed persistence

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -77,7 +77,13 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
   ],
 };
 
-type PartialState = Partial<MessengerUserState>;
+type LegacyMessengerState = {
+  currentStep?: MessengerFlowState;
+  lastImage?: string | null;
+  style?: string | null;
+};
+
+type PartialState = Partial<MessengerUserState> & LegacyMessengerState;
 
 function looksLikeUserKey(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value);
@@ -118,9 +124,10 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
 function normalizeState(psid: string, value: PartialState | null | undefined): MessengerUserState {
   const resolvedPsid = value?.psid ?? psid;
   const fallback = createDefaultState(resolvedPsid);
-  const stage = value?.stage ?? value?.state ?? fallback.stage;
+  const stage = value?.stage ?? value?.state ?? value?.currentStep ?? fallback.stage;
   const lastPhoto = value?.lastPhoto ?? value?.lastPhotoUrl ?? fallback.lastPhoto;
-  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? fallback.selectedStyle;
+  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? value?.style ?? fallback.selectedStyle;
+  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? value?.lastImage ?? fallback.lastGeneratedUrl;
 
   return {
     ...fallback,
@@ -134,6 +141,8 @@ function normalizeState(psid: string, value: PartialState | null | undefined): M
     lastPhoto,
     selectedStyle,
     chosenStyle: selectedStyle,
+    lastImageUrl: value?.lastImageUrl ?? lastGeneratedUrl ?? fallback.lastImageUrl,
+    lastGeneratedUrl,
     quota: {
       dayKey: value?.quota?.dayKey ?? fallback.quota.dayKey,
       count: value?.quota?.count ?? fallback.quota.count,


### PR DESCRIPTION
### Motivation
- Handle legacy messenger state payloads stored in Redis or in-memory so older keys are safely mapped to the current canonical schema when read and rewritten.

### Description
- Add a `LegacyMessengerState` type and extend `PartialState` to include legacy keys `currentStep`, `lastImage`, and `style`.
- Update `normalizeState` to prefer legacy values when canonical fields are missing and map `currentStep` → `stage/state`, `style` → `selectedStyle/chosenStyle`, and `lastImage` → `lastGeneratedUrl/lastImageUrl`.
- Ensure normalized values are written back in the canonical shape while leaving the existing Redis-backed state store flow untouched.

### Testing
- Ran `pnpm -s eslint server/_core/messengerState.ts` which succeeded. 
- Ran `pnpm -s check` (TypeScript typecheck) which failed due to unrelated existing type errors in `client/src/components/ui/resizable.tsx` and not due to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a74048b2c48325bc60caa2781a3220)