### PR TITLE
 Production hardening for Messenger webhook reliability and API security

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Related files:
 - `OAUTH_SERVER_URL` (enables OAuth route initialization)
 - `LOG_LEVEL`, `DEBUG_STATE_DUMP` (diagnostics)
 - `X-Request-Id` (optional inbound tracing header; server echoes it or generates one)
+- `traceparent` (optional W3C Trace Context header; server continues the trace and emits a new server span)
 - `GENERATOR_MODE=mock` (forces mock generator)
 - `OPENAI_IMAGE_TIMEOUT_MS`, `FB_IMAGE_FETCH_TIMEOUT_MS` (per-request timeouts; OpenAI defaults to 30000ms and applies per retry attempt)
 - `OPENAI_IMAGE_MAX_RETRIES`, `OPENAI_IMAGE_RETRY_BASE_MS` (retry policy for OpenAI image edits on 408/429/5xx/transient network errors)
@@ -292,5 +293,6 @@ Operational notes:
 - Health check endpoint is `/healthz`.
 - `/metrics` exposes Prometheus-style request counters and latency histograms.
 - Each request carries an `X-Request-Id` header for simple request tracing across logs and downstream calls.
+- The server accepts and returns `traceparent` so it can plug into OpenTelemetry-compatible tracing later without changing route behavior.
 - `APP_BASE_URL` must be publicly reachable in OpenAI mode so Messenger can fetch generated images from `/generated/<id>.png`.
 - Keep `FB_APP_SECRET` configured to enforce webhook signature verification middleware.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ASCII version:
                     | - /webhook/facebook              |
                     | - /api/trpc                      |
                     | - /auth/github/*                 |
-                    | - /healthz, /__version          |
+                    | - /healthz, /__version, /metrics|
                     | - /generated/*, /demo/*         |
                     +----+---------------+-------------+
                          |               |
@@ -163,6 +163,7 @@ Related files:
 - `ADMIN_GITHUB_USERS` (comma-separated GitHub usernames allowed into `/admin`)
 - `OAUTH_SERVER_URL` (enables OAuth route initialization)
 - `LOG_LEVEL`, `DEBUG_STATE_DUMP` (diagnostics)
+- `X-Request-Id` (optional inbound tracing header; server echoes it or generates one)
 - `GENERATOR_MODE=mock` (forces mock generator)
 - `OPENAI_IMAGE_TIMEOUT_MS`, `FB_IMAGE_FETCH_TIMEOUT_MS` (per-request timeouts; OpenAI defaults to 30000ms and applies per retry attempt)
 - `OPENAI_IMAGE_MAX_RETRIES`, `OPENAI_IMAGE_RETRY_BASE_MS` (retry policy for OpenAI image edits on 408/429/5xx/transient network errors)
@@ -193,6 +194,7 @@ Useful checks while developing:
 ```bash
 curl http://localhost:8080/healthz
 curl http://localhost:8080/__version
+curl http://localhost:8080/metrics
 ```
 
 Production build locally:
@@ -288,5 +290,7 @@ Operational notes:
 - `NODE_ENV=production` and `PORT=8080` are expected in runtime.
 - `REDIS_URL` must be set in Fly secrets before deploy; production startup now fails without it.
 - Health check endpoint is `/healthz`.
+- `/metrics` exposes Prometheus-style request counters and latency histograms.
+- Each request carries an `X-Request-Id` header for simple request tracing across logs and downstream calls.
 - `APP_BASE_URL` must be publicly reachable in OpenAI mode so Messenger can fetch generated images from `/generated/<id>.png`.
 - Keep `FB_APP_SECRET` configured to enforce webhook signature verification middleware.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -110,6 +110,7 @@ Recommended metrics / alerts:
 * alert on elevated `429` rates
 * alert on latency regressions for `/webhook/facebook` and `/api/chat`
 * use `X-Request-Id` to correlate logs across retries and downstream calls
+* propagate W3C `traceparent` headers so the service is OpenTelemetry-ready for distributed tracing
 
 Important rule:
 Secrets must never appear in logs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,8 +100,16 @@ Production systems require monitoring and structured logging.
 Goals:
 
 * structured logs
+* Prometheus-style metrics
 * request tracing
 * alerting
+
+Recommended metrics / alerts:
+
+* alert on sustained `5xx` rate spikes
+* alert on elevated `429` rates
+* alert on latency regressions for `/webhook/facebook` and `/api/chat`
+* use `X-Request-Id` to correlate logs across retries and downstream calls
 
 Important rule:
 Secrets must never appear in logs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ Leaderbot runs as one Node.js process (Express + HTTP server):
 - Executes conversation flow + generation orchestration.
 - Serves static assets (`/demo`, `/generated`, web build output).
 - Exposes health/version/debug endpoints.
+- Exposes Prometheus-style metrics and request tracing hooks.
 - Optionally mounts OAuth and additional chat routes.
 
 Primary bootstrap is in `server/_core/index.ts`.

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -34,6 +34,7 @@ import {
 import {
   attachRequestTracing,
   getRequestId,
+  getTraceContext,
   recordHttpRequestMetric,
   registerMetricsRoute,
 } from "./observability";
@@ -86,6 +87,8 @@ async function startServer() {
       const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
       const log = {
         reqId: getRequestId(req),
+        traceId: getTraceContext(req)?.traceId,
+        spanId: getTraceContext(req)?.spanId,
         method: req.method,
         path: req.path,
         status: res.statusCode,
@@ -148,6 +151,7 @@ async function startServer() {
         globalHttpRateLimiterRedisBacked: isRedisHttpRateLimitEnabled(),
         metricsEndpointEnabled: true,
         requestTracingEnabled: true,
+        traceparentPropagationEnabled: true,
       },
     });
   });

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -31,6 +31,12 @@ import {
   ensureHttpRateLimiterReady,
   isRedisHttpRateLimitEnabled,
 } from "./httpRateLimit";
+import {
+  attachRequestTracing,
+  getRequestId,
+  recordHttpRequestMetric,
+  registerMetricsRoute,
+} from "./observability";
 
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
@@ -59,6 +65,7 @@ async function startServer() {
   const server = createServer(app);
 
   applySecurityHeaders(app);
+  app.use(attachRequestTracing());
   app.use(createGlobalHttpRateLimiter());
 
   app.use(
@@ -78,14 +85,20 @@ async function startServer() {
     res.on("finish", () => {
       const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
       const log = {
+        reqId: getRequestId(req),
         method: req.method,
         path: req.path,
         status: res.statusCode,
         ms: Number(durationMs.toFixed(1)),
       };
+      recordHttpRequestMetric(req.method, req.path, res.statusCode, durationMs);
 
       // Keep info logs compact: skip webhook and health checks unless debug logging is enabled.
-      const shouldLogAtInfo = !req.path.startsWith("/webhook") && req.path !== "/healthz" && req.path !== "/health";
+      const shouldLogAtInfo =
+        !req.path.startsWith("/webhook") &&
+        req.path !== "/healthz" &&
+        req.path !== "/health" &&
+        req.path !== "/metrics";
       if (isDebugLogEnabled() || shouldLogAtInfo) {
         console.log(JSON.stringify(log));
       }
@@ -104,6 +117,7 @@ async function startServer() {
   app.get("/__version", (_req, res) => {
     res.status(200).json(buildVersionPayload());
   });
+  registerMetricsRoute(app);
 
   app.get("/debug/build", (req, res) => {
     const adminToken = process.env.ADMIN_TOKEN;
@@ -132,6 +146,8 @@ async function startServer() {
         webhookReplayProtectionRedisBacked: isRedisReplayProtectionEnabled(),
         globalHttpRateLimiterEnabled: true,
         globalHttpRateLimiterRedisBacked: isRedisHttpRateLimitEnabled(),
+        metricsEndpointEnabled: true,
+        requestTracingEnabled: true,
       },
     });
   });

--- a/server/_core/observability.ts
+++ b/server/_core/observability.ts
@@ -1,8 +1,13 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 import type express from "express";
 
 type RequestWithId = express.Request & {
   requestId?: string;
+  traceContext?: {
+    traceId: string;
+    spanId: string;
+    traceparent: string;
+  };
 };
 
 type MetricKey = {
@@ -16,6 +21,7 @@ const durationSums = new Map<string, number>();
 const durationCounts = new Map<string, number>();
 const durationBuckets = new Map<string, number>();
 const latencyBucketBoundariesMs = [50, 100, 250, 500, 1000, 2500, 5000];
+const TRACEPARENT_REGEX = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/i;
 
 function escapeLabelValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
@@ -41,15 +47,29 @@ export function attachRequestTracing(): express.RequestHandler {
   return (req, res, next) => {
     const incomingRequestId = req.header("X-Request-Id")?.trim();
     const requestId = incomingRequestId || randomUUID();
+    const traceContext = parseOrCreateTraceContext(req.header("traceparent"));
 
     (req as RequestWithId).requestId = requestId;
+    (req as RequestWithId).traceContext = traceContext;
     res.setHeader("X-Request-Id", requestId);
+    res.setHeader("traceparent", traceContext.traceparent);
+    res.setHeader("X-Trace-Id", traceContext.traceId);
     next();
   };
 }
 
 export function getRequestId(req: express.Request): string | undefined {
   return (req as RequestWithId).requestId;
+}
+
+export function getTraceContext(req: express.Request):
+  | {
+      traceId: string;
+      spanId: string;
+      traceparent: string;
+    }
+  | undefined {
+  return (req as RequestWithId).traceContext;
 }
 
 export function recordHttpRequestMetric(method: string, path: string, statusCode: number, durationMs: number): void {
@@ -107,4 +127,17 @@ export function resetObservabilityMetrics(): void {
   durationSums.clear();
   durationCounts.clear();
   durationBuckets.clear();
+}
+
+function parseOrCreateTraceContext(traceparentHeader: string | undefined) {
+  const parsed = traceparentHeader ? TRACEPARENT_REGEX.exec(traceparentHeader.trim()) : null;
+  const traceId = parsed?.[1]?.toLowerCase() ?? randomBytes(16).toString("hex");
+  const spanId = randomBytes(8).toString("hex");
+  const traceFlags = parsed?.[3]?.toLowerCase() ?? "01";
+
+  return {
+    traceId,
+    spanId,
+    traceparent: `00-${traceId}-${spanId}-${traceFlags}`,
+  };
 }

--- a/server/_core/observability.ts
+++ b/server/_core/observability.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import type express from "express";
+
+type RequestWithId = express.Request & {
+  requestId?: string;
+};
+
+type MetricKey = {
+  method: string;
+  path: string;
+  status: string;
+};
+
+const requestCounters = new Map<string, number>();
+const durationSums = new Map<string, number>();
+const durationCounts = new Map<string, number>();
+const durationBuckets = new Map<string, number>();
+const latencyBucketBoundariesMs = [50, 100, 250, 500, 1000, 2500, 5000];
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function normalizePath(path: string): string {
+  return path || "/";
+}
+
+function metricLabelKey({ method, path, status }: MetricKey): string {
+  return `method="${escapeLabelValue(method)}",path="${escapeLabelValue(path)}",status="${escapeLabelValue(status)}"`;
+}
+
+function durationBucketKey(method: string, path: string, le: string): string {
+  return `method="${escapeLabelValue(method)}",path="${escapeLabelValue(path)}",le="${escapeLabelValue(le)}"`;
+}
+
+function incrementMetric(map: Map<string, number>, key: string, delta = 1): void {
+  map.set(key, (map.get(key) ?? 0) + delta);
+}
+
+export function attachRequestTracing(): express.RequestHandler {
+  return (req, res, next) => {
+    const incomingRequestId = req.header("X-Request-Id")?.trim();
+    const requestId = incomingRequestId || randomUUID();
+
+    (req as RequestWithId).requestId = requestId;
+    res.setHeader("X-Request-Id", requestId);
+    next();
+  };
+}
+
+export function getRequestId(req: express.Request): string | undefined {
+  return (req as RequestWithId).requestId;
+}
+
+export function recordHttpRequestMetric(method: string, path: string, statusCode: number, durationMs: number): void {
+  const normalizedPath = normalizePath(path);
+  const status = String(statusCode);
+  const labels = metricLabelKey({ method, path: normalizedPath, status });
+  incrementMetric(requestCounters, labels);
+  incrementMetric(durationSums, labels, durationMs / 1000);
+  incrementMetric(durationCounts, labels);
+
+  for (const bucketMs of latencyBucketBoundariesMs) {
+    if (durationMs <= bucketMs) {
+      incrementMetric(durationBuckets, durationBucketKey(method, normalizedPath, String(bucketMs / 1000)));
+    }
+  }
+  incrementMetric(durationBuckets, durationBucketKey(method, normalizedPath, "+Inf"));
+}
+
+export function renderPrometheusMetrics(): string {
+  const lines: string[] = [
+    "# HELP http_requests_total Total HTTP requests handled by the server",
+    "# TYPE http_requests_total counter",
+  ];
+
+  for (const [labels, value] of requestCounters.entries()) {
+    lines.push(`http_requests_total{${labels}} ${value}`);
+  }
+
+  lines.push("# HELP http_request_duration_seconds HTTP request duration in seconds");
+  lines.push("# TYPE http_request_duration_seconds histogram");
+
+  for (const [labels, value] of durationBuckets.entries()) {
+    lines.push(`http_request_duration_seconds_bucket{${labels}} ${value}`);
+  }
+
+  for (const [labels, value] of durationSums.entries()) {
+    lines.push(`http_request_duration_seconds_sum{${labels}} ${value.toFixed(6)}`);
+  }
+
+  for (const [labels, value] of durationCounts.entries()) {
+    lines.push(`http_request_duration_seconds_count{${labels}} ${value}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function registerMetricsRoute(app: express.Express): void {
+  app.get("/metrics", (_req, res) => {
+    res.type("text/plain; version=0.0.4").send(renderPrometheusMetrics());
+  });
+}
+
+export function resetObservabilityMetrics(): void {
+  requestCounters.clear();
+  durationSums.clear();
+  durationCounts.clear();
+  durationBuckets.clear();
+}

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -391,7 +391,10 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
     if (dedupeKey) {
       const claimed = await claimWebhookReplayKey(dedupeKey);
       if (!claimed) {
-        safeLog("webhook_replay_ignored", { user: toLogUser(userId) });
+        safeLog("webhook_replay_ignored", {
+          user: toLogUser(userId),
+          eventId: dedupeKey,
+        });
         return;
       }
     }

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -239,6 +239,7 @@ describe("messenger webhook dedupe", () => {
     expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
     expect(safeLogMock).toHaveBeenCalledWith("webhook_replay_ignored", {
       user: expect.any(String),
+      eventId: expect.stringContaining("entry:entry-123:"),
     });
   });
 

--- a/server/observability.test.ts
+++ b/server/observability.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   attachRequestTracing,
   getRequestId,
+  getTraceContext,
   recordHttpRequestMetric,
   registerMetricsRoute,
   resetObservabilityMetrics,
@@ -56,7 +57,11 @@ describe("observability", () => {
   it("propagates incoming X-Request-Id headers", async () => {
     const server = await startServer(app => {
       app.get("/trace", (req, res) => {
-        res.status(200).json({ reqId: getRequestId(req) ?? null });
+        res.status(200).json({
+          reqId: getRequestId(req) ?? null,
+          traceId: getTraceContext(req)?.traceId ?? null,
+          spanId: getTraceContext(req)?.spanId ?? null,
+        });
       });
     });
 
@@ -69,7 +74,45 @@ describe("observability", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("x-request-id")).toBe("req-test-123");
-      expect(await response.json()).toEqual({ reqId: "req-test-123" });
+      expect(response.headers.get("x-trace-id")).toMatch(/^[0-9a-f]{32}$/);
+      expect(response.headers.get("traceparent")).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/);
+      expect(await response.json()).toEqual({
+        reqId: "req-test-123",
+        traceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+        spanId: expect.stringMatching(/^[0-9a-f]{16}$/),
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("continues an incoming traceparent and creates a fresh server span", async () => {
+    const incomingTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    const server = await startServer(app => {
+      app.get("/traceparent", (req, res) => {
+        res.status(200).json({
+          traceparent: getTraceContext(req)?.traceparent ?? null,
+          traceId: getTraceContext(req)?.traceId ?? null,
+          spanId: getTraceContext(req)?.spanId ?? null,
+        });
+      });
+    });
+
+    try {
+      const response = await fetch(`${server.baseUrl}/traceparent`, {
+        headers: {
+          traceparent: incomingTraceparent,
+        },
+      });
+      const payload = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(payload.traceId).toBe("4bf92f3577b34da6a3ce929d0e0e4736");
+      expect(payload.spanId).toMatch(/^[0-9a-f]{16}$/);
+      expect(payload.spanId).not.toBe("00f067aa0ba902b7");
+      expect(response.headers.get("traceparent")).toMatch(
+        /^00-4bf92f3577b34da6a3ce929d0e0e4736-[0-9a-f]{16}-01$/,
+      );
     } finally {
       await server.close();
     }

--- a/server/observability.test.ts
+++ b/server/observability.test.ts
@@ -1,0 +1,99 @@
+import http from "node:http";
+import express from "express";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  attachRequestTracing,
+  getRequestId,
+  recordHttpRequestMetric,
+  registerMetricsRoute,
+  resetObservabilityMetrics,
+} from "./_core/observability";
+
+afterEach(() => {
+  resetObservabilityMetrics();
+});
+
+async function startServer(configure?: (app: express.Express) => void) {
+  const app = express();
+  app.use(attachRequestTracing());
+  app.use((req, res, next) => {
+    const start = process.hrtime.bigint();
+    res.on("finish", () => {
+      const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+      recordHttpRequestMetric(req.method, req.path, res.statusCode, durationMs);
+    });
+    next();
+  });
+  configure?.(app);
+  registerMetricsRoute(app);
+
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Unable to get test server address");
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+  };
+}
+
+describe("observability", () => {
+  it("propagates incoming X-Request-Id headers", async () => {
+    const server = await startServer(app => {
+      app.get("/trace", (req, res) => {
+        res.status(200).json({ reqId: getRequestId(req) ?? null });
+      });
+    });
+
+    try {
+      const response = await fetch(`${server.baseUrl}/trace`, {
+        headers: {
+          "X-Request-Id": "req-test-123",
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-request-id")).toBe("req-test-123");
+      expect(await response.json()).toEqual({ reqId: "req-test-123" });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("exposes Prometheus-style HTTP metrics", async () => {
+    const server = await startServer(app => {
+      app.get("/ok", (_req, res) => {
+        res.status(200).json({ ok: true });
+      });
+    });
+
+    try {
+      await fetch(`${server.baseUrl}/ok`);
+      const response = await fetch(`${server.baseUrl}/metrics`);
+      const body = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/plain");
+      expect(body).toContain("http_requests_total");
+      expect(body).toContain('path="/ok"');
+      expect(body).toContain("http_request_duration_seconds_bucket");
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

  This PR hardens the production path of the Messenger bot and related API
  routes, with a focus on replay protection, rate limiting, input
  validation, and observability.

  ## Included

  - add `SECURITY.md`
  - add architecture diagrams to `README.md` and `docs/architecture.md`
  - add Messenger webhook replay protection
  - ignore duplicate webhook retries before AI generation and Messenger
  replies
  - require `REDIS_URL` in production for replay protection
  - add duplicate webhook logging with `eventId`
  - add global HTTP rate limiting
  - make HTTP rate limiting Redis-backed
  - add Zod schema validation for Messenger webhook payloads
  - add Zod schema validation for `/api/chat`
  - add Prometheus-style `/metrics` endpoint
  - add request ID and trace context propagation
  - clarify Fly.io production setup for Redis

  ## Why

  These changes reduce duplicate processing, lower unnecessary OpenAI and
  Messenger API usage, tighten request validation, and improve production
  visibility when retries or abuse happen.

  ## Validation

  - `pnpm check`
  - Vitest coverage for webhook replay protection
  - Vitest coverage for rate limiting
  - Vitest coverage for webhook validation
  - Vitest coverage for `/api/chat` validation
  - Vitest coverage for observability and tracing