### PR TITLE
SSRF mitigation: allowlist source image hosts (fail-closed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,8 @@ PRIVACY_PEPPER=replace_with_long_random_secret
 
 # Optional: absolute base URL used for mock Messenger image attachments
 APP_BASE_URL=http://localhost:3000
+# Required for inbound source-image fetching. If unset, source-image fetches fail closed.
+# Conservative starting point for Meta-hosted attachments; tighten to exact observed hosts in production logs if possible.
+SOURCE_IMAGE_ALLOWED_HOSTS=fbcdn.net,fbsbx.com
 # Optional: set to false to disable mock image generation
 MOCK_MODE=true

--- a/.git-commit-message.txt
+++ b/.git-commit-message.txt
@@ -1,1 +1,0 @@
-SSRF mitigation: allowlist source image hosts (fail-closed)

--- a/.git-commit-message.txt
+++ b/.git-commit-message.txt
@@ -1,0 +1,1 @@
+SSRF mitigation: allowlist source image hosts (fail-closed)

--- a/README.md
+++ b/README.md
@@ -149,11 +149,13 @@ Related files:
 - `REDIS_URL` (required in production for webhook replay protection)
 - `APP_BASE_URL` (required in OpenAI mode for public generated image URLs)
 - `OPENAI_API_KEY` (required in OpenAI mode)
+- `SOURCE_IMAGE_ALLOWED_HOSTS` (required for inbound source-image fetching; if unset, source-image fetches are blocked)
 
 ### Common optional
 
 - `REDIS_URL` (enable Redis state store; required in production)
 - `WEBHOOK_REPLAY_TTL_SECONDS` (override webhook replay-protection TTL, default `300`)
+- `SOURCE_IMAGE_ALLOWED_HOSTS` (comma-separated host allowlist for inbound source images, for example `fbcdn.net,fbsbx.com`; fail-closed when unset)
 - `HTTP_RATE_LIMIT_WINDOW_MS` (global HTTP rate-limit window, default `60000`; Redis-backed when `REDIS_URL` is set)
 - `HTTP_RATE_LIMIT_MAX_REQUESTS` (max requests per IP per window, default `120`)
 - `DEFAULT_MESSENGER_LANG` (`nl`/`en` fallback behavior)
@@ -296,3 +298,4 @@ Operational notes:
 - The server accepts and returns `traceparent` so it can plug into OpenTelemetry-compatible tracing later without changing route behavior.
 - `APP_BASE_URL` must be publicly reachable in OpenAI mode so Messenger can fetch generated images from `/generated/<id>.png`.
 - Keep `FB_APP_SECRET` configured to enforce webhook signature verification middleware.
+- Set `SOURCE_IMAGE_ALLOWED_HOSTS` in production. Source-image fetches fail closed when it is unset. `fbcdn.net,fbsbx.com` is a conservative Meta-focused starting point, but the preferred setup is to narrow this to the exact attachment hostnames you observe in your Messenger webhook traffic.

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import net from "node:net";
 import os from "node:os";
 import { STYLE_TO_DEMO_FILE, type Style } from "./messengerStyles";
 import fs from "fs/promises";
@@ -26,6 +27,7 @@ export class GenerationTimeoutError extends Error {}
 export class OpenAiGenerationError extends Error {}
 export class MissingAppBaseUrlError extends Error {}
 export class MissingInputImageError extends Error {}
+export class InvalidSourceImageUrlError extends Error {}
 
 export type GenerationMetrics = {
   fbImageFetchMs?: number;
@@ -217,6 +219,91 @@ function isTransientNetworkError(error: unknown): boolean {
   return error.name === "AbortError" || error instanceof TypeError;
 }
 
+function parseAllowedHostsFromEnv(): string[] {
+  return (process.env.SOURCE_IMAGE_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map(s => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map(x => Number(x));
+  if (parts.length !== 4 || parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true;
+  }
+
+  const [a, b] = parts;
+
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+
+  return false;
+}
+
+function hostnameMatchesAllowedHost(hostname: string, allowedHost: string): boolean {
+  return hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+
+  const ipType = net.isIP(h);
+  if (ipType === 4) return isPrivateIPv4(h);
+  if (ipType === 6) {
+    if (h === "::1") return true;
+    if (h.startsWith("fc") || h.startsWith("fd")) return true;
+    if (h.startsWith("fe8") || h.startsWith("fe9") || h.startsWith("fea") || h.startsWith("feb")) return true;
+    return true;
+  }
+
+  return false;
+}
+
+export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: string): URL {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(sourceImageUrl);
+  } catch {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "invalid_url" });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  if (parsedUrl.protocol !== "https:") {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "invalid_scheme", protocol: parsedUrl.protocol });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "embedded_credentials" });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  if (isBlockedHostname(hostname)) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "blocked_hostname", hostname });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  const allowedHosts = parseAllowedHostsFromEnv();
+  if (allowedHosts.length === 0) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "allowlist_not_configured" });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  if (!allowedHosts.some(allowedHost => hostnameMatchesAllowedHost(hostname, allowedHost))) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "host_not_allowed", hostname });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  return parsedUrl;
+}
+
 async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit | undefined, timeoutMs: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => {
@@ -226,6 +313,7 @@ async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit | un
   try {
     return await fetch(input, {
       ...init,
+      redirect: init?.redirect ?? "follow",
       signal: controller.signal,
     });
   } finally {
@@ -262,6 +350,7 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
   incomingSha256: string;
   fbImageFetchMs: number;
 }> {
+  const validatedSourceImageUrl = validateSourceImageUrlOrThrow(sourceImageUrl, reqId);
   const timeoutMs = getInboundImageTimeoutMs();
   let totalFetchMs = 0;
 
@@ -269,7 +358,7 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
     const attemptStartedAt = Date.now();
 
     try {
-      const response = await fetchWithTimeout(sourceImageUrl, undefined, timeoutMs);
+      const response = await fetchWithTimeout(validatedSourceImageUrl, { redirect: "error" }, timeoutMs);
       const contentType = response.headers.get("content-type") ?? "application/octet-stream";
 
       if (!response.ok) {
@@ -318,7 +407,7 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
         fbImageFetchMs: totalFetchMs,
       };
     } catch (error) {
-      if (error instanceof MissingInputImageError) {
+      if (error instanceof MissingInputImageError || error instanceof InvalidSourceImageUrlError) {
         throw error;
       }
 

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -57,6 +57,14 @@ const SMALLTALK = new Set([
 ]);
 
 export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: HandlerDeps) {
+  function getAttachmentHostname(url: string): string | null {
+    try {
+      return new URL(url).hostname || null;
+    } catch {
+      return null;
+    }
+  }
+
   function logIncomingMessage(
     psid: string,
     userId: string,
@@ -426,10 +434,16 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
       att => att.type === "image" && att.payload?.url
     );
     if (imageAttachment?.payload?.url) {
-      console.log("PHOTO_RECEIVED", {
-        psid,
-        hasAttachments: !!message.attachments,
-      });
+      console.log(
+        JSON.stringify({
+          level: "debug",
+          msg: "photo_received",
+          reqId,
+          psidHash: anonymizePsid(psid).slice(0, 12),
+          hasAttachments: !!message.attachments,
+          attachmentHostname: getAttachmentHostname(imageAttachment.payload.url),
+        })
+      );
 
       const state = await getOrCreateState(psid);
       logUserState(psid, userId, state, reqId, "image_received");

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
-import { OpenAiImageGenerator } from "./_core/imageService";
+import { InvalidSourceImageUrlError, OpenAiImageGenerator } from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
 
 const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
+
+function toUrlString(url: string | URL): string {
+  return typeof url === "string" ? url : url.toString();
+}
 
 describe("OpenAi image-to-image proof", () => {
   afterEach(() => {
@@ -14,18 +18,20 @@ describe("OpenAi image-to-image proof", () => {
     delete process.env.OPENAI_IMAGE_MAX_RETRIES;
     delete process.env.OPENAI_IMAGE_RETRY_BASE_MS;
     delete process.env.OPENAI_IMAGE_TIMEOUT_MS;
+    delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
   });
 
   it("sends the original image bytes in OpenAI edits request", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const fixture = Buffer.alloc(7000, 9);
     const fixtureHash = sha256(fixture);
-    const generatedImageBytes = GENERATED_IMAGE_BASE64;
 
-    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        expect(init?.redirect).toBe("error");
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -33,7 +39,7 @@ describe("OpenAi image-to-image proof", () => {
         } as Response;
       }
 
-      expect(url).toBe("https://api.openai.com/v1/images/edits");
+      expect(toUrlString(url)).toBe("https://api.openai.com/v1/images/edits");
       const formData = init?.body as FormData;
       expect(formData).toBeInstanceOf(FormData);
       const imageBlob = formData.get("image");
@@ -45,7 +51,7 @@ describe("OpenAi image-to-image proof", () => {
 
       return {
         ok: true,
-        json: async () => ({ data: [{ b64_json: generatedImageBytes }] }),
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
       } as Response;
     });
 
@@ -69,10 +75,11 @@ describe("OpenAi image-to-image proof", () => {
   it("hard-fails before OpenAI call when input image is too small", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const tinyFixture = Buffer.alloc(1024, 1);
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -104,15 +111,15 @@ describe("OpenAi image-to-image proof", () => {
   it("retries the source image download once on transient network errors", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const fixture = Buffer.alloc(7000, 9);
-    const generatedImageBytes = GENERATED_IMAGE_BASE64;
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg" && fetchMock.mock.calls.length === 1) {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg" && fetchMock.mock.calls.length === 1) {
         throw new TypeError("temporary network failure");
       }
 
-      if (url === "https://img.example/source.jpg") {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -122,7 +129,7 @@ describe("OpenAi image-to-image proof", () => {
 
       return {
         ok: true,
-        json: async () => ({ data: [{ b64_json: generatedImageBytes }] }),
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
       } as Response;
     });
 
@@ -141,17 +148,95 @@ describe("OpenAi image-to-image proof", () => {
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("rejects localhost and private IP source image URLs before fetch", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://127.0.0.1/source.jpg",
+        userKey: "user-1",
+        reqId: "req-private-ip",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("enforces SOURCE_IMAGE_ALLOWED_HOSTS when configured", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fixture = Buffer.alloc(7000, 9);
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://cdn.img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    const result = await generator.generate({
+      style: "disco",
+      sourceImageUrl: "https://cdn.img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-allowlist",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+  });
+
+  it("blocks hosts outside SOURCE_IMAGE_ALLOWED_HOSTS before fetch", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://other.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-deny-allowlist",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("removes leftover generated webp files", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const generatedDir = path.resolve(process.cwd(), "public", "generated");
     await fs.mkdir(generatedDir, { recursive: true });
     await fs.writeFile(path.join(generatedDir, "old-artifact.webp"), Buffer.from("webp"));
 
     const fixture = Buffer.alloc(7000, 9);
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -183,11 +268,12 @@ describe("OpenAi image-to-image proof", () => {
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     process.env.OPENAI_IMAGE_MAX_RETRIES = "1";
     process.env.OPENAI_IMAGE_RETRY_BASE_MS = "1";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const fixture = Buffer.alloc(7000, 9);
     let openAiCallCount = 0;
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -225,17 +311,76 @@ describe("OpenAi image-to-image proof", () => {
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
+  it("fails closed when SOURCE_IMAGE_ALLOWED_HOSTS is not set", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-no-allowlist",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks redirects for source image fetches", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        expect(init?.redirect).toBe("error");
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => Buffer.alloc(7000, 9),
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "disco",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-redirect-error",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.any(URL),
+      expect.objectContaining({ redirect: "error" }),
+    );
+  });
+
   it("retries OpenAI edits request after timeout aborts", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     process.env.OPENAI_IMAGE_MAX_RETRIES = "1";
     process.env.OPENAI_IMAGE_RETRY_BASE_MS = "1";
     process.env.OPENAI_IMAGE_TIMEOUT_MS = "5";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
 
     const fixture = Buffer.alloc(7000, 9);
     let openAiCallCount = 0;
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -270,6 +415,4 @@ describe("OpenAi image-to-image proof", () => {
     expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
-
-
 });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -25,6 +25,10 @@ import { anonymizePsid, getState, resetStateStore, setFlowState } from "./_core/
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 
+function toUrlString(url: string | URL): string {
+  return typeof url === "string" ? url : url.toString();
+}
+
 beforeAll(() => {
   process.env.PRIVACY_PEPPER = TEST_PEPPER;
 });
@@ -121,6 +125,7 @@ describe("messenger webhook dedupe", () => {
   beforeEach(() => {
     process.env.MOCK_MODE = "true";
     process.env.GENERATOR_MODE = "mock";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
     delete process.env.OPENAI_API_KEY;
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
@@ -241,6 +246,55 @@ describe("messenger webhook dedupe", () => {
       user: expect.any(String),
       eventId: expect.stringContaining("entry:entry-123:"),
     });
+  });
+
+  it("logs only the attachment hostname for inbound photo messages", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    try {
+      const expectedPsidHash = anonymizePsid("psid-host-log").slice(0, 12);
+      await processFacebookWebhookPayload({
+        entry: [
+          {
+            messaging: [
+              {
+                sender: { id: "psid-host-log" },
+                message: {
+                  mid: "mid-host-log",
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: {
+                        url: "https://lookaside.fbsbx.com/path/to/file.jpg?token=secret",
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
+      const photoReceivedCall = consoleLogSpy.mock.calls
+        .map(args => args[0])
+        .find(
+          value =>
+            typeof value === "string" &&
+            value.includes("\"msg\":\"photo_received\"")
+        );
+
+      expect(photoReceivedCall).toBeDefined();
+      expect(JSON.parse(photoReceivedCall as string)).toEqual({
+        level: "debug",
+        msg: "photo_received",
+        reqId: expect.any(String),
+        psidHash: expectedPsidHash,
+        hasAttachments: true,
+        attachmentHostname: "lookaside.fbsbx.com",
+      });
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
   });
 
   it("updates lastUserMessageAt only for inbound user messages", async () => {
@@ -487,8 +541,8 @@ describe("messenger webhook dedupe", () => {
 
     const sourceImage = Buffer.alloc(6000, 7);
     const generatedImageBytes = Buffer.from("fake-png").toString("base64");
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -617,8 +671,8 @@ describe("messenger webhook dedupe", () => {
     const timeoutError = new Error("aborted");
     timeoutError.name = "AbortError";
     const sourceImage = Buffer.alloc(6000, 7);
-    const fetchMock = vi.fn(async (url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -668,8 +722,8 @@ describe("messenger webhook dedupe", () => {
 
     let resolveFetch: ((value: { ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }) => void) | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
-    const fetchMock = vi.fn((url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn((url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return Promise.resolve({
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -757,8 +811,8 @@ describe("messenger webhook dedupe", () => {
 
     let resolveFetch: ((value: { ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }) => void) | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
-    const fetchMock = vi.fn((url: string) => {
-      if (url === "https://img.example/source.jpg") {
+    const fetchMock = vi.fn((url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
         return Promise.resolve({
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -845,6 +899,7 @@ describe("messenger webhook dedupe", () => {
 
 describe("messenger greeting behavior", () => {
   beforeEach(() => {
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();


### PR DESCRIPTION
Mitigates a potential Server-Side Request Forgery (SSRF) risk when downloading inbound source images.

Adds a configurable hostname allowlist (`SOURCE_IMAGE_ALLOWED_HOSTS`) for external image fetches. Only hosts matching the allowlist (e.g. `fbcdn.net`, `fbsbx.com`) are permitted. Requests to other hosts are rejected before any network request is made.

The system now fails closed: if `SOURCE_IMAGE_ALLOWED_HOSTS` is not configured, source image fetches are blocked by default.

Documentation and `.env.example` have been updated to reflect the new configuration and recommended Meta CDN host defaults.
