### PR TITLE
Harden source image URL validation and block redirects; use manual fetch redirect handling

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -247,6 +247,10 @@ function hostnameMatchesAllowedHost(hostname: string, allowedHost: string): bool
   return hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
 }
 
+function isRedirectStatus(status: number): boolean {
+  return status >= 300 && status <= 399 && status !== 304;
+}
+
 function isBlockedHostname(hostname: string): boolean {
   const h = hostname.toLowerCase();
 
@@ -276,12 +280,17 @@ export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: st
 
   const hostname = parsedUrl.hostname.toLowerCase();
   if (parsedUrl.protocol !== "https:") {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "invalid_scheme", protocol: parsedUrl.protocol });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_https", protocol: parsedUrl.protocol });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (parsedUrl.username || parsedUrl.password) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "embedded_credentials" });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "credentials_in_url" });
+    throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+  }
+
+  if (parsedUrl.port && parsedUrl.port !== "443") {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_standard_port", port: parsedUrl.port });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
@@ -313,7 +322,7 @@ async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit | un
   try {
     return await fetch(input, {
       ...init,
-      redirect: init?.redirect ?? "error",
+      redirect: init?.redirect ?? "manual",
       signal: controller.signal,
     });
   } finally {
@@ -358,8 +367,18 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
     const attemptStartedAt = Date.now();
 
     try {
-      const response = await fetchWithTimeout(validatedSourceImageUrl, { redirect: "error" }, timeoutMs);
+      const response = await fetchWithTimeout(validatedSourceImageUrl, { redirect: "manual" }, timeoutMs);
       const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+
+      if (isRedirectStatus(response.status)) {
+        console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+          reqId,
+          reason: "redirect_not_allowed",
+          status: response.status,
+          location: response.headers.get("location") ?? undefined,
+        });
+        throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
+      }
 
       if (!response.ok) {
         totalFetchMs += Date.now() - attemptStartedAt;

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -31,7 +31,7 @@ describe("OpenAi image-to-image proof", () => {
 
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
       if (toUrlString(url) === "https://img.example/source.jpg") {
-        expect(init?.redirect).toBe("error");
+        expect(init?.redirect).toBe("manual");
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -225,6 +225,48 @@ describe("OpenAi image-to-image proof", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects source image URLs with embedded credentials before fetch", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://user:pass@img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-embedded-credentials",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects source image URLs on non-443 ports before fetch", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example:8443/source.jpg",
+        userKey: "user-1",
+        reqId: "req-non-standard-port",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("removes leftover generated webp files", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
@@ -338,9 +380,10 @@ describe("OpenAi image-to-image proof", () => {
 
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
       if (toUrlString(url) === "https://img.example/source.jpg") {
-        expect(init?.redirect).toBe("error");
+        expect(init?.redirect).toBe("manual");
         return {
-          ok: true,
+          ok: false,
+          status: 302,
           headers: new Headers({ "content-type": "image/jpeg" }),
           arrayBuffer: async () => Buffer.alloc(7000, 9),
         } as Response;
@@ -355,17 +398,19 @@ describe("OpenAi image-to-image proof", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    await generator.generate({
-      style: "disco",
-      sourceImageUrl: "https://img.example/source.jpg",
-      userKey: "user-1",
-      reqId: "req-redirect-error",
-    });
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-redirect-error",
+      }),
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       expect.any(URL),
-      expect.objectContaining({ redirect: "error" }),
+      expect.objectContaining({ redirect: "manual" }),
     );
   });
 


### PR DESCRIPTION
### Motivation

- Tighten security around fetching externally provided source images to prevent SSRF and unexpected redirects or credentials leakage.

### Description

- Added `isRedirectStatus` and treat 3xx (except 304) responses as disallowed, logging `redirect_not_allowed` with status and location.
- Changed fetch redirect handling default to `manual` in `fetchWithTimeout` and calls to it so redirects are not automatically followed by the runtime.
- Strengthened `validateSourceImageUrlOrThrow` to reject URLs that contain embedded credentials and non-443 ports and adjusted warn reasons (`non_https`, `credentials_in_url`, `non_standard_port`).
- Updated tests to expect `redirect: "manual"` and added unit tests that assert rejection of URLs with embedded credentials and non-443 ports.

### Testing

- Ran the unit tests in `server/imageService.proof.test.ts`, including the new `rejects source image URLs with embedded credentials before fetch` and `rejects source image URLs on non-443 ports before fetch` tests, and the updated redirect blocking test, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92e659d3883259cc91f324fc2ba5c)