### PR TITLE
Harden SSRF handling, tighten webhook validation, and add Vite rate limiter

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -313,7 +313,7 @@ async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit | un
   try {
     return await fetch(input, {
       ...init,
-      redirect: init?.redirect ?? "follow",
+      redirect: init?.redirect ?? "error",
       signal: controller.signal,
     });
   } finally {

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -45,13 +45,7 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
       facebookWebhookPayloadSchema.parse(req.body);
     } catch (error) {
       if (error instanceof ZodError) {
-        res.status(400).json({
-          error: "Invalid webhook payload",
-          issues: error.issues.map(issue => ({
-            path: issue.path.join("."),
-            message: issue.message,
-          })),
-        });
+        res.status(400).json({ error: "Invalid webhook payload" });
         return;
       }
 

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -3,10 +3,12 @@ import fs from "fs";
 import { type Server } from "http";
 import { nanoid } from "nanoid";
 import path from "path";
+import { createGlobalHttpRateLimiter } from "./httpRateLimit";
 
 type ViteCreateServer = (typeof import("vite"))["createServer"];
 
 export async function setupVite(app: Express, server: Server, createViteServer: ViteCreateServer) {
+  app.use(createGlobalHttpRateLimiter());
 
   const serverOptions = {
     middlewareMode: true,


### PR DESCRIPTION
### Motivation
- Prevent server-side request forgery by failing closed on redirected image fetches and ensuring all downloads run through the existing URL validator. 
- Reduce reflected-content exposure from webhook validation errors to mitigate reflected XSS risk. 
- Ensure development Vite middleware is covered by the global HTTP rate limiter to address missing rate limiting.

### Description
- Default `fetch` redirect handling to `"error"` in `fetchWithTimeout` so inbound image fetches fail closed unless `redirect` is explicitly overridden in the call (file: `server/_core/imageService.ts`).
- Simplify the webhook validation error response to `json({ error: "Invalid webhook payload" })` so Zod validation issue details are not echoed back to the client (file: `server/_core/messengerWebhook.ts`).
- Register the global HTTP rate limiter middleware in the Vite dev setup by invoking `app.use(createGlobalHttpRateLimiter())` inside `setupVite` (file: `server/_core/vite.ts`).

### Testing
- Ran unit tests with `pnpm vitest run server/imageService.proof.test.ts server/messengerWebhook.validation.test.ts server/httpRateLimit.test.ts` and all test files passed (`3 passed`, `14 tests` passed).
- Ran typecheck with `pnpm check` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8485be5fc8325833203eb95ecbca9)