### PR TITLE
security: harden webhook verification and add audit-focused triage

### DIFF
--- a/docs/SECURITY_TRIAGE.md
+++ b/docs/SECURITY_TRIAGE.md
@@ -1,0 +1,75 @@
+# Security Triage (Audit-Focused)
+
+Date: 2026-03-04
+Scope: `leaderbot-fb-image-gen`
+
+## Data sources used
+
+Because this environment cannot query GitHub APIs from this container, I performed triage using:
+
+1. In-repo security-related docs and workflow config.
+2. Current code paths for webhook verification and signature validation.
+3. Local test execution focused on the webhook auth path.
+
+### GitHub alert/PR inspection status
+
+- `gh` CLI is not installed in this environment.
+- Direct GitHub API requests returned `403 Forbidden` from this environment.
+- npm audit endpoint also returned `403 Forbidden` from this environment.
+
+As a result, **current live GitHub Security / CodeQL / Dependabot / PR alert state could not be fetched from GitHub** in this run.
+
+## Triage groups
+
+## 1) Must fix before audit
+
+### Item: Webhook GET verification accepted unsafe edge cases when token config is missing/malformed
+- **Title:** Fail-closed verification for `GET /webhook` and `GET /webhook/facebook`
+- **Severity:** Medium
+- **Affected file:** `server/_core/messengerWebhook.ts`
+- **Real risk now?:** Yes (prior behavior could compare against undefined/malformed values and did not require a string challenge).
+- **Recommended action:** Require all of the following before returning challenge:
+  - `FB_VERIFY_TOKEN` configured and non-empty
+  - `hub.mode === subscribe`
+  - `hub.verify_token` is a string and exactly matches configured token
+  - `hub.challenge` is a string
+- **Status in this branch:** Fixed with minimal route guard hardening and dedicated tests.
+
+## 2) Can document as mitigated
+
+### Item: Meta webhook signature authenticity checks
+- **Title:** Webhook POST signature verification middleware present
+- **Severity:** High (if absent)
+- **Affected file:** `server/_core/webhookSignatureVerification.ts` (wired in `server/_core/index.ts`)
+- **Real risk now?:** No, for configured environments with `FB_APP_SECRET`; route is protected by signature middleware.
+- **Recommended action:** Keep as-is; ensure `FB_APP_SECRET` is always set in production and covered by startup checks/policy.
+
+### Item: Dependabot configuration for npm ecosystem
+- **Title:** Dependabot weekly npm updates configured
+- **Severity:** Informational
+- **Affected file:** `.github/dependabot.yml`
+- **Real risk now?:** Low by itself; this is a mitigation process, not a runtime control.
+- **Recommended action:** Keep schedule; during audit, export open Dependabot alerts from GitHub UI/API from a network that can reach GitHub.
+
+## 3) False positive / stale / superseded
+
+### Item: Historical review notes claiming missing signature verification
+- **Title:** `CODE_REVIEW.md` finding “Missing Meta webhook signature verification”
+- **Severity:** High (historical claim)
+- **Affected file:** `CODE_REVIEW.md`
+- **Real risk now?:** No, superseded by current code that applies `verifyMetaWebhookSignature` middleware.
+- **Recommended action:** Treat as stale historical finding; do not patch based on this note.
+- **Superseded by:** Current implementation in `server/_core/index.ts` + `server/_core/webhookSignatureVerification.ts`.
+
+## Open security PRs status
+
+Unable to determine from GitHub in this environment (API access blocked), so no open security PR was classified as stale/active from live metadata.
+
+## Changes made (smallest safe fix)
+
+1. Hardened webhook verification handler to fail closed unless token/challenge are valid strings and configured token is non-empty.
+2. Added targeted tests for missing token config, missing challenge, and valid challenge flow.
+
+## Validation commands run
+
+- `pnpm exec vitest run server/messengerWebhook.verification.test.ts`

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -37,12 +37,19 @@ export function registerMetaWebhookRoutes(app: express.Express): void {
     const mode = req.query["hub.mode"];
     const verifyToken = req.query["hub.verify_token"];
     const challenge = req.query["hub.challenge"];
-    const configuredToken = process.env.FB_VERIFY_TOKEN;
+    const configuredToken = process.env.FB_VERIFY_TOKEN?.trim();
 
-    if (mode === "subscribe" && verifyToken === configuredToken) {
-      return res.status(200).type("text/plain").send(challenge);
+    if (
+      !configuredToken ||
+      mode !== "subscribe" ||
+      typeof verifyToken !== "string" ||
+      verifyToken !== configuredToken ||
+      typeof challenge !== "string"
+    ) {
+      return res.sendStatus(403);
     }
-    return res.sendStatus(403);
+
+    return res.status(200).type("text/plain").send(challenge);
   };
 
   app.use("/webhook", webhookLimiter);

--- a/server/messengerWebhook.verification.test.ts
+++ b/server/messengerWebhook.verification.test.ts
@@ -1,0 +1,93 @@
+import http from "node:http";
+import express from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("express-rate-limit", () => ({
+  default: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+async function getWebhook(path: string): Promise<{ status: number; payload: string }> {
+  const { registerMetaWebhookRoutes } = await import("./_core/messengerWebhook");
+  const app = express();
+  registerMetaWebhookRoutes(app);
+
+  const server = http.createServer(app);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Failed to bind test server");
+  }
+
+  const response = await new Promise<{ status: number; payload: string }>((resolve, reject) => {
+    const request = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: address.port,
+        path,
+        method: "GET",
+      },
+      res => {
+        let payload = "";
+        res.on("data", chunk => {
+          payload += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, payload });
+        });
+      },
+    );
+
+    request.on("error", reject);
+    request.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+
+  return response;
+}
+
+describe("messenger webhook verification route", () => {
+  afterEach(() => {
+    delete process.env.FB_VERIFY_TOKEN;
+  });
+
+  it("fails closed when FB_VERIFY_TOKEN is missing", async () => {
+    const response = await getWebhook(
+      "/webhook/facebook?hub.mode=subscribe&hub.verify_token=test&hub.challenge=abc",
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects requests with a missing challenge", async () => {
+    process.env.FB_VERIFY_TOKEN = "test-token";
+
+    const response = await getWebhook(
+      "/webhook/facebook?hub.mode=subscribe&hub.verify_token=test-token",
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns challenge for valid token", async () => {
+    process.env.FB_VERIFY_TOKEN = "test-token";
+
+    const response = await getWebhook(
+      "/webhook/facebook?hub.mode=subscribe&hub.verify_token=test-token&hub.challenge=abc123",
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload).toBe("abc123");
+  });
+});


### PR DESCRIPTION
### Motivation

- Close an unsafe edge case in webhook verification where a missing or blank `FB_VERIFY_TOKEN` could allow accidental acceptance of verification requests. 
- Provide an audit-focused triage summary documenting repository findings and the environment limitations encountered when trying to fetch live GitHub/npm alerts. 
- Make the smallest non-speculative change to ensure webhook subscription verification fails closed and is test-covered.

### Description

- Hardened the `GET /webhook` and `GET /webhook/facebook` verification handler in `server/_core/messengerWebhook.ts` to require a non-empty trimmed `FB_VERIFY_TOKEN`, `hub.mode === "subscribe"`, a string `hub.verify_token` that matches the configured token, and a string `hub.challenge` before returning the challenge. 
- Added `server/messengerWebhook.verification.test.ts` with three focused tests covering missing token config, missing challenge, and valid token+challenge flows, and mocked `express-rate-limit` to make the unit tests hermetic. 
- Added `docs/SECURITY_TRIAGE.md` documenting the fast audit triage, grouping of findings, and the fact that live GitHub Security/CodeQL/Dependabot and `pnpm audit` endpoints were inaccessible from this environment (403), with recommended next steps.

### Testing

- Ran `pnpm exec vitest run server/messengerWebhook.verification.test.ts`, which passed all tests (3 tests passed). 
- Attempted `pnpm audit --json` and `pnpm install --frozen-lockfile` but both were blocked by the registry/GitHub in this environment and returned `403 Forbidden`, so dependency-audit and full install validation could not be completed here. 
- No speculative code fixes were made beyond the small verification hardening and test additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86bcc51ec832583f84ee25f60c384)