### PR TITLE
Update docs to use /webhook/facebook endpoint

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -9,7 +9,7 @@
 - [x] Test webhook connectivity
 
 ## Phase 2: Backend Messenger Bot Integration
-- [x] Create Messenger webhook handler (/api/webhook/facebook)
+- [x] Create Messenger webhook handler (/webhook/facebook)
 - [x] Implement message receiving and parsing
 - [x] Set up user authentication flow with Manus OAuth
 - [x] Create message sending to users via Messenger API
@@ -57,3 +57,5 @@
 - [ ] Document filter options and seasonal updates
 - [ ] Provide cost monitoring dashboard
 - [ ] Create user-facing bot instructions
+
+> Note: Legacy route `/api/webhook/facebook` is deprecated and no longer used.


### PR DESCRIPTION
### Motivation
- Ensure documentation references the active Messenger webhook endpoint to avoid confusion and mismatches with deployed routes.
- Mark the old `/api/webhook/facebook` route as deprecated so maintainers know it is no longer used.

### Description
- Replaced `/api/webhook/facebook` with `/webhook/facebook` in `todo.md` checklist for the Messenger webhook handler.
- Added a short deprecation note to `todo.md` stating that the legacy `/api/webhook/facebook` route is deprecated and no longer used.
- Changes were committed to the repository (file modified: `todo.md`).

### Testing
- Ran `rg -n "/api/webhook/facebook" .` to locate occurrences and confirmed no remaining outdated references outside the added legacy note, which succeeded.
- Inspected the change with `git diff -- todo.md` to verify the patch, which succeeded.
- Committed the update with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe864545c8325a5bcfe61e359c29f)