### PR TITLE
docs: make todo.md canonical backlog and re-verify audit reports

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -1,4 +1,6 @@
 # Code Audit Report - Leaderbot Facebook Image Generator
+**Last verified:** 2026-03-07 (commit `9380024`)  
+**Backlog authority:** zie `todo.md` voor actuele open acties.  
 **Date:** February 24, 2026  
 **Auditor:** Manus Agent  
 **Status:** ✅ EXCELLENT - Production Ready with Minor Notes
@@ -195,16 +197,16 @@ export async function generateImage(styleId: StyleId, imageUrl: string) {
 
 **Webhook UX remains unchanged** - excellent separation of concerns.
 
-### Real Image Generation Checklist
+### Real Image Generation Checklist (Historical snapshot re-verified)
 
-- [ ] Add OpenAI API integration
-- [ ] Implement image upload from Messenger to S3
-- [ ] Add cost tracking (€0.04 per image)
-- [ ] Implement €100/month cost cap
-- [ ] Add database persistence for quota (currently in-memory)
-- [ ] Add user authentication (Manus OAuth)
-- [ ] Implement premium tier (currently free-only)
-- [ ] Add image gallery/history
+- [x] Add OpenAI API integration **(historical/resolved)**
+- [ ] Implement image upload from Messenger to S3 **(open; tracked in `todo.md`)**
+- [ ] Add cost tracking (€0.04 per image) **(open; tracked in `todo.md`)**
+- [ ] Implement €100/month cost cap **(open; tracked in `todo.md`)**
+- [x] Add database persistence for quota **(historical/resolved; DB helpers exist, Messenger runtime quota still state-based)**
+- [x] Add user authentication (Manus OAuth) **(historical/resolved)**
+- [ ] Implement premium tier (currently free-only) **(open; tracked in `todo.md`)**
+- [ ] Add image gallery/history **(open; tracked in `todo.md`)**
 
 ---
 
@@ -291,13 +293,13 @@ The following TypeScript errors exist in template components and are **NOT** fro
    # Should return: test123
    ```
 
-### Short-term (Next Sprint)
+### Short-term (Next Sprint, re-verified)
 
-1. Integrate real image generation (OpenAI)
-2. Add database persistence for quota
-3. Implement Manus OAuth authentication
-4. Add cost tracking and €10/month cap
-5. Create admin dashboard for monitoring
+1. [x] Integrate real image generation (OpenAI) **(historical/resolved)**
+2. [x] Add database persistence for quota **(historical/resolved at DB layer)**
+3. [x] Implement Manus OAuth authentication **(historical/resolved)**
+4. [ ] Add cost tracking and €100/month cap **(open; see `todo.md`)**
+5. [ ] Create admin dashboard for monitoring **(open; see `todo.md`)**
 
 ### Medium-term (Growth Phase)
 
@@ -391,7 +393,7 @@ fly logs -a groepsscore
 
 *Report Generated: 2026-02-24*  
 *Updated: 2026-02-24 with latest improvements*  
-*Next Review: After real image generation integration*
+*Next Review: Based on open items tracked in `todo.md`*
 
 ---
 

--- a/CODE_AUDIT_REPORT.md
+++ b/CODE_AUDIT_REPORT.md
@@ -1,9 +1,14 @@
 # Code Audit Report: Leaderbot AI Image Generator
 
-## Overview
-This audit evaluates the current state of the Leaderbot repository, focusing on the last 5 Pull Requests (#100 to #104) and general architecture to ensure it's optimized for a solo developer ("1-man show").
+**Last verified:** 2026-03-07 (commit `9380024`)  
+**Backlog authority:** zie `todo.md` voor alle nog-open actiepunten.
 
-## Summary of Last 5 PRs
+## Overview
+This report is now treated as a **historical architecture snapshot**. Recommendations from this audit are re-validated below and mapped to either:
+- ✅ **Historical (resolved in code)**, or
+- 🔄 **Still open (tracked in `todo.md`)**.
+
+## Summary of Last 5 PRs (historical)
 | PR # | Title | Key Changes | Impact |
 | :--- | :--- | :--- | :--- |
 | **104** | `fix/test-export-alignments` | Restored webhook test exports and aligned test suites. | **High Stability:** Ensures CI/CD and local testing remain reliable. |
@@ -14,39 +19,13 @@ This audit evaluates the current state of the Leaderbot repository, focusing on 
 
 ---
 
-## 🔍 Detailed Findings & Improvements
+## Re-validated actions from this audit
 
-### 1. Architectural Integrity
-- **Observation:** The project has successfully transitioned from a volatile in-memory state to a persistent architecture using both a Database (MySQL/Drizzle) and Redis (with in-memory fallback).
-- **Recommendation:** Stick with the **Redis Optional** pattern. For a solo developer, minimizing moving parts is key. If you don't need distributed state across multiple server instances, the in-memory fallback is perfectly fine.
+1. [x] **Verify State Sync** — **Historical/resolved**: `messengerQuota.ts` updates quota via `stateStore` and aligns with current runtime state strategy.
+2. [x] **Clean up Webhook** — **Historical/resolved**: webhook logic is split across `messengerWebhook.ts`, `webhookHandlers.ts`, and `webhookHelpers.ts`.
+3. [ ] **Monitoring** — **Open**: external uptime monitor for `/healthz` still advised (tracked in `todo.md`).
+4. [x] **Documentation** — **Historical/resolved**: `README.md` documents current state/quota architecture including DB-backed quota context.
 
-### 2. State Management & Consistency
-- **Observation:** There is a slight fragmentation between `messengerState.ts` (using Redis/In-memory) and `db.ts` (using MySQL). Some PRs (#100) attempted to move state to the DB, while #103 moved it to Redis.
-- **Critical Fix:** Ensure that `messengerState.ts` and `messengerQuota.ts` are using the same underlying store. Currently, `messengerState.ts` uses the `stateStore.ts` (Redis/Memory), while `messengerQuota.ts` has some hardcoded logic.
-- **Optimization:** Use the **Database** for long-term user data (PSID mapping, total generations) and **Redis/Memory** for "active session" data (current stage, last photo URL).
-
-### 3. Image Handling & Performance
-- **Observation:** The switch to JPEG in PR #102 is excellent for compatibility. However, the use of `sharp` as a runtime dependency might be heavy for a small Fly.io instance.
-- **Optimization:** If OpenAI already returns JPEG (as set in PR #102), `sharp` is mostly redundant. You can keep it as a fallback, but ensure it's not bloating your deployment image if not needed.
-
-### 4. Code Quality & Maintenance
-- **Observation:** The codebase uses a "Perfect Repo" structure which is very clean but can be "over-engineered" for a single person.
-- **Recommendation:** 
-    - **Simplify `messengerWebhook.ts`:** It's growing large (~600 lines). Consider splitting it into `webhookHandlers.ts` and `webhookHelpers.ts`.
-    - **Unified Error Handling:** Create a centralized `errorHandler.ts` for Messenger-specific errors to avoid repetitive `try-catch` blocks in the webhook logic.
-
-### 5. Solo Developer "1-Man Show" Tips
-- **Automate Testing:** Since you are alone, you can't rely on PR reviews. PR #104 shows you value tests—keep this up. Run `pnpm test` before every deploy.
-- **Logging:** You have good logging (PR #102 added `PROOF_SUMMARY`). Use a tool like **BetterStack** or **Axiom** (free tiers) to monitor these logs without logging into the Fly.io CLI.
-- **Environment Variables:** Ensure your `FB_PAGE_ACCESS_TOKEN` and `FB_APP_SECRET` are rotated periodically.
-
----
-
-## ✅ Actionable Checklist
-1. [ ] **Verify State Sync:** Check if `messengerQuota.ts` correctly reads from the same store as `messengerState.ts`.
-2. [ ] **Clean up Webhook:** Split the 600-line `messengerWebhook.ts` into smaller modules.
-3. [ ] **Monitoring:** Set up a simple uptime monitor (like UptimeRobot) for your `/healthz` endpoint.
-4. [ ] **Documentation:** Update the `README.md` to reflect the new Redis/DB architecture clearly.
-
-**Overall Status: HEALTHY 🚀**
-The repo is in a very strong state for a solo developer. The recent architectural changes provide a solid foundation for scaling if needed.
+## Status
+**Overall status:** HEALTHY 🚀  
+For execution priority and current open work, use `todo.md` as canonical backlog.

--- a/todo.md
+++ b/todo.md
@@ -1,61 +1,53 @@
-# Leaderbot Image Generator — Facebook Messenger Bot
+# Leaderbot Image Generator — Primary Backlog (`todo.md`)
 
-## Phase 1: Meta Developer Setup
-- [x] Rebrand Groepsscore app to "Leaderbot Image Generator"
-- [x] Configure Messenger webhook at https://groepsscore.fly.dev/webhook/facebook
-- [x] Set up Facebook Page integration (ID: 61587343141159)
-- [x] Generate and store Page Access Token
-- [x] Configure webhook verify token
-- [x] Test webhook connectivity
+> Dit bestand is de **enige bron van waarheid** voor open werk.  
+> Audit-bestanden (`AUDIT_REPORT.md`, `CODE_AUDIT_REPORT.md`) zijn historisch; open punten daaruit worden hier beheerd.
 
-## Phase 2: Backend Messenger Bot Integration
-- [x] Create Messenger webhook handler (/webhook/facebook)
-- [x] Implement message receiving and parsing
-- [x] Set up user authentication flow with Manus OAuth
-- [x] Create message sending to users via Messenger API
-- [x] Implement quick reply buttons for style selection
-- [x] Handle image uploads from Messenger
+## Verified snapshot
+- Last reviewed against code: **2026-03-07**
+- Verified commit: **`9380024`**
 
-## Phase 3: Preset Filter System
-- [x] Define transformation filter options (Caricature, Petals, Gold, Cinematic, Disco, Clouds)
-- [x] Implement image-to-image transformation with DALL-E / gpt-image-1
-- [x] Create filter templates with style prompts
+## Actieve backlog (open)
+
+### Product & bot-ervaring
 - [ ] Add seasonal filter rotation
-- [x] Implement image upload and processing pipeline
+- [ ] Create "upgrade to premium" prompt when limit reached
+- [ ] Add image gallery/history for users
 
-## Phase 4: Manus OAuth Integration
-- [x] Create OAuth callback handler for Messenger users
-- [x] Link Facebook user ID to Manus user account
-- [x] Store user authentication state
-- [x] Handle re-authentication flow
-
-## Phase 5: Free Tier Implementation
-- [x] Implement daily quota tracking (1 image/day per user)
-- [x] Create quota checking before transformation
+### Kosten & quota
 - [ ] Implement cost tracking (€0.04 per image)
 - [ ] Add €100/month cost cap enforcement
 - [ ] Send cost alerts to owner
-- [ ] Create "upgrade to premium" prompt when limit reached
+- [ ] Add external uptime monitor for `/healthz` (e.g. UptimeRobot)
 
-## Phase 6: Premium Tier (Ready but Inactive)
+### Opslag & platform
+- [ ] Implement image upload from Messenger/OpenAI flow to S3 (instead of local `public/generated`)
+
+### Premium tier (ready but inactive)
 - [ ] Design premium tier database schema
 - [ ] Implement Stripe payment integration
 - [ ] Create premium subscription management
 - [ ] Implement premium quota limits (10 images/day)
 - [ ] Add premium feature flags (ready to activate)
 
-## Phase 7: Testing & Deployment
-- [x] Test Messenger bot message flow
-- [x] Test image upload and transformation
-- [x] Test quota enforcement
+### Testing & docs
 - [ ] Test cost tracking
-- [x] Deploy to production
-- [x] Verify webhook connectivity
-
-## Phase 8: Delivery & Documentation
 - [ ] Create setup guide for Meta configuration
 - [ ] Document filter options and seasonal updates
 - [ ] Provide cost monitoring dashboard
 - [ ] Create user-facing bot instructions
+
+## Reeds geverifieerd in code (afgerond)
+- [x] OpenAI image generation integration (`gpt-image-1` flow)
+- [x] OAuth callback + state validation flow
+- [x] Messenger quota checks before transformation
+- [x] Database-backed quota tables/helpers (`dailyQuota`) beschikbaar
+- [x] Webhook opgesplitst in `messengerWebhook.ts` + `webhookHandlers.ts` + `webhookHelpers.ts`
+- [x] Deploy to production + webhook connectivity tests
+
+## Historisch afgerond (samenvatting eerdere fasen)
+- [x] Meta webhook/page/token setup
+- [x] Messenger webhook handler, quick replies, image uploads
+- [x] Preset filter system + style prompts
 
 > Note: Legacy route `/api/webhook/facebook` is deprecated and no longer used.


### PR DESCRIPTION
### Motivation
- Consolidate project tracking by making `todo.md` the single source of truth for all open work so audit files become historical snapshots. 
- Improve traceability by recording a "Last verified" date + commit in both audit reports so readers know when conclusions were validated. 
- Prevent stale action items by verifying each checklist entry against the codebase and marking items as historical (resolved) or still open. 

### Description
- Made `todo.md` the primary backlog and added a verified snapshot at the top with review date `2026-03-07` and commit `9380024`, then moved/annotated open work into concise sections. 
- Updated `AUDIT_REPORT.md` with a top-level `Last verified` + commit reference, declared `todo.md` as the backlog authority, and re-labeled checklist items to show which are historical vs still open (open items now point to `todo.md`). 
- Updated `CODE_AUDIT_REPORT.md` with `Last verified` + commit and converted recommendations into a re-validated list showing `historical/resolved` vs `open (tracked in todo.md)`. 
- No runtime code changes were made; this PR is documentation and backlog hygiene only. 

### Testing
- Verified presence of resolved implementations with repository searches using `rg` (checked OpenAI image edits in `server/_core/imageService.ts`, OAuth callback in `server/_core/oauth.ts`, quota helpers in `server/db.ts` and `server/_core/messengerQuota.ts`, and webhook split in `server/_core/messengerWebhook.ts`). 
- Confirmed verification metadata with `git rev-parse --short HEAD` (commit `9380024`) and `date -u +%Y-%m-%d` (`2026-03-07`) and committed the documentation changes. 
- No unit tests were changed in this PR; the audit references the repository's existing test state (previous report shows 13 tests passing) and the change does not affect runtime logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac000f180083258861910c4c4581a6)