### PR TITLE
Enforce HTTPS for production base URLs and outbound requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ FB_APP_SECRET=replace_with_app_secret
 
 # Required for inbound source-image fetching allowlist.
 # If unset/empty, source-image fetches fail closed.
+# Security: regularly review this list and keep only trusted domains.
 SOURCE_IMAGE_ALLOWED_HOSTS=fbcdn.net,fbsbx.com
 
 # ------------------------------------------------------------
@@ -25,7 +26,8 @@ SOURCE_IMAGE_ALLOWED_HOSTS=fbcdn.net,fbsbx.com
 # ------------------------------------------------------------
 # Optional: generator mode (supported: mock|openai). Defaults effectively to openai.
 GENERATOR_MODE=mock
-# Required when GENERATOR_MODE=openai: public absolute base URL (https://... in production).
+# Required when GENERATOR_MODE=openai: public absolute base URL.
+# Security: this must be HTTPS in production.
 APP_BASE_URL=http://localhost:3000
 # Required when GENERATOR_MODE=openai.
 OPENAI_API_KEY=replace_with_openai_api_key

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ Related files:
 - `FB_VERIFY_TOKEN` (Webhook verification)
 - `FB_PAGE_ACCESS_TOKEN` (Messenger send API)
 - `FB_APP_SECRET` (Webhook signature validation)
-- `SOURCE_IMAGE_ALLOWED_HOSTS` (required for inbound source-image fetching; if unset, source-image fetches are blocked)
+- `SOURCE_IMAGE_ALLOWED_HOSTS` (required for inbound source-image fetching; if unset, source-image fetches are blocked; review regularly and keep only trusted domains)
 - `REDIS_URL` (required in production for webhook replay protection)
-- `APP_BASE_URL` (required when `GENERATOR_MODE=openai` for public generated image URLs)
+- `APP_BASE_URL` (required when `GENERATOR_MODE=openai` for public generated image URLs; must be `https://` in production)
 - `OPENAI_API_KEY` (required when `GENERATOR_MODE=openai`)
 
 ### Common optional

--- a/server/_core/chat.ts
+++ b/server/_core/chat.ts
@@ -12,12 +12,17 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { Express } from "express";
 import { z } from "zod/v4";
 import { createPatchedFetch } from "./patchedFetch";
+import { getForgeApiBaseUrlOrThrow } from "./env";
 
 let hasLoggedChatDisabledOnStartup = false;
 
 function getChatConfig() {
-  const apiUrl = (process.env.BUILT_IN_FORGE_API_URL ?? "").trim();
   const apiKey = (process.env.BUILT_IN_FORGE_API_KEY ?? "").trim();
+
+  let apiUrl = "";
+  if ((process.env.BUILT_IN_FORGE_API_URL ?? "").trim().length > 0) {
+    apiUrl = getForgeApiBaseUrlOrThrow();
+  }
 
   return {
     apiUrl,

--- a/server/_core/dataApi.ts
+++ b/server/_core/dataApi.ts
@@ -4,7 +4,7 @@
  *     query: { gl: "US", hl: "en", q: "manus" },
  *   })
  */
-import { ENV } from "./env";
+import { ENV, getForgeApiBaseUrlOrThrow } from "./env";
 
 export type DataApiCallOptions = {
   query?: Record<string, unknown>;
@@ -25,7 +25,8 @@ export async function callDataApi(
   }
 
   // Build the full URL by appending the service path to the base URL
-  const baseUrl = ENV.forgeApiUrl.endsWith("/") ? ENV.forgeApiUrl : `${ENV.forgeApiUrl}/`;
+  const forgeApiUrl = getForgeApiBaseUrlOrThrow();
+  const baseUrl = forgeApiUrl.endsWith("/") ? forgeApiUrl : `${forgeApiUrl}/`;
   const fullUrl = new URL("webdevtoken.v1.WebDevService/CallApi", baseUrl).toString();
 
   const response = await fetch(fullUrl, {

--- a/server/_core/env.ts
+++ b/server/_core/env.ts
@@ -24,3 +24,43 @@ export function assertAuthConfig(): void {
     );
   }
 }
+
+
+function parseUrlOrThrow(rawUrl: string, envName: string): URL {
+  try {
+    return new URL(rawUrl);
+  } catch {
+    throw new Error(`${envName} must be a valid absolute URL`);
+  }
+}
+
+function enforceHttpsInProduction(url: URL, label: string): void {
+  if (process.env.NODE_ENV === "production" && url.protocol !== "https:") {
+    throw new Error(`${label} must use HTTPS in production`);
+  }
+}
+
+export function getForgeApiBaseUrlOrThrow(): string {
+  const raw = (process.env.BUILT_IN_FORGE_API_URL ?? "").trim();
+
+  if (!raw) {
+    throw new Error("BUILT_IN_FORGE_API_URL is not configured");
+  }
+
+  const parsed = parseUrlOrThrow(raw, "BUILT_IN_FORGE_API_URL");
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("BUILT_IN_FORGE_API_URL must start with http:// or https://");
+  }
+
+  enforceHttpsInProduction(parsed, "BUILT_IN_FORGE_API_URL");
+  return parsed.toString();
+}
+
+export function assertOutboundHttpsUrl(rawUrl: string, label = "outbound URL"): void {
+  const parsed = parseUrlOrThrow(rawUrl, label);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`${label} must start with http:// or https://`);
+  }
+
+  enforceHttpsInProduction(parsed, label);
+}

--- a/server/_core/imageGeneration.ts
+++ b/server/_core/imageGeneration.ts
@@ -16,7 +16,7 @@
  *   });
  */
 import { storagePut } from "server/storage";
-import { ENV } from "./env";
+import { ENV, getForgeApiBaseUrlOrThrow } from "./env";
 
 export type GenerateImageOptions = {
   prompt: string;
@@ -42,9 +42,10 @@ export async function generateImage(
   }
 
   // Build the full URL by appending the service path to the base URL
-  const baseUrl = ENV.forgeApiUrl.endsWith("/")
-    ? ENV.forgeApiUrl
-    : `${ENV.forgeApiUrl}/`;
+  const forgeApiUrl = getForgeApiBaseUrlOrThrow();
+  const baseUrl = forgeApiUrl.endsWith("/")
+    ? forgeApiUrl
+    : `${forgeApiUrl}/`;
   const fullUrl = new URL(
     "images.v1.ImageService/GenerateImage",
     baseUrl

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -47,11 +47,19 @@ const OPENAI_TIMEOUT_MS_DEFAULT = 30_000;
 function getConfiguredBaseUrl(): string | undefined {
   const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
 
-  if (configuredBaseUrl && /^https?:\/\//.test(configuredBaseUrl)) {
-    return configuredBaseUrl.replace(/\/$/, "");
+  if (!configuredBaseUrl || !/^https?:\/\//.test(configuredBaseUrl)) {
+    return undefined;
   }
 
-  return undefined;
+  if (process.env.NODE_ENV === "production" && !configuredBaseUrl.startsWith("https://")) {
+    console.error("APP_BASE_URL must use https:// in production", {
+      hasConfiguredBaseUrl: true,
+      protocol: configuredBaseUrl.split(":")[0],
+    });
+    return undefined;
+  }
+
+  return configuredBaseUrl.replace(/\/$/, "");
 }
 
 function getBaseUrl(): string {

--- a/server/_core/map.ts
+++ b/server/_core/map.ts
@@ -7,7 +7,7 @@
  * See API examples below the type definitions for usage patterns.
  */
 
-import { ENV } from "./env";
+import { ENV, getForgeApiBaseUrlOrThrow } from "./env";
 
 // ============================================================================
 // Configuration
@@ -19,7 +19,7 @@ type MapsConfig = {
 };
 
 function getMapsConfig(): MapsConfig {
-  const baseUrl = ENV.forgeApiUrl;
+  const baseUrl = getForgeApiBaseUrlOrThrow();
   const apiKey = ENV.forgeApiKey;
 
   if (!baseUrl || !apiKey) {

--- a/server/_core/voiceTranscription.ts
+++ b/server/_core/voiceTranscription.ts
@@ -25,7 +25,7 @@
  * });
  * ```
  */
-import { ENV } from "./env";
+import { ENV, assertOutboundHttpsUrl, getForgeApiBaseUrlOrThrow } from "./env";
 
 export type TranscribeOptions = {
   audioUrl: string; // URL to the audio file (e.g., S3 URL)
@@ -94,6 +94,7 @@ export async function transcribeAudio(
     let audioBuffer: Buffer;
     let mimeType: string;
     try {
+      assertOutboundHttpsUrl(options.audioUrl, "audioUrl");
       const response = await fetch(options.audioUrl);
       if (!response.ok) {
         return {
@@ -143,9 +144,10 @@ export async function transcribeAudio(
     formData.append("prompt", prompt);
 
     // Step 4: Call the transcription service
-    const baseUrl = ENV.forgeApiUrl.endsWith("/")
-      ? ENV.forgeApiUrl
-      : `${ENV.forgeApiUrl}/`;
+    const forgeApiUrl = getForgeApiBaseUrlOrThrow();
+    const baseUrl = forgeApiUrl.endsWith("/")
+      ? forgeApiUrl
+      : `${forgeApiUrl}/`;
     
     const fullUrl = new URL(
       "v1/audio/transcriptions",

--- a/server/chat.routes.test.ts
+++ b/server/chat.routes.test.ts
@@ -63,6 +63,7 @@ async function postJson(
 describe("chat route configuration", () => {
   const originalForgeApiUrl = process.env.BUILT_IN_FORGE_API_URL;
   const originalForgeApiKey = process.env.BUILT_IN_FORGE_API_KEY;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   afterEach(() => {
     if (originalForgeApiUrl === undefined) {
@@ -75,6 +76,12 @@ describe("chat route configuration", () => {
       delete process.env.BUILT_IN_FORGE_API_KEY;
     } else {
       process.env.BUILT_IN_FORGE_API_KEY = originalForgeApiKey;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
     }
 
     vi.restoreAllMocks();
@@ -98,6 +105,19 @@ describe("chat route configuration", () => {
     const { isChatConfigured } = await import("./_core/chat");
 
     expect(isChatConfigured()).toBe(true);
+  });
+
+
+
+  it("rejects non-https forge URL in production", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.BUILT_IN_FORGE_API_URL = "http://example.test/forge";
+    process.env.BUILT_IN_FORGE_API_KEY = "secret-token";
+
+    vi.resetModules();
+    const { isChatConfigured } = await import("./_core/chat");
+
+    expect(() => isChatConfigured()).toThrow("BUILT_IN_FORGE_API_URL must use HTTPS in production");
   });
 
   it("registers active /api/chat when config is present", async () => {

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -267,6 +267,44 @@ describe("OpenAi image-to-image proof", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("requires https APP_BASE_URL in production for openai mode", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "http://leaderbot.example";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fixture = Buffer.alloc(7000, 9);
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-insecure-app-base-url",
+      }),
+    ).rejects.toThrow("APP_BASE_URL is missing or invalid");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    delete process.env.NODE_ENV;
+  });
+
   it("removes leftover generated webp files", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";


### PR DESCRIPTION
### Motivation
- Harden image generation URLs by requiring `APP_BASE_URL` to be HTTPS in production so public generated links are not served over insecure schemes.
- Ensure any outbound service endpoints are validated and use HTTPS in production to prevent accidental plaintext API calls.
- Explicitly document security guidance for `SOURCE_IMAGE_ALLOWED_HOSTS` and `APP_BASE_URL` to reduce operational risk.

### Description
- Tighten `getConfiguredBaseUrl()` in `server/_core/imageService.ts` to treat non-HTTP(S) or non-`https://` (when `NODE_ENV=production`) `APP_BASE_URL` values as invalid and log an error, causing OpenAI generator flow to fail closed when misconfigured.
- Add URL validation helpers in `server/_core/env.ts`: `parseUrlOrThrow`, `enforceHttpsInProduction`, `getForgeApiBaseUrlOrThrow`, and `assertOutboundHttpsUrl` to centralize absolute-URL parsing and HTTPS enforcement.
- Route Forge/third-party base URL resolution through `getForgeApiBaseUrlOrThrow` and apply HTTPS checks in `server/_core/chat.ts`, `server/_core/dataApi.ts`, `server/_core/imageGeneration.ts`, and `server/_core/map.ts`.
- Add `assertOutboundHttpsUrl` validation for `audioUrl` in `server/_core/voiceTranscription.ts` and use `getForgeApiBaseUrlOrThrow` for transcription service calls.
- Add tests: a production `APP_BASE_URL` must be `https://` in `server/imageService.proof.test.ts`, and a production Forge URL must be `https://` in `server/chat.routes.test.ts`.
- Update configuration docs/files: `.env.example` and `README.md` to call out that `APP_BASE_URL` must be HTTPS in production and to regularly review `SOURCE_IMAGE_ALLOWED_HOSTS`.

### Testing
- Ran the focused test suite with `pnpm test server/imageService.proof.test.ts server/chat.routes.test.ts` and all tests passed (20 tests across the two files).
- Ran server linting with `pnpm lint:server` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12bbd68208325b44f2ec1348cb970)