### PR TITLE
docs: add human-readable tRPC API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ Legacy/app-specific environment variables also exist for SDK and data API integr
 - Never commit real `.env` files; only keep `.env.example` in git.
 - If a secret appears in GitHub code search (for example by searching for `.env` in this repo), rotate all exposed credentials immediately.
 
+## API documentation
+
+The API is served through `tRPC` at `/api/trpc`, with types inferred directly from server routers.
+
+For a human-readable reference of current procedures, auth requirements, and input/output shapes, see [`docs/trpc-api.md`](docs/trpc-api.md).
+
 ## Local dev
 
 ```bash

--- a/docs/trpc-api.md
+++ b/docs/trpc-api.md
@@ -1,0 +1,55 @@
+# tRPC API Surface (`/api/trpc`)
+
+This project exposes application APIs through a single tRPC endpoint: `/api/trpc`.
+
+Because the API is type-safe and inferred from server routers, the source of truth is:
+
+- `server/routers.ts`
+- `server/_core/systemRouter.ts`
+
+Use this document as a human-readable reference for procedures and their behavior.
+
+## Procedures
+
+### `system.health`
+
+- **Type:** Query
+- **Auth:** Public
+- **Input schema:**
+  - `timestamp: number` (must be `>= 0`)
+- **Response:**
+  - `{ ok: true }`
+
+### `system.notifyOwner`
+
+- **Type:** Mutation
+- **Auth:** Admin only (`ctx.user.role === "admin"`)
+- **Input schema:**
+  - `title: string` (required, min length 1)
+  - `content: string` (required, min length 1)
+- **Response:**
+  - `{ success: boolean }` (`true` when owner notification is delivered)
+
+### `auth.me`
+
+- **Type:** Query
+- **Auth:** Public (returns current user context if authenticated)
+- **Input schema:** None
+- **Response:**
+  - `ctx.user` (nullable/optional depending on session)
+
+### `auth.logout`
+
+- **Type:** Mutation
+- **Auth:** Public (session-aware)
+- **Input schema:** None
+- **Side effects:**
+  - Clears the auth session cookie.
+- **Response:**
+  - `{ success: true }`
+
+## Notes
+
+- Runtime request/response serialization uses `superjson` (`server/_core/trpc.ts`).
+- Zod input validation is enforced on procedures that define `.input(...)`.
+- For implementation details and definitive types, inspect the routers directly.


### PR DESCRIPTION
### Motivation
- Provide a human-readable reference of the tRPC API surface at `/api/trpc` to complement tRPC's type-inferred contract and help external consumers understand procedures and auth/input/output shapes.

### Description
- Add `docs/trpc-api.md` documenting `system.health`, `system.notifyOwner`, `auth.me`, and `auth.logout` with auth requirements and input/output shapes, and add an `API documentation` section to `README.md` linking to the new doc.

### Testing
- Ran `pnpm -s exec prettier --check README.md docs/trpc-api.md` which passed, and ran `pnpm test` which completed with all tests passing (`129 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12c15dcd083259f8eec62067027b4)