### PR TITLE
Production hardening for Messenger webhook reliability, response-window   safety, and API security

### DIFF
--- a/server/_core/messengerApi.ts
+++ b/server/_core/messengerApi.ts
@@ -1,3 +1,5 @@
+import { hasOpenMessengerResponseWindow } from "./messengerState";
+
 const GRAPH_API_VERSION = "v21.0";
 
 type QuickReply = {
@@ -62,6 +64,11 @@ async function sendMessage(
   psid: string,
   message: Record<string, unknown>
 ): Promise<void> {
+  const withinResponseWindow = await Promise.resolve(hasOpenMessengerResponseWindow(psid));
+  if (!withinResponseWindow) {
+    throw new Error("Messenger response window is closed");
+  }
+
   const maxRetries = parsePositiveInt("GRAPH_API_MAX_RETRIES", 3);
   const retryBaseMs = parsePositiveInt("GRAPH_API_RETRY_BASE_MS", 300);
 
@@ -72,6 +79,7 @@ async function sendMessage(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
+        messaging_type: "RESPONSE",
         recipient: { id: psid },
         message,
       }),

--- a/server/_core/messengerApi.ts
+++ b/server/_core/messengerApi.ts
@@ -66,7 +66,8 @@ async function sendMessage(
 ): Promise<void> {
   const withinResponseWindow = await Promise.resolve(hasOpenMessengerResponseWindow(psid));
   if (!withinResponseWindow) {
-    throw new Error("Messenger response window is closed");
+    safeLog("messenger_send_skipped", { reason: "response_window_closed" });
+    return;
   }
 
   const maxRetries = parsePositiveInt("GRAPH_API_MAX_RETRIES", 3);

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -38,6 +38,7 @@ export type MessengerUserState = {
   userKey: string;
   stage: MessengerFlowState;
   state: MessengerFlowState;
+  lastUserMessageAt?: number;
   lastPhotoUrl: string | null;
   lastPhoto: string | null;
   selectedStyle: string | null;
@@ -99,6 +100,7 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
     userKey: getUserKey(psid),
     stage: "IDLE",
     state: "IDLE",
+    lastUserMessageAt: undefined,
     lastPhotoUrl: null,
     lastPhoto: null,
     selectedStyle: null,
@@ -137,6 +139,7 @@ function normalizeState(psid: string, value: PartialState | null | undefined): M
     hasSeenIntro: value?.hasSeenIntro ?? fallback.hasSeenIntro,
     stage,
     state: stage,
+    lastUserMessageAt: value?.lastUserMessageAt ?? fallback.lastUserMessageAt,
     lastPhotoUrl: lastPhoto,
     lastPhoto,
     selectedStyle,
@@ -335,6 +338,20 @@ export function setPreferredLang(psid: string, lang: Lang, now = Date.now()): Ma
       preferredLang: lang,
     },
     now,
+  );
+
+  if (isPromiseLike(result)) {
+    return result.then(() => undefined);
+  }
+}
+
+export function setLastUserMessageAt(psid: string, timestamp = Date.now()): MaybePromise<void> {
+  const result = patchState(
+    psid,
+    {
+      lastUserMessageAt: timestamp,
+    },
+    timestamp,
   );
 
   if (isPromiseLike(result)) {

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -237,12 +237,41 @@ export function getDayKey(now = Date.now()): string {
   return new Date(now).toISOString().slice(0, 10);
 }
 
+export function getMessengerResponseWindowMs(): number {
+  const configured = Number(process.env.MESSENGER_RESPONSE_WINDOW_MS);
+  if (Number.isFinite(configured) && configured >= 0) {
+    return Math.floor(configured);
+  }
+
+  return 24 * 60 * 60 * 1000;
+}
+
 export function getState(psid: string): MaybePromise<MessengerUserState | null> {
   if (!isRedisStateStoreEnabled()) {
     return getStateFromMemory(psid);
   }
 
   return getStateFromRedis(psid);
+}
+
+export function hasOpenMessengerResponseWindow(psid: string, now = Date.now()): MaybePromise<boolean> {
+  const state = getState(psid);
+
+  if (isPromiseLike(state)) {
+    return state.then(current => {
+      if (!current?.lastUserMessageAt) {
+        return false;
+      }
+
+      return now - current.lastUserMessageAt <= getMessengerResponseWindowMs();
+    });
+  }
+
+  if (!state?.lastUserMessageAt) {
+    return false;
+  }
+
+  return now - state.lastUserMessageAt <= getMessengerResponseWindowMs();
 }
 
 export function getOrCreateState(psid: string): MaybePromise<MessengerUserState> {

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -13,6 +13,7 @@ import {
   setChosenStyle,
   setFlowState,
   setLastGenerated,
+  setLastUserMessageAt,
   setPendingImage,
   setPreselectedStyle,
   setPreferredLang,
@@ -301,6 +302,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
   ): Promise<void> {
     const message = event.message;
     if (!message || message.is_echo) return;
+    await setLastUserMessageAt(psid, event.timestamp ?? Date.now());
 
     const quickPayload = message.quick_reply?.payload;
     if (quickPayload) {

--- a/server/messengerApi.retry.test.ts
+++ b/server/messengerApi.retry.test.ts
@@ -1,16 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sendText } from "./_core/messengerApi";
+import { resetStateStore, setLastUserMessageAt } from "./_core/messengerState";
 
 describe("messengerApi retries", () => {
   const originalFetch = global.fetch;
   const originalToken = process.env.FB_PAGE_ACCESS_TOKEN;
   const originalMaxRetries = process.env.GRAPH_API_MAX_RETRIES;
   const originalRetryBase = process.env.GRAPH_API_RETRY_BASE_MS;
+  const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 
   beforeEach(() => {
     process.env.FB_PAGE_ACCESS_TOKEN = "test-token";
     process.env.GRAPH_API_MAX_RETRIES = "2";
     process.env.GRAPH_API_RETRY_BASE_MS = "1";
+    process.env.PRIVACY_PEPPER = "ci-test-pepper";
+    resetStateStore();
+    setLastUserMessageAt("psid-1", Date.now());
   });
 
   afterEach(() => {
@@ -32,6 +37,12 @@ describe("messengerApi retries", () => {
       delete process.env.GRAPH_API_RETRY_BASE_MS;
     } else {
       process.env.GRAPH_API_RETRY_BASE_MS = originalRetryBase;
+    }
+
+    if (originalPrivacyPepper === undefined) {
+      delete process.env.PRIVACY_PEPPER;
+    } else {
+      process.env.PRIVACY_PEPPER = originalPrivacyPepper;
     }
   });
 
@@ -57,6 +68,13 @@ describe("messengerApi retries", () => {
     await sendText("psid-1", "hello");
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/me/messages");
+    expect(JSON.parse(String(request.body))).toMatchObject({
+      messaging_type: "RESPONSE",
+      recipient: { id: "psid-1" },
+      message: { text: "hello" },
+    });
   });
 
   it("throws after max retries", async () => {
@@ -72,5 +90,18 @@ describe("messengerApi retries", () => {
       "Messenger API error 429"
     );
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects outbound messages when the 24h Messenger response window is closed", async () => {
+    const now = Date.now();
+    setLastUserMessageAt("psid-1", now - 24 * 60 * 60 * 1000 - 1);
+
+    const fetchMock = vi.fn<typeof fetch>();
+    global.fetch = fetchMock;
+
+    await expect(sendText("psid-1", "hello")).rejects.toThrow(
+      "Messenger response window is closed"
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/server/messengerApi.retry.test.ts
+++ b/server/messengerApi.retry.test.ts
@@ -92,16 +92,14 @@ describe("messengerApi retries", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
-  it("rejects outbound messages when the 24h Messenger response window is closed", async () => {
+  it("skips outbound messages when the 24h Messenger response window is closed", async () => {
     const now = Date.now();
     setLastUserMessageAt("psid-1", now - 24 * 60 * 60 * 1000 - 1);
 
     const fetchMock = vi.fn<typeof fetch>();
     global.fetch = fetchMock;
 
-    await expect(sendText("psid-1", "hello")).rejects.toThrow(
-      "Messenger response window is closed"
-    );
+    await expect(sendText("psid-1", "hello")).resolves.toBeUndefined();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -243,6 +243,64 @@ describe("messenger webhook dedupe", () => {
     });
   });
 
+  it("updates lastUserMessageAt only for inbound user messages", async () => {
+    const psid = "window-user";
+    const userId = anonymizePsid(psid);
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              timestamp: 1730000000000,
+              read: { watermark: 1730000000000 },
+            },
+            {
+              sender: { id: psid },
+              timestamp: 1730000000001,
+              delivery: { mids: ["mid-delivery"] },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(getState(userId)?.lastUserMessageAt).toBeUndefined();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              timestamp: 1730000000123,
+              message: { mid: "mid-window-1", text: "Hi" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(getState(userId)?.lastUserMessageAt).toBe(1730000000123);
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              timestamp: 1730000000999,
+              message: { mid: "mid-window-echo", is_echo: true, text: "echo" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(getState(userId)?.lastUserMessageAt).toBe(1730000000123);
+  });
+
 
 
   it("returns local demo images for all canonical styles in MOCK_MODE", async () => {


### PR DESCRIPTION
## Summary

  This PR hardens the production path of the Messenger bot and related API
  routes, with a focus on replay protection, rate limiting, input
  validation, observability, and Messenger platform safety rules.

  ## Included

  - add `SECURITY.md`
  - add architecture diagrams to `README.md` and `docs/architecture.md`
  - add Messenger webhook replay protection
  - ignore duplicate webhook retries before AI generation and Messenger
  replies
  - log ignored duplicate webhook events with `eventId`
  - require `REDIS_URL` in production for replay protection
  - add global HTTP rate limiting
  - make HTTP rate limiting Redis-backed
  - add Zod schema validation for Messenger webhook payloads
  - add Zod schema validation for `/api/chat`
  - add Prometheus-style `/metrics` endpoint
  - add request ID and trace context propagation
  - track `lastUserMessageAt` only for real inbound user messages
  - exclude `read`, `delivery`, and `echo` events from Messenger response-
  window refresh
  - enforce Messenger outbound sends against the 24-hour response window
  - send Messenger messages with `messaging_type: RESPONSE`
  - safely skip sends when the Messenger response window is closed
  - clarify Fly.io production setup for Redis

  ## Why

  These changes reduce duplicate processing, lower unnecessary OpenAI and
  Messenger API usage, tighten request validation, improve production
  visibility, and make Messenger send behavior safer and more compliant with
  platform rules.

  ## Validation

  - `pnpm check`
  - Vitest coverage for webhook replay protection
  - Vitest coverage for rate limiting
  - Vitest coverage for webhook validation
  - Vitest coverage for `/api/chat` validation
  - Vitest coverage for observability and tracing
  - Vitest coverage for Messenger response-window enforcement