### PR TITLE
docs: update REPO_HEALTH_SNAPSHOT to match current CI workflow

### DIFF
--- a/REPO_HEALTH_SNAPSHOT.md
+++ b/REPO_HEALTH_SNAPSHOT.md
@@ -3,10 +3,10 @@
 ## 1) Repo Health Snapshot (Very Light)
 
 ### CI Status Overview
-- **Status:** ⚠️ Matig / Verbeterbaar.
+- **Status:** ✅ Goed op orde.
 - **Workflow:** Eén workflow (`.github/workflows/ci.yml`) die draait op PR's en pushes naar `main`.
-- **Huidige Gates:** Installatie van dependencies, lint (`pnpm run lint`) en build (`pnpm run build`).
-- **Ontbrekend:** Geen expliciete server-linting (`lint:server`), geen typecheck (`check`) en geen geautomatiseerde tests (`test`) in de CI-pijplijn.
+- **Huidige Gates:** Installatie van dependencies, lint (`pnpm run lint`), test (`pnpm run test`), build (`pnpm run build`) en security-audit (`pnpm audit --prod --audit-level=high`).
+- **Ontbrekend:** `pnpm run check` (typecheck) en `pnpm run lint:server` draaien nog niet in CI.
 
 ### Lint/Typecheck Setup Summary
 - **TypeScript:** Staat in `strict` mode (`"strict": true`). Handmatige check mogelijk via `pnpm run check`.


### PR DESCRIPTION
### Motivation
- De projectdocumentatie voor CI liep achter op de daadwerkelijke workflow en moet de huidige gates en open punten accuraat weergeven.

### Description
- Werkte `REPO_HEALTH_SNAPSHOT.md` bij zodat de CI-status reflecteert dat de workflow nu `lint`, `test`, `build` en `pnpm audit --prod --audit-level=high` uitvoert.
- Vereenvoudigde de sectie “Ontbrekend” zodat alleen nog echte openstaande items worden genoemd: `pnpm run check` en `pnpm run lint:server`.
- Deze wijziging is uitsluitend documentatie en brengt geen runtime- of codewijzigingen aan.

### Testing
- Gecontroleerd dat `REPO_HEALTH_SNAPSHOT.md` en `.github/workflows/ci.yml` overeenkomen door ze te vergelijken met `sed -n '1,240p' REPO_HEALTH_SNAPSHOT.md && echo '---' && sed -n '1,260p' .github/workflows/ci.yml`, en dit draaide succesvol.
- Extra visuele validatie uitgevoerd met `nl -ba REPO_HEALTH_SNAPSHOT.md | sed -n '1,80p' && echo '---' && nl -ba .github/workflows/ci.yml | sed -n '1,120p'`, en dit draaide succesvol.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abfcd7b4148325ab1dd5ce2ab42f97)