### PR TITLE
test: assert OpenAI image edits fetch sets redirect to 'error'

### DIFF
--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -40,6 +40,7 @@ describe("OpenAi image-to-image proof", () => {
       }
 
       expect(toUrlString(url)).toBe("https://api.openai.com/v1/images/edits");
+      expect(init?.redirect).toBe("error");
       const formData = init?.body as FormData;
       expect(formData).toBeInstanceOf(FormData);
       const imageBlob = formData.get("image");


### PR DESCRIPTION
### Motivation
- Add a regression assertion to ensure the OpenAI image edits `fetch` call is sent with `redirect: "error"` to prevent accidental redirects during generation.

### Description
- Added `expect(init?.redirect).toBe("error")` to the `https://api.openai.com/v1/images/edits` branch in `server/imageService.proof.test.ts` to assert the fetch init uses `redirect: "error"`.

### Testing
- Ran `pnpm -s vitest run server/imageService.proof.test.ts`, but the run failed during transform due to a duplicate symbol `validateSourceImageUrlOrThrow` declared in `server/_core/imageService.ts`, so the new test did not execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84c1e1b0883258e349e72c10b0d02)