### PR TITLE
Add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
### Motivation
- Add explicit least-privilege GitHub Actions permissions to address the security alert about missing workflow permissions by granting `contents: read` and `security-events: write` for the CI workflow.

### Description
- Inserted a top-level `permissions` section under `name: CI` in `.github/workflows/ci.yml` with `contents: read` and `security-events: write`.

### Testing
- Verified the change with `sed -n '1,40p' .github/workflows/ci.yml`, checked the repo state with `git status --short`, committed the change with `git commit` (succeeded), and attempted `git push` which failed because no remote push destination is configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84e1de57c8325989b7bd10c5fd84a)