### PR TITLE
Harden webhook security, add rate limiting, and validate inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Related files:
 
 - `REDIS_URL` (enable Redis state store; required in production)
 - `WEBHOOK_REPLAY_TTL_SECONDS` (override webhook replay-protection TTL, default `300`)
-- `HTTP_RATE_LIMIT_WINDOW_MS` (global HTTP rate-limit window, default `60000`)
+- `HTTP_RATE_LIMIT_WINDOW_MS` (global HTTP rate-limit window, default `60000`; Redis-backed when `REDIS_URL` is set)
 - `HTTP_RATE_LIMIT_MAX_REQUESTS` (max requests per IP per window, default `120`)
 - `DEFAULT_MESSENGER_LANG` (`nl`/`en` fallback behavior)
 - `PRIVACY_POLICY_URL` (link sent in privacy quick reply)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Related files:
 
 - `REDIS_URL` (enable Redis state store; required in production)
 - `WEBHOOK_REPLAY_TTL_SECONDS` (override webhook replay-protection TTL, default `300`)
+- `HTTP_RATE_LIMIT_WINDOW_MS` (global HTTP rate-limit window, default `60000`)
+- `HTTP_RATE_LIMIT_MAX_REQUESTS` (max requests per IP per window, default `120`)
 - `DEFAULT_MESSENGER_LANG` (`nl`/`en` fallback behavior)
 - `PRIVACY_POLICY_URL` (link sent in privacy quick reply)
 - `ADMIN_TOKEN` (protects `/debug/build`)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,6 +69,7 @@ AI endpoints must be protected against abuse.
 
 Implemented / planned protections:
 
+* global HTTP rate limiting
 * Redis-backed rate limiting
 * per user quota
 * daily usage limits

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,6 +91,7 @@ Typical protections include:
 * control character stripping
 * request size limits
 * JSON body validation
+* schema validation with Zod for webhook payloads and typed server inputs
 
 ## 5. Observability
 

--- a/server/_core/chat.ts
+++ b/server/_core/chat.ts
@@ -75,13 +75,42 @@ const tools = {
   }),
 };
 
-function isModelMessage(value: unknown): value is ModelMessage {
-  if (typeof value !== "object" || value === null) {
-    return false;
+const modelMessageSchema = z.object({
+  role: z.string().min(1),
+  content: z.unknown(),
+}).passthrough();
+
+const chatRequestSchema = z.object({
+  messages: z.array(modelMessageSchema),
+}).passthrough();
+
+function parseChatRequestBody(body: unknown): { messages: ModelMessage[] } {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("messages array is required");
   }
 
-  const candidate = value as { role?: unknown; content?: unknown };
-  return typeof candidate.role === "string" && "content" in candidate;
+  const parsed = chatRequestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    const missingMessages = parsed.error.issues.some(
+      issue =>
+        issue.path.length === 1 &&
+        issue.path[0] === "messages" &&
+        (issue.code === "invalid_type" || issue.code === "unrecognized_keys" || issue.code === "custom"),
+    );
+
+    const invalidMessages = parsed.error.issues.some(issue => issue.path[0] === "messages" && issue.path.length > 1);
+
+    if (missingMessages && !invalidMessages) {
+      throw new Error("messages array is required");
+    }
+
+    throw new Error("messages must be valid model messages");
+  }
+
+  return {
+    messages: parsed.data.messages as ModelMessage[],
+  };
 }
 
 function evaluateMathExpression(expression: string): number {
@@ -216,26 +245,17 @@ export function registerChatRoutes(app: Express) {
 
   app.post("/api/chat", (req, res) => {
     try {
-      const requestBody: unknown = req.body;
+      let messages: ModelMessage[];
+      try {
+        ({ messages } = parseChatRequestBody(req.body));
+      } catch (error) {
+        if (error instanceof Error) {
+          res.status(400).json({ error: error.message });
+          return;
+        }
 
-      if (typeof requestBody !== "object" || requestBody === null) {
-        res.status(400).json({ error: "messages array is required" });
-        return;
+        throw error;
       }
-
-      const messagesValue = (requestBody as { messages?: unknown }).messages;
-
-      if (!Array.isArray(messagesValue)) {
-        res.status(400).json({ error: "messages array is required" });
-        return;
-      }
-
-      if (!messagesValue.every(isModelMessage)) {
-        res.status(400).json({ error: "messages must be valid model messages" });
-        return;
-      }
-
-      const messages: ModelMessage[] = messagesValue;
 
       const result = streamText({
         model: openai.chat("gpt-4o"),
@@ -256,4 +276,4 @@ export function registerChatRoutes(app: Express) {
   });
 }
 
-export { tools };
+export { parseChatRequestBody, tools };

--- a/server/_core/httpRateLimit.ts
+++ b/server/_core/httpRateLimit.ts
@@ -3,13 +3,25 @@ import type express from "express";
 const DEFAULT_WINDOW_MS = 60_000;
 const DEFAULT_MAX_REQUESTS = 120;
 const DEFAULT_MAX_KEYS = 20_000;
+const RATE_LIMIT_KEY_PREFIX = "http-rate-limit:";
 
 type RateLimitBucket = {
   count: number;
   resetAt: number;
 };
 
+type RedisLike = {
+  ping(): Promise<string>;
+  incr(key: string): Promise<number>;
+  expire(key: string, seconds: number): Promise<number>;
+};
+
+type RedisModule = {
+  default: new (url: string) => RedisLike;
+};
+
 const buckets = new Map<string, RateLimitBucket>();
+let redisClientPromise: Promise<RedisLike> | null = null;
 
 function getWindowMs(): number {
   const parsed = Number(process.env.HTTP_RATE_LIMIT_WINDOW_MS);
@@ -27,6 +39,37 @@ function getMaxRequests(): number {
   }
 
   return DEFAULT_MAX_REQUESTS;
+}
+
+function getRedisUrl(): string | null {
+  return process.env.REDIS_URL?.trim() || null;
+}
+
+function isRedisHttpRateLimitEnabled(): boolean {
+  return Boolean(getRedisUrl());
+}
+
+async function importRedisModule(): Promise<RedisModule> {
+  const dynamicImport = Function("specifier", "return import(specifier)") as (specifier: string) => Promise<unknown>;
+  return (await dynamicImport("ioredis")) as RedisModule;
+}
+
+async function createRedisClient(): Promise<RedisLike> {
+  const redisUrl = getRedisUrl();
+  if (!redisUrl) {
+    throw new Error("REDIS_URL is not configured");
+  }
+
+  const { default: Redis } = await importRedisModule();
+  return new Redis(redisUrl);
+}
+
+async function getRedisClient(): Promise<RedisLike> {
+  if (!redisClientPromise) {
+    redisClientPromise = createRedisClient();
+  }
+
+  return redisClientPromise;
 }
 
 function getClientIp(req: express.Request): string {
@@ -69,10 +112,50 @@ export function createGlobalHttpRateLimiter(): express.RequestHandler {
       return;
     }
 
+    void applyRateLimit(req, res, next);
+  };
+}
+
+async function applyRateLimit(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): Promise<void> {
+  try {
     const now = Date.now();
     const windowMs = getWindowMs();
     const maxRequests = getMaxRequests();
     const key = `${req.method}:${getClientIp(req)}`;
+
+    if (isRedisHttpRateLimitEnabled()) {
+      const windowBucket = Math.floor(now / windowMs);
+      const redisKey = `${RATE_LIMIT_KEY_PREFIX}${key}:${windowBucket}`;
+      const redis = await getRedisClient();
+      const count = await redis.incr(redisKey);
+
+      if (count === 1) {
+        await redis.expire(redisKey, Math.max(1, Math.ceil(windowMs / 1000)));
+      }
+
+      const resetAt = (windowBucket + 1) * windowMs;
+      const remaining = Math.max(0, maxRequests - count);
+      res.setHeader("X-RateLimit-Limit", String(maxRequests));
+      res.setHeader("X-RateLimit-Remaining", String(remaining));
+      res.setHeader("X-RateLimit-Reset", String(Math.ceil(resetAt / 1000)));
+
+      if (count > maxRequests) {
+        const retryAfterSeconds = Math.max(1, Math.ceil((resetAt - now) / 1000));
+        res.setHeader("Retry-After", String(retryAfterSeconds));
+        res.status(429).json({
+          error: "Too Many Requests",
+          message: "Global HTTP rate limit exceeded. Please retry shortly.",
+        });
+        return;
+      }
+
+      next();
+      return;
+    }
 
     pruneBuckets(now);
 
@@ -104,11 +187,26 @@ export function createGlobalHttpRateLimiter(): express.RequestHandler {
     }
 
     next();
-  };
+  } catch (error) {
+    next(error);
+  }
 }
 
 export function resetGlobalHttpRateLimiter(): void {
   buckets.clear();
 }
 
-export { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS };
+export async function ensureHttpRateLimiterReady(): Promise<void> {
+  if (!isRedisHttpRateLimitEnabled()) {
+    return;
+  }
+
+  const redis = await getRedisClient();
+  await redis.ping();
+}
+
+export function resetHttpRateLimiterRedisClient(): void {
+  redisClientPromise = null;
+}
+
+export { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS, isRedisHttpRateLimitEnabled };

--- a/server/_core/httpRateLimit.ts
+++ b/server/_core/httpRateLimit.ts
@@ -1,0 +1,114 @@
+import type express from "express";
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX_REQUESTS = 120;
+const DEFAULT_MAX_KEYS = 20_000;
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+const buckets = new Map<string, RateLimitBucket>();
+
+function getWindowMs(): number {
+  const parsed = Number(process.env.HTTP_RATE_LIMIT_WINDOW_MS);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed);
+  }
+
+  return DEFAULT_WINDOW_MS;
+}
+
+function getMaxRequests(): number {
+  const parsed = Number(process.env.HTTP_RATE_LIMIT_MAX_REQUESTS);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.floor(parsed);
+  }
+
+  return DEFAULT_MAX_REQUESTS;
+}
+
+function getClientIp(req: express.Request): string {
+  const forwardedFor = req.headers["x-forwarded-for"];
+  if (typeof forwardedFor === "string") {
+    const firstIp = forwardedFor.split(",")[0]?.trim();
+    if (firstIp) {
+      return firstIp;
+    }
+  }
+
+  return req.ip || req.socket.remoteAddress || "unknown";
+}
+
+function shouldSkipRateLimit(req: express.Request): boolean {
+  return req.path === "/health" || req.path === "/healthz";
+}
+
+function pruneBuckets(now: number): void {
+  buckets.forEach((bucket, key) => {
+    if (bucket.resetAt <= now) {
+      buckets.delete(key);
+    }
+  });
+
+  while (buckets.size > DEFAULT_MAX_KEYS) {
+    const oldestKey = buckets.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+
+    buckets.delete(oldestKey);
+  }
+}
+
+export function createGlobalHttpRateLimiter(): express.RequestHandler {
+  return (req, res, next) => {
+    if (shouldSkipRateLimit(req)) {
+      next();
+      return;
+    }
+
+    const now = Date.now();
+    const windowMs = getWindowMs();
+    const maxRequests = getMaxRequests();
+    const key = `${req.method}:${getClientIp(req)}`;
+
+    pruneBuckets(now);
+
+    const current = buckets.get(key);
+    if (!current || current.resetAt <= now) {
+      buckets.set(key, {
+        count: 1,
+        resetAt: now + windowMs,
+      });
+      next();
+      return;
+    }
+
+    current.count += 1;
+
+    const remaining = Math.max(0, maxRequests - current.count);
+    res.setHeader("X-RateLimit-Limit", String(maxRequests));
+    res.setHeader("X-RateLimit-Remaining", String(remaining));
+    res.setHeader("X-RateLimit-Reset", String(Math.ceil(current.resetAt / 1000)));
+
+    if (current.count > maxRequests) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+      res.setHeader("Retry-After", String(retryAfterSeconds));
+      res.status(429).json({
+        error: "Too Many Requests",
+        message: "Global HTTP rate limit exceeded. Please retry shortly.",
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+export function resetGlobalHttpRateLimiter(): void {
+  buckets.clear();
+}
+
+export { DEFAULT_MAX_REQUESTS, DEFAULT_WINDOW_MS };

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -26,7 +26,11 @@ import {
   isRedisReplayProtectionEnabled,
 } from "./webhookReplayProtection";
 import { bodyParserErrorHandler } from "./bodyParserErrorHandler";
-import { createGlobalHttpRateLimiter } from "./httpRateLimit";
+import {
+  createGlobalHttpRateLimiter,
+  ensureHttpRateLimiterReady,
+  isRedisHttpRateLimitEnabled,
+} from "./httpRateLimit";
 
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
@@ -49,6 +53,7 @@ async function startServer() {
   assertProductionWebhookReplayProtectionConfig();
   await ensureStateStoreReady();
   await ensureWebhookReplayProtectionReady();
+  await ensureHttpRateLimiterReady();
 
   const app = express();
   const server = createServer(app);
@@ -126,6 +131,7 @@ async function startServer() {
         webhookReplayProtectionEnabled: true,
         webhookReplayProtectionRedisBacked: isRedisReplayProtectionEnabled(),
         globalHttpRateLimiterEnabled: true,
+        globalHttpRateLimiterRedisBacked: isRedisHttpRateLimitEnabled(),
       },
     });
   });

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -26,6 +26,7 @@ import {
   isRedisReplayProtectionEnabled,
 } from "./webhookReplayProtection";
 import { bodyParserErrorHandler } from "./bodyParserErrorHandler";
+import { createGlobalHttpRateLimiter } from "./httpRateLimit";
 
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
@@ -53,6 +54,7 @@ async function startServer() {
   const server = createServer(app);
 
   applySecurityHeaders(app);
+  app.use(createGlobalHttpRateLimiter());
 
   app.use(
     express.json({
@@ -123,6 +125,7 @@ async function startServer() {
         verifyTokenConfigured: Boolean(process.env.FB_VERIFY_TOKEN),
         webhookReplayProtectionEnabled: true,
         webhookReplayProtectionRedisBacked: isRedisReplayProtectionEnabled(),
+        globalHttpRateLimiterEnabled: true,
       },
     });
   });

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,8 +1,10 @@
 import express from "express";
+import { ZodError } from "zod";
 import { normalizeLang } from "./i18n";
 import { createWebhookHandlers } from "./webhookHandlers";
 import { resetWebhookReplayProtection } from "./webhookReplayProtection";
 import { detectAck, getGreetingResponse, summarizeWebhook } from "./webhookHelpers";
+import { facebookWebhookPayloadSchema } from "./webhookSchemas";
 
 const PRIVACY_POLICY_URL = process.env.PRIVACY_POLICY_URL?.trim() || "<link>";
 const DEFAULT_LANG = normalizeLang(process.env.DEFAULT_MESSENGER_LANG);
@@ -39,6 +41,23 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
   app.get("/webhook/facebook", handleVerification);
 
   app.post("/webhook/facebook", (req, res) => {
+    try {
+      facebookWebhookPayloadSchema.parse(req.body);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        res.status(400).json({
+          error: "Invalid webhook payload",
+          issues: error.issues.map(issue => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        });
+        return;
+      }
+
+      throw error;
+    }
+
     res.sendStatus(200);
     setImmediate(() => {
       void processFacebookWebhookPayload(req.body).catch(console.error);

--- a/server/_core/webhookSchemas.ts
+++ b/server/_core/webhookSchemas.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+const messengerAttachmentSchema = z.object({
+  type: z.string().optional(),
+  payload: z
+    .object({
+      url: z.string().url().optional(),
+    })
+    .passthrough()
+    .optional(),
+}).passthrough();
+
+const messengerMessageSchema = z.object({
+  mid: z.string().min(1).optional(),
+  is_echo: z.boolean().optional(),
+  text: z.string().optional(),
+  quick_reply: z.object({
+    payload: z.string().min(1).optional(),
+  }).passthrough().optional(),
+  attachments: z.array(messengerAttachmentSchema).optional(),
+}).passthrough();
+
+const messengerEventSchema = z.object({
+  sender: z.object({
+    id: z.string().min(1).optional(),
+    locale: z.string().optional(),
+  }).passthrough().optional(),
+  recipient: z.object({
+    id: z.string().min(1).optional(),
+  }).passthrough().optional(),
+  message: messengerMessageSchema.optional(),
+  postback: z.object({
+    title: z.string().optional(),
+    payload: z.string().optional(),
+    referral: z.object({
+      ref: z.string().optional(),
+    }).passthrough().optional(),
+  }).passthrough().optional(),
+  referral: z.object({
+    ref: z.string().optional(),
+  }).passthrough().optional(),
+  timestamp: z.number().finite().nonnegative().optional(),
+  delivery: z.unknown().optional(),
+  read: z.unknown().optional(),
+}).passthrough();
+
+export const facebookWebhookPayloadSchema = z.object({
+  object: z.string().min(1),
+  entry: z.array(
+    z.object({
+      id: z.string().optional(),
+      time: z.number().finite().optional(),
+      messaging: z.array(messengerEventSchema).default([]),
+    }).passthrough(),
+  ).default([]),
+}).passthrough();
+
+export type FacebookWebhookPayload = z.infer<typeof facebookWebhookPayloadSchema>;

--- a/server/chat.validation.test.ts
+++ b/server/chat.validation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { parseChatRequestBody } from "./_core/chat";
+
+describe("chat request validation", () => {
+  it("rejects payloads without a messages array", () => {
+    expect(() => parseChatRequestBody({})).toThrow("messages array is required");
+    expect(() => parseChatRequestBody(null)).toThrow("messages array is required");
+  });
+
+  it("rejects payloads with invalid model messages", () => {
+    expect(() =>
+      parseChatRequestBody({
+        messages: [{ content: "hello" }],
+      }),
+    ).toThrow("messages must be valid model messages");
+  });
+
+  it("accepts payloads with role and content", () => {
+    const parsed = parseChatRequestBody({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(parsed.messages).toEqual([{ role: "user", content: "hello" }]);
+  });
+});

--- a/server/httpRateLimit.test.ts
+++ b/server/httpRateLimit.test.ts
@@ -1,0 +1,107 @@
+import http from "node:http";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createGlobalHttpRateLimiter,
+  resetGlobalHttpRateLimiter,
+} from "./_core/httpRateLimit";
+
+const originalWindowMs = process.env.HTTP_RATE_LIMIT_WINDOW_MS;
+const originalMaxRequests = process.env.HTTP_RATE_LIMIT_MAX_REQUESTS;
+
+afterEach(() => {
+  resetGlobalHttpRateLimiter();
+
+  if (originalWindowMs === undefined) {
+    delete process.env.HTTP_RATE_LIMIT_WINDOW_MS;
+  } else {
+    process.env.HTTP_RATE_LIMIT_WINDOW_MS = originalWindowMs;
+  }
+
+  if (originalMaxRequests === undefined) {
+    delete process.env.HTTP_RATE_LIMIT_MAX_REQUESTS;
+  } else {
+    process.env.HTTP_RATE_LIMIT_MAX_REQUESTS = originalMaxRequests;
+  }
+});
+
+async function startServer() {
+  const app = express();
+  app.use(createGlobalHttpRateLimiter());
+  app.get("/limited", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+  app.get("/healthz", (_req, res) => {
+    res.status(200).send("ok");
+  });
+
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Unable to get test server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      }),
+  };
+}
+
+describe("global http rate limiter", () => {
+  it("returns 429 after exceeding the per-IP request budget", async () => {
+    process.env.HTTP_RATE_LIMIT_WINDOW_MS = "60000";
+    process.env.HTTP_RATE_LIMIT_MAX_REQUESTS = "2";
+
+    const server = await startServer();
+
+    try {
+      const first = await fetch(`${server.baseUrl}/limited`);
+      const second = await fetch(`${server.baseUrl}/limited`);
+      const third = await fetch(`${server.baseUrl}/limited`);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(third.status).toBe(429);
+      expect(third.headers.get("retry-after")).not.toBeNull();
+      expect(await third.json()).toEqual({
+        error: "Too Many Requests",
+        message: "Global HTTP rate limit exceeded. Please retry shortly.",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not rate limit health checks", async () => {
+    process.env.HTTP_RATE_LIMIT_WINDOW_MS = "60000";
+    process.env.HTTP_RATE_LIMIT_MAX_REQUESTS = "1";
+
+    const server = await startServer();
+
+    try {
+      const first = await fetch(`${server.baseUrl}/healthz`);
+      const second = await fetch(`${server.baseUrl}/healthz`);
+      const third = await fetch(`${server.baseUrl}/healthz`);
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(200);
+      expect(third.status).toBe(200);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/server/messengerWebhook.validation.test.ts
+++ b/server/messengerWebhook.validation.test.ts
@@ -1,0 +1,95 @@
+import { createHmac } from "node:crypto";
+import http from "node:http";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  captureMetaWebhookRawBody,
+  verifyMetaWebhookSignature,
+} from "./_core/webhookSignatureVerification";
+import { registerMetaWebhookRoutes } from "./_core/messengerWebhook";
+
+function buildSignature(body: string, secret: string): string {
+  const digest = createHmac("sha256", secret).update(body).digest("hex");
+  return `sha256=${digest}`;
+}
+
+async function postWebhook(body: string, signature: string): Promise<{ status: number; payload: string }> {
+  const app = express();
+
+  app.use(
+    express.json({
+      verify: captureMetaWebhookRawBody,
+    }),
+  );
+  app.use("/webhook/facebook", verifyMetaWebhookSignature);
+  registerMetaWebhookRoutes(app);
+
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Failed to bind test server");
+  }
+
+  const result = await new Promise<{ status: number; payload: string }>((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        path: "/webhook/facebook",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+          "x-hub-signature-256": signature,
+        },
+      },
+      response => {
+        let payload = "";
+        response.on("data", chunk => {
+          payload += chunk;
+        });
+        response.on("end", () => {
+          resolve({ status: response.statusCode ?? 0, payload });
+        });
+      },
+    );
+
+    request.on("error", reject);
+    request.write(body);
+    request.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return result;
+}
+
+describe("messenger webhook payload validation", () => {
+  afterEach(() => {
+    delete process.env.FB_APP_SECRET;
+  });
+
+  it("rejects schema-invalid signed webhook payloads", async () => {
+    const secret = "test-secret";
+    process.env.FB_APP_SECRET = secret;
+
+    const body = JSON.stringify({ object: "page", entry: [{ messaging: "invalid" }] });
+    const response = await postWebhook(body, buildSignature(body, secret));
+
+    expect(response.status).toBe(400);
+    expect(response.payload).toContain("Invalid webhook payload");
+  });
+});

--- a/server/webhookSignatureVerification.test.ts
+++ b/server/webhookSignatureVerification.test.ts
@@ -116,4 +116,5 @@ describe("Meta webhook signature verification", () => {
     expect(response.status).toBe(403);
     expect(response.payload).toContain("Signature verification failed");
   });
+
 });


### PR DESCRIPTION
## Summary

  - add `SECURITY.md`
  - add architecture diagrams to README and architecture docs
  - add webhook replay protection
  - require `REDIS_URL` in production for replay protection
  - add global HTTP rate limiting
  - make HTTP rate limiting Redis-backed
  - add Zod validation for Messenger webhook payloads
  - add Zod validation for `/api/chat`
  - clarify Fly.io Redis deployment requirements

  ## Validation

  - `pnpm check`
  - `pnpm test -- server/messengerWebhook.test.ts`
  - `pnpm test -- server/webhookReplayProtection.test.ts`
  - `pnpm test -- server/httpRateLimit.test.ts`
  - `pnpm test -- server/messengerWebhook.validation.test.ts`
  - `pnpm test -- server/chat.validation.test.ts`