### PR TITLE
Harden env-file hygiene and add secret rotation guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,12 @@ build/
 
 # Environment variables
 .env
+.env.*
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+!.env.example
 
 # IDE and editor files
 .vscode/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Related files:
 
 Legacy/app-specific environment variables also exist for SDK and data API integrations in `server/_core/env.ts`.
 
+### Secret hygiene
+
+- Never commit real `.env` files; only keep `.env.example` in git.
+- If a secret appears in GitHub code search (for example by searching for `.env` in this repo), rotate all exposed credentials immediately.
+
 ## Local dev
 
 ```bash


### PR DESCRIPTION
### Motivation

- Prevent accidental commits of environment files and ensure maintainers rotate credentials immediately if secrets are discovered via repository code search.

### Description

- Update `.gitignore` to ignore all `*.env` variants by adding `.env.*` while explicitly allowing the canonical `!.env.example`, and add a new `Secret hygiene` section to `README.md` instructing to never commit real `.env` files and to rotate exposed credentials immediately.

### Testing

- `git ls-files | rg '^\.env'` confirmed only `.env.example` is tracked; `rg -n '^!?\.env' .gitignore` confirmed the new ignore and allowlist lines are present; an automated `curl` check against GitHub code search returned `403` due to network/proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d8560b888325939efa4db68ad985)