### PR TITLE
Remove duplicate URL validator in imageService; preserve redirect='error' and fix tests

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -321,50 +321,6 @@ async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit | un
   }
 }
 
-/**
- * Validate a source image URL coming from user-controlled state to prevent SSRF.
- * Throws MissingInputImageError if the URL is invalid or targets disallowed hosts.
- */
-function validateSourceImageUrlOrThrow(sourceImageUrl: string): URL {
-  let url: URL;
-  try {
-    url = new URL(sourceImageUrl);
-  } catch {
-    throw new MissingInputImageError("Invalid sourceImageUrl");
-  }
-
-  // Only allow http(s) schemes; block others such as file:, data:, etc.
-  if (url.protocol !== "https:" && url.protocol !== "http:") {
-    throw new MissingInputImageError("Invalid sourceImageUrl protocol");
-  }
-
-  const hostname = url.hostname.toLowerCase();
-
-  // Block obvious local/loopback hostnames.
-  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") {
-    throw new MissingInputImageError("Disallowed sourceImageUrl host");
-  }
-
-  // Best-effort check against private IPv4 ranges.
-  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (ipv4Match) {
-    const [_, aStr, bStr] = ipv4Match;
-    const a = Number(aStr);
-    const b = Number(bStr);
-
-    if (
-      a === 10 || // 10.0.0.0/8
-      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-      (a === 192 && b === 168) || // 192.168.0.0/16
-      (a === 169 && b === 254) // 169.254.0.0/16 (link-local)
-    ) {
-      throw new MissingInputImageError("Disallowed sourceImageUrl host");
-    }
-  }
-
-  return url;
-}
-
 class MockImageGenerator implements ImageGenerator {
   generate(input: { style: Style; sourceImageUrl?: string; userKey: string; reqId: string }): Promise<{
     imageUrl: string;


### PR DESCRIPTION
### Motivation
- Tests were failing due to a TypeScript transform error caused by a duplicated `validateSourceImageUrlOrThrow` declaration in `server/_core/imageService.ts` which blocked test suites from running. 
- The change keeps the hardened fetch behavior (`redirect: "error"`) to maintain SSRF mitigation when downloading source images. 

### Description
- Removed the duplicate `validateSourceImageUrlOrThrow` implementation from `server/_core/imageService.ts` so the symbol is declared only once. 
- Kept the existing `fetchWithTimeout` implementation that sets `redirect: init?.redirect ?? "error"` to block redirects by default. 
- Preserved the SSRF hostname and allowlist validation logic and general behavior of the image service and mock generator. 

### Testing
- Ran the full test suite with `pnpm test` and all test files passed. 
- The previous TypeScript transform error is resolved and the test run completed successfully (`106 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84e0451188325a4e90e38f08f54c9)