### PR TITLE
Add generation backpressure guard and Graph API retry handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ Related files:
 - `LOG_LEVEL`, `DEBUG_STATE_DUMP` (diagnostics)
 - `GENERATOR_MODE=mock` (forces mock generator)
 - `OPENAI_IMAGE_TIMEOUT_MS`, `FB_IMAGE_FETCH_TIMEOUT_MS` (timeouts)
+- `MESSENGER_MAX_IMAGE_JOBS` (global cap for concurrent image generations, default `3`)
+- `MESSENGER_PSID_COOLDOWN_MS` (optional per-PSID cooldown between generations, default `0`)
+- `MESSENGER_PSID_LOCK_TTL_MS` (per-PSID in-flight lock TTL, default `120000`)
+- `GRAPH_API_MAX_RETRIES`, `GRAPH_API_RETRY_BASE_MS` (retry policy for Meta Graph API 429/5xx responses)
 - `PORT` (default `8080`)
 
 Legacy/app-specific environment variables also exist for SDK and data API integrations in `server/_core/env.ts`.

--- a/server/_core/generationGuard.ts
+++ b/server/_core/generationGuard.ts
@@ -1,0 +1,90 @@
+import {
+  deleteEphemeralKey,
+  hasEphemeralKey,
+  setEphemeralKey,
+  setEphemeralKeyIfAbsent,
+} from "./stateStore";
+
+const DEFAULT_GLOBAL_CONCURRENCY = 3;
+const DEFAULT_PSID_COOLDOWN_MS = 0;
+const DEFAULT_PSID_LOCK_MS = 120000;
+
+function readNonNegativeInt(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw >= 0 ? Math.floor(raw) : fallback;
+}
+
+class ConcurrencyLimiter {
+  private active = 0;
+
+  private readonly pending: Array<() => void> = [];
+
+  constructor(private readonly maxConcurrency: number) {}
+
+  async run<T>(task: () => Promise<T>): Promise<T> {
+    if (this.active >= this.maxConcurrency) {
+      await new Promise<void>(resolve => this.pending.push(resolve));
+    }
+
+    this.active += 1;
+    try {
+      return await task();
+    } finally {
+      this.active -= 1;
+      const next = this.pending.shift();
+      next?.();
+    }
+  }
+}
+
+const globalLimiter = new ConcurrencyLimiter(
+  readNonNegativeInt("MESSENGER_MAX_IMAGE_JOBS", DEFAULT_GLOBAL_CONCURRENCY)
+);
+
+function lockKey(psid: string): string {
+  return `messenger:inflight:${psid}`;
+}
+
+function cooldownKey(psid: string): string {
+  return `messenger:cooldown:${psid}`;
+}
+
+function toSeconds(milliseconds: number): number {
+  return Math.max(1, Math.ceil(milliseconds / 1000));
+}
+
+export async function runGuardedGeneration<T>(
+  psid: string,
+  task: () => Promise<T>
+): Promise<T | null> {
+  const cooldownMs = readNonNegativeInt(
+    "MESSENGER_PSID_COOLDOWN_MS",
+    DEFAULT_PSID_COOLDOWN_MS
+  );
+  const lockMs = readNonNegativeInt(
+    "MESSENGER_PSID_LOCK_TTL_MS",
+    DEFAULT_PSID_LOCK_MS
+  );
+
+  if (cooldownMs > 0 && (await hasEphemeralKey(cooldownKey(psid)))) {
+    return null;
+  }
+
+  const acquired = await setEphemeralKeyIfAbsent(
+    lockKey(psid),
+    "1",
+    toSeconds(lockMs)
+  );
+  if (!acquired) {
+    return null;
+  }
+
+  try {
+    return await globalLimiter.run(task);
+  } finally {
+    await deleteEphemeralKey(lockKey(psid));
+    if (cooldownMs > 0) {
+      await setEphemeralKey(cooldownKey(psid), "1", toSeconds(cooldownMs));
+    }
+  }
+}

--- a/server/_core/messengerApi.ts
+++ b/server/_core/messengerApi.ts
@@ -31,35 +31,89 @@ function getSendApiUrl(): string {
   return `https://graph.facebook.com/${GRAPH_API_VERSION}/me/messages?access_token=${encodeURIComponent(getPageToken())}`;
 }
 
+function parsePositiveInt(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value >= 0 ? Math.floor(value) : fallback;
+}
+
+function shouldRetry(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function getRetryAfterMs(response: Response): number | null {
+  const header = response.headers.get("retry-after");
+  if (!header) {
+    return null;
+  }
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.floor(seconds * 1000);
+  }
+
+  return null;
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
 async function sendMessage(
   psid: string,
   message: Record<string, unknown>
 ): Promise<void> {
-  const response = await fetch(getSendApiUrl(), {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      recipient: { id: psid },
-      message,
-    }),
-  });
+  const maxRetries = parsePositiveInt("GRAPH_API_MAX_RETRIES", 3);
+  const retryBaseMs = parsePositiveInt("GRAPH_API_RETRY_BASE_MS", 300);
 
-  if (!response.ok) {
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const response = await fetch(getSendApiUrl(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        recipient: { id: psid },
+        message,
+      }),
+    });
+
+    if (response.ok) {
+      return;
+    }
+
     const body = await response.text();
-    throw new Error(`Messenger API error ${response.status}: ${body}`);
+    const canRetry = attempt < maxRetries && shouldRetry(response.status);
+    if (!canRetry) {
+      throw new Error(`Messenger API error ${response.status}: ${body}`);
+    }
+
+    const retryAfterMs = getRetryAfterMs(response);
+    const exponentialBackoffMs = retryBaseMs * 2 ** attempt;
+    const waitMs = retryAfterMs ?? exponentialBackoffMs;
+    await delay(waitMs);
   }
+
+  throw new Error("Messenger API error: retry loop exited unexpectedly");
 }
 
 function shouldDropLogKey(key: string): boolean {
   const lowered = key.toLowerCase();
-  return ["token", "psid", "text", "url", "payload", "attachment", "message", "sender", "body"].some(fragment =>
-    lowered.includes(fragment)
-  );
+  return [
+    "token",
+    "psid",
+    "text",
+    "url",
+    "payload",
+    "attachment",
+    "message",
+    "sender",
+    "body",
+  ].some(fragment => lowered.includes(fragment));
 }
 
-function redactLogDetails(details: Record<string, unknown>): Record<string, unknown> {
+function redactLogDetails(
+  details: Record<string, unknown>
+): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(details)
       .filter(([key]) => !shouldDropLogKey(key))

--- a/server/_core/stateStore.ts
+++ b/server/_core/stateStore.ts
@@ -3,7 +3,12 @@ const STATE_TTL_SECONDS = 172800;
 type RedisLike = {
   ping(): Promise<string>;
   get(key: string): Promise<string | null>;
-  set(key: string, value: string, mode: "EX", seconds: number): Promise<unknown>;
+  set(
+    key: string,
+    value: string,
+    ...args: Array<string | number>
+  ): Promise<unknown>;
+  del(key: string): Promise<number>;
 };
 
 type RedisModule = {
@@ -13,6 +18,7 @@ type RedisModule = {
 export type MaybePromise<T> = T | Promise<T>;
 
 const memoryState = new Map<string, string>();
+const memoryEphemeral = new Map<string, number>();
 
 let redisClientPromise: Promise<RedisLike> | null = null;
 
@@ -25,7 +31,9 @@ function isPromiseLike<T>(value: MaybePromise<T>): value is Promise<T> {
 }
 
 async function importRedisModule(): Promise<RedisModule> {
-  const dynamicImport = Function("specifier", "return import(specifier)") as (specifier: string) => Promise<unknown>;
+  const dynamicImport = Function("specifier", "return import(specifier)") as (
+    specifier: string
+  ) => Promise<unknown>;
   return (await dynamicImport("ioredis")) as RedisModule;
 }
 
@@ -85,11 +93,16 @@ export function writeState<T>(psid: string, value: T): MaybePromise<void> {
   }
 
   return getRedisClient().then(redis => {
-    return redis.set(getStateKey(psid), payload, "EX", STATE_TTL_SECONDS).then(() => undefined);
+    return redis
+      .set(getStateKey(psid), payload, "EX", STATE_TTL_SECONDS)
+      .then(() => undefined);
   });
 }
 
-export function getOrCreateStoredState<T>(psid: string, createValue: () => T): MaybePromise<T> {
+export function getOrCreateStoredState<T>(
+  psid: string,
+  createValue: () => T
+): MaybePromise<T> {
   const current = readState<T>(psid);
 
   if (isPromiseLike(current)) {
@@ -117,7 +130,10 @@ export function getOrCreateStoredState<T>(psid: string, createValue: () => T): M
   return created;
 }
 
-export function updateStoredState<T>(psid: string, updater: (current: T | null) => T): MaybePromise<T> {
+export function updateStoredState<T>(
+  psid: string,
+  updater: (current: T | null) => T
+): MaybePromise<T> {
   const current = readState<T>(psid);
 
   if (isPromiseLike(current)) {
@@ -137,7 +153,9 @@ export function updateStoredState<T>(psid: string, updater: (current: T | null) 
   return next;
 }
 
-export function findInMemoryState<T>(predicate: (value: T) => boolean): T | null {
+export function findInMemoryState<T>(
+  predicate: (value: T) => boolean
+): T | null {
   if (isRedisStateStoreEnabled()) {
     return null;
   }
@@ -154,6 +172,69 @@ export function findInMemoryState<T>(predicate: (value: T) => boolean): T | null
 
 export function clearStateStore(): void {
   memoryState.clear();
+  memoryEphemeral.clear();
+}
+
+function clearExpiredMemoryEphemeral(now = Date.now()): void {
+  for (const [key, expiresAt] of memoryEphemeral.entries()) {
+    if (expiresAt <= now) {
+      memoryEphemeral.delete(key);
+    }
+  }
+}
+
+export async function hasEphemeralKey(key: string): Promise<boolean> {
+  if (!isRedisStateStoreEnabled()) {
+    clearExpiredMemoryEphemeral();
+    return memoryEphemeral.has(key);
+  }
+
+  const redis = await getRedisClient();
+  return (await redis.get(key)) !== null;
+}
+
+export async function setEphemeralKey(
+  key: string,
+  value: string,
+  ttlSeconds: number
+): Promise<void> {
+  if (!isRedisStateStoreEnabled()) {
+    memoryEphemeral.set(key, Date.now() + ttlSeconds * 1000);
+    return;
+  }
+
+  const redis = await getRedisClient();
+  await redis.set(key, value, "EX", ttlSeconds);
+}
+
+export async function setEphemeralKeyIfAbsent(
+  key: string,
+  value: string,
+  ttlSeconds: number
+): Promise<boolean> {
+  if (!isRedisStateStoreEnabled()) {
+    clearExpiredMemoryEphemeral();
+    if (memoryEphemeral.has(key)) {
+      return false;
+    }
+
+    memoryEphemeral.set(key, Date.now() + ttlSeconds * 1000);
+    return true;
+  }
+
+  const redis = await getRedisClient();
+  const response = await redis.set(key, value, "EX", ttlSeconds, "NX");
+  return response === "OK";
+}
+
+export async function deleteEphemeralKey(key: string): Promise<void> {
+  if (!isRedisStateStoreEnabled()) {
+    memoryEphemeral.delete(key);
+    return;
+  }
+
+  const redis = await getRedisClient();
+  await redis.del(key);
 }
 
 export { STATE_TTL_SECONDS, isPromiseLike };

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -36,6 +36,7 @@ import {
   stylePayloadToStyle,
   toMessengerReplies,
 } from "./webhookHelpers";
+import { runGuardedGeneration } from "./generationGuard";
 
 type HandlerDeps = {
   incomingEventDedupe: TtlDedupeSet;
@@ -44,10 +45,26 @@ type HandlerDeps = {
 };
 
 const GREETINGS = new Set(["hi", "hello", "hey", "yo", "hola"]);
-const SMALLTALK = new Set(["how are you", "how are you?", "sup", "what's up", "whats up", "thanks", "thank you"]);
+const SMALLTALK = new Set([
+  "how are you",
+  "how are you?",
+  "sup",
+  "what's up",
+  "whats up",
+  "thanks",
+  "thank you",
+]);
 
-export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privacyPolicyUrl }: HandlerDeps) {
-  async function sendStateQuickReplies(psid: string, state: ConversationState, text: string): Promise<void> {
+export function createWebhookHandlers({
+  incomingEventDedupe,
+  defaultLang,
+  privacyPolicyUrl,
+}: HandlerDeps) {
+  async function sendStateQuickReplies(
+    psid: string,
+    state: ConversationState,
+    text: string
+  ): Promise<void> {
     const replies = toMessengerReplies(state);
     if (replies.length === 0) {
       await sendText(psid, text);
@@ -61,7 +78,10 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     await sendStateQuickReplies(psid, "AWAITING_STYLE", t(lang, "stylePicker"));
   }
 
-  async function sendPhotoReceivedPrompt(psid: string, lang: Lang): Promise<void> {
+  async function sendPhotoReceivedPrompt(
+    psid: string,
+    lang: Lang
+  ): Promise<void> {
     await sendStylePicker(psid, lang);
   }
 
@@ -69,7 +89,11 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     await sendStateQuickReplies(psid, "IDLE", t(lang, "flowExplanation"));
   }
 
-  async function sendReferralPhotoPrompt(psid: string, style: Style, lang: Lang): Promise<void> {
+  async function sendReferralPhotoPrompt(
+    psid: string,
+    style: Style,
+    lang: Lang
+  ): Promise<void> {
     const styleLabel = STYLE_LABELS[style];
     const text =
       lang === "en"
@@ -78,89 +102,133 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     await sendText(psid, text);
   }
 
-  async function runStyleGeneration(psid: string, userId: string, style: Style, reqId: string, lang: Lang): Promise<void> {
-    const { mode, generator } = createImageGenerator();
+  async function runStyleGeneration(
+    psid: string,
+    userId: string,
+    style: Style,
+    reqId: string,
+    lang: Lang
+  ): Promise<void> {
+    const didRun = await runGuardedGeneration(psid, async () => {
+      const { mode, generator } = createImageGenerator();
 
-    await setFlowState(psid, "PROCESSING");
-    await sendText(psid, t(lang, "generatingPrompt", { styleLabel: STYLE_LABELS[style] }));
-
-    const state = await getOrCreateState(psid);
-    const lastImageUrl = state.lastPhotoUrl;
-
-    try {
-      const { imageUrl, proof, metrics } = await generator.generate({
-        style,
-        sourceImageUrl: lastImageUrl ?? undefined,
-        userKey: userId,
-        reqId,
-      });
-
-      console.info(JSON.stringify({
-        level: "info",
-        msg: "generation_summary",
-        reqId,
+      await setFlowState(psid, "PROCESSING");
+      await sendText(
         psid,
-        mode,
-        style,
-        ok: true,
-        fb_image_fetch_ms: metrics.fbImageFetchMs,
-        openai_ms: metrics.openAiMs,
-        upload_or_serve_ms: metrics.uploadOrServeMs,
-        total_ms: metrics.totalMs,
-      }));
+        t(lang, "generatingPrompt", { styleLabel: STYLE_LABELS[style] })
+      );
 
-      console.log("PROOF_SUMMARY", JSON.stringify({
-        reqId,
-        psidHash: anonymizePsid(psid).slice(0, 12),
-        style,
-        incomingLen: proof.incomingLen,
-        incomingSha256: proof.incomingSha256,
-        openaiInputLen: proof.openaiInputLen,
-        openaiInputSha256: proof.openaiInputSha256,
-        outputUrl: imageUrl,
-        totalMs: metrics.totalMs,
-        ok: true,
-      }));
+      const state = await getOrCreateState(psid);
+      const lastImageUrl = state.lastPhotoUrl;
 
-      await sendImage(psid, imageUrl);
-      await setLastGenerated(psid, imageUrl);
-      await sendStateQuickReplies(psid, "RESULT_READY", t(lang, "success"));
-    } catch (error) {
-      console.error("OPENAI_CALL_ERROR", { psid, error: error instanceof Error ? error.message : undefined });
+      try {
+        const { imageUrl, proof, metrics } = await generator.generate({
+          style,
+          sourceImageUrl: lastImageUrl ?? undefined,
+          userKey: userId,
+          reqId,
+        });
 
-      const errorClass = error instanceof Error ? error.constructor.name : "UnknownError";
-      getGenerationMetrics(error) ?? { totalMs: 0 };
+        console.info(
+          JSON.stringify({
+            level: "info",
+            msg: "generation_summary",
+            reqId,
+            psid,
+            mode,
+            style,
+            ok: true,
+            fb_image_fetch_ms: metrics.fbImageFetchMs,
+            openai_ms: metrics.openAiMs,
+            upload_or_serve_ms: metrics.uploadOrServeMs,
+            total_ms: metrics.totalMs,
+          })
+        );
 
-      console.log("PROOF_SUMMARY", JSON.stringify({
-        reqId,
-        psidHash: anonymizePsid(psid).slice(0, 12),
-        style,
-        ok: false,
-        errorCode: errorClass,
-      }));
+        console.log(
+          "PROOF_SUMMARY",
+          JSON.stringify({
+            reqId,
+            psidHash: anonymizePsid(psid).slice(0, 12),
+            style,
+            incomingLen: proof.incomingLen,
+            incomingSha256: proof.incomingSha256,
+            openaiInputLen: proof.openaiInputLen,
+            openaiInputSha256: proof.openaiInputSha256,
+            outputUrl: imageUrl,
+            totalMs: metrics.totalMs,
+            ok: true,
+          })
+        );
 
-      let failureText = t(lang, "generationGenericFailure");
-      if (error instanceof MissingInputImageError) {
-        await sendText(psid, t(lang, "missingInputImage"));
-        await setFlowState(psid, "AWAITING_PHOTO");
-        return;
-      } else if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
-        failureText = t(lang, "generationUnavailable");
-      } else if (error instanceof GenerationTimeoutError) {
-        failureText = t(lang, "generationTimeout");
+        await sendImage(psid, imageUrl);
+        await setLastGenerated(psid, imageUrl);
+        await sendStateQuickReplies(psid, "RESULT_READY", t(lang, "success"));
+      } catch (error) {
+        console.error("OPENAI_CALL_ERROR", {
+          psid,
+          error: error instanceof Error ? error.message : undefined,
+        });
+
+        const errorClass =
+          error instanceof Error ? error.constructor.name : "UnknownError";
+        getGenerationMetrics(error) ?? { totalMs: 0 };
+
+        console.log(
+          "PROOF_SUMMARY",
+          JSON.stringify({
+            reqId,
+            psidHash: anonymizePsid(psid).slice(0, 12),
+            style,
+            ok: false,
+            errorCode: errorClass,
+          })
+        );
+
+        let failureText = t(lang, "generationGenericFailure");
+        if (error instanceof MissingInputImageError) {
+          await sendText(psid, t(lang, "missingInputImage"));
+          await setFlowState(psid, "AWAITING_PHOTO");
+          return;
+        } else if (
+          error instanceof MissingOpenAiApiKeyError ||
+          error instanceof MissingAppBaseUrlError
+        ) {
+          failureText = t(lang, "generationUnavailable");
+        } else if (error instanceof GenerationTimeoutError) {
+          failureText = t(lang, "generationTimeout");
+        }
+
+        await sendText(psid, t(lang, "failure"));
+        await setFlowState(psid, "FAILURE");
+
+        await sendQuickReplies(psid, failureText, [
+          {
+            content_type: "text",
+            title: t(lang, "retryThisStyle"),
+            payload: `RETRY_STYLE_${style}`,
+          },
+          {
+            content_type: "text",
+            title: t(lang, "otherStyle"),
+            payload: "CHOOSE_STYLE",
+          },
+        ]);
       }
+    });
 
-      await sendText(psid, t(lang, "failure"));
-      await setFlowState(psid, "FAILURE");
-
-      await sendQuickReplies(psid, failureText, [
-        { content_type: "text", title: t(lang, "retryThisStyle"), payload: `RETRY_STYLE_${style}` },
-        { content_type: "text", title: t(lang, "otherStyle"), payload: "CHOOSE_STYLE" },
-      ]);
+    if (didRun === null) {
+      await sendText(psid, t(lang, "processingBlocked"));
     }
   }
 
-  async function handleStyleSelection(psid: string, userId: string, selectedStyle: Style, reqId: string, lang: Lang): Promise<void> {
+  async function handleStyleSelection(
+    psid: string,
+    userId: string,
+    selectedStyle: Style,
+    reqId: string,
+    lang: Lang
+  ): Promise<void> {
     const state = await getOrCreateState(psid);
     if (state.stage === "PROCESSING") {
       await sendText(psid, t(lang, "processingBlocked"));
@@ -177,7 +245,13 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     await runStyleGeneration(psid, userId, selectedStyle, reqId, lang);
   }
 
-  async function handlePayload(psid: string, userId: string, payload: string, reqId: string, lang: Lang): Promise<void> {
+  async function handlePayload(
+    psid: string,
+    userId: string,
+    payload: string,
+    reqId: string,
+    lang: Lang
+  ): Promise<void> {
     if (payload.startsWith("RETRY_STYLE_")) {
       const retryStyle = normalizeStyle(payload.slice("RETRY_STYLE_".length));
       if (retryStyle) {
@@ -226,7 +300,13 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     safeLog("unknown_payload", { user: toLogUser(userId) });
   }
 
-  async function handleMessage(psid: string, userId: string, event: FacebookWebhookEvent, reqId: string, lang: Lang): Promise<void> {
+  async function handleMessage(
+    psid: string,
+    userId: string,
+    event: FacebookWebhookEvent,
+    reqId: string,
+    lang: Lang
+  ): Promise<void> {
     const message = event.message;
     if (!message || message.is_echo) return;
 
@@ -236,7 +316,9 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
       return;
     }
 
-    const imageAttachment = message.attachments?.find(att => att.type === "image" && att.payload?.url);
+    const imageAttachment = message.attachments?.find(
+      att => att.type === "image" && att.payload?.url
+    );
     if (imageAttachment?.payload?.url) {
       console.log("PHOTO_RECEIVED", {
         psid,
@@ -316,7 +398,9 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     const dedupeKey = getEventDedupeKey(event, userId);
     if (dedupeKey && incomingEventDedupe.seen(dedupeKey)) return;
 
-    const referralStyle = parseReferralStyle(event.postback?.referral?.ref ?? event.referral?.ref);
+    const referralStyle = parseReferralStyle(
+      event.postback?.referral?.ref ?? event.referral?.ref
+    );
     if (referralStyle) {
       await clearPendingImageState(psid);
       await setPreselectedStyle(psid, referralStyle);
@@ -332,7 +416,9 @@ export function createWebhookHandlers({ incomingEventDedupe, defaultLang, privac
     await handleMessage(psid, userId, event, reqId, lang);
   }
 
-  async function processFacebookWebhookPayload(payload: unknown): Promise<void> {
+  async function processFacebookWebhookPayload(
+    payload: unknown
+  ): Promise<void> {
     const entries = (payload as any)?.entry || [];
     for (const entry of entries) {
       const events = entry?.messaging || [];

--- a/server/messengerApi.retry.test.ts
+++ b/server/messengerApi.retry.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendText } from "./_core/messengerApi";
+
+describe("messengerApi retries", () => {
+  const originalFetch = global.fetch;
+  const originalToken = process.env.FB_PAGE_ACCESS_TOKEN;
+  const originalMaxRetries = process.env.GRAPH_API_MAX_RETRIES;
+  const originalRetryBase = process.env.GRAPH_API_RETRY_BASE_MS;
+
+  beforeEach(() => {
+    process.env.FB_PAGE_ACCESS_TOKEN = "test-token";
+    process.env.GRAPH_API_MAX_RETRIES = "2";
+    process.env.GRAPH_API_RETRY_BASE_MS = "1";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+
+    if (originalToken === undefined) {
+      delete process.env.FB_PAGE_ACCESS_TOKEN;
+    } else {
+      process.env.FB_PAGE_ACCESS_TOKEN = originalToken;
+    }
+
+    if (originalMaxRetries === undefined) {
+      delete process.env.GRAPH_API_MAX_RETRIES;
+    } else {
+      process.env.GRAPH_API_MAX_RETRIES = originalMaxRetries;
+    }
+
+    if (originalRetryBase === undefined) {
+      delete process.env.GRAPH_API_RETRY_BASE_MS;
+    } else {
+      process.env.GRAPH_API_RETRY_BASE_MS = originalRetryBase;
+    }
+  });
+
+  it("retries 429 responses and succeeds", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after": "0" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("still limited", {
+          status: 429,
+          headers: { "retry-after": "0" },
+        })
+      )
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    global.fetch = fetchMock;
+
+    await sendText("psid-1", "hello");
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after max retries", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementation(
+        async () => new Response("rate limited", { status: 429 })
+      );
+
+    global.fetch = fetchMock;
+
+    await expect(sendText("psid-1", "hello")).rejects.toThrow(
+      "Messenger API error 429"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent webhook bursts from spawning unbounded image-generation jobs (e.g. 200 events → 200 concurrent generators) by providing lightweight backpressure without requiring a queue system like BullMQ. 
- Handle Meta Graph API `429`/`5xx` responses robustly by retrying with exponential backoff and honoring `Retry-After` so transient rate limits don’t immediately fail flows. 
- Provide a Redis-backed coordination primitive with an in-memory fallback to enable safe per-PSID locking and optional cooldown windows for deployments without Redis.

### Description
- Add a new `runGuardedGeneration` guard (`server/_core/generationGuard.ts`) that applies a process-level global concurrency cap and per-PSID in-flight locking + optional cooldown, configurable via `MESSENGER_MAX_IMAGE_JOBS`, `MESSENGER_PSID_COOLDOWN_MS`, and `MESSENGER_PSID_LOCK_TTL_MS`.
- Extend the state store (`server/_core/stateStore.ts`) with ephemeral key helpers (`hasEphemeralKey`, `setEphemeralKey`, `setEphemeralKeyIfAbsent`, `deleteEphemeralKey`) and an in-memory fallback for coordination when `REDIS_URL` is not set.
- Wire the guard into the webhook flow (`server/_core/webhookHandlers.ts`) so style generation runs are routed through `runGuardedGeneration` and callers get the existing "processing blocked" response when a generation is rejected by the guard.
- Add retrying send logic to the Messenger Graph API wrapper (`server/_core/messengerApi.ts`) that detects `429` and `5xx`, retries with exponential backoff, and respects `Retry-After`, configurable via `GRAPH_API_MAX_RETRIES` and `GRAPH_API_RETRY_BASE_MS`.
- Add a focused unit test for Graph API retry behavior (`server/messengerApi.retry.test.ts`) and document the new env knobs in `README.md`.

### Testing
- Ran `pnpm test server/messengerApi.retry.test.ts server/messengerWebhook.test.ts` and both test suites passed. 
- Ran `pnpm test server/messengerApi.retry.test.ts` locally and it passed. 
- Ran `pnpm check` which failed due to existing unrelated TypeScript issues in client code (`client/src/components/ui/resizable.tsx`), not touched by these server-side changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a740a525588325920349fca2721757)