### PR TITLE
Harden API input validation with zod schemas

### DIFF
--- a/server/_core/githubAdmin.ts
+++ b/server/_core/githubAdmin.ts
@@ -1,7 +1,14 @@
 import { randomBytes } from "node:crypto";
 import { parse as parseCookieHeader } from "cookie";
-import type { Express, NextFunction, Request, RequestHandler, Response } from "express";
+import type {
+  Express,
+  NextFunction,
+  Request,
+  RequestHandler,
+  Response,
+} from "express";
 import { SignJWT, jwtVerify } from "jose";
+import { z } from "zod";
 import { getAdminCookieOptions } from "./cookies";
 import { getConfiguredJwtSecret } from "./env";
 
@@ -13,6 +20,11 @@ const STATE_COOKIE_TTL_MS = 10 * 60 * 1000;
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
+
+const githubCallbackQuerySchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1),
+});
 
 type GitHubTokenResponse = {
   access_token?: string;
@@ -203,7 +215,9 @@ function clearAdminSessionCookie(req: Request, res: Response): void {
   clearCookie(res, req, ADMIN_SESSION_COOKIE_NAME);
 }
 
-export function parseAdminGithubUsers(raw = process.env.ADMIN_GITHUB_USERS ?? ""): Set<string> {
+export function parseAdminGithubUsers(
+  raw = process.env.ADMIN_GITHUB_USERS ?? ""
+): Set<string> {
   return new Set(
     raw
       .split(",")
@@ -222,13 +236,17 @@ export async function createAdminSessionToken(login: string): Promise<string> {
     .sign(getJwtSecretKey());
 }
 
-export async function verifyAdminSessionToken(token: string): Promise<string | null> {
+export async function verifyAdminSessionToken(
+  token: string
+): Promise<string | null> {
   try {
     const { payload } = await jwtVerify(token, getJwtSecretKey(), {
       algorithms: ["HS256"],
     });
 
-    return typeof payload.sub === "string" && payload.sub.length > 0 ? payload.sub : null;
+    return typeof payload.sub === "string" && payload.sub.length > 0
+      ? payload.sub
+      : null;
   } catch {
     return null;
   }
@@ -262,7 +280,11 @@ function sendUnauthorizedAdminResponse(req: Request, res: Response): void {
   res.status(401).type("text/plain").send("Admin login required");
 }
 
-export const requireAdmin: RequestHandler = (req: Request, res: Response, next: NextFunction) => {
+export const requireAdmin: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   void (async () => {
     const login = await getAdminLoginFromRequest(req);
     if (!login) {
@@ -281,7 +303,10 @@ export function registerGitHubAdminRoutes(app: Express): void {
   app.get("/auth/github/start", (req, res) => {
     const config = getGitHubAdminConfig();
     if (!config) {
-      res.status(503).type("text/plain").send("GitHub admin auth is not configured");
+      res
+        .status(503)
+        .type("text/plain")
+        .send("GitHub admin auth is not configured");
       return;
     }
 
@@ -301,19 +326,30 @@ export function registerGitHubAdminRoutes(app: Express): void {
     void (async () => {
       const config = getGitHubAdminConfig();
       if (!config) {
-        res.status(503).type("text/plain").send("GitHub admin auth is not configured");
+        res
+          .status(503)
+          .type("text/plain")
+          .send("GitHub admin auth is not configured");
         return;
       }
 
-      const code = getQueryParam(req, "code");
-      const state = getQueryParam(req, "state");
+      const parsedQuery = githubCallbackQuerySchema.safeParse({
+        code: getQueryParam(req, "code"),
+        state: getQueryParam(req, "state"),
+      });
       const expectedState = getCookieValue(req, GITHUB_ADMIN_STATE_COOKIE_NAME);
       clearStateCookie(req, res);
 
-      if (!code || !state || !expectedState || state !== expectedState) {
+      if (
+        !parsedQuery.success ||
+        !expectedState ||
+        parsedQuery.data.state !== expectedState
+      ) {
         res.status(400).type("text/plain").send("Invalid GitHub OAuth state");
         return;
       }
+
+      const { code } = parsedQuery.data;
 
       try {
         const accessToken = await exchangeCodeForAccessToken(code, config);

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -26,6 +26,7 @@ import {
   isRedisReplayProtectionEnabled,
 } from "./webhookReplayProtection";
 import { bodyParserErrorHandler } from "./bodyParserErrorHandler";
+import { z } from "zod";
 import {
   createGlobalHttpRateLimiter,
   ensureHttpRateLimiterReady,
@@ -42,6 +43,10 @@ import {
 const gitSha = process.env.GIT_SHA ?? process.env.SOURCE_VERSION ?? "dev";
 const bootTimestamp = new Date().toISOString();
 const REQUEST_BODY_LIMIT = "10mb";
+
+const debugBuildHeadersSchema = z.object({
+  "x-admin-token": z.string().min(1).optional(),
+});
 
 function buildVersionPayload() {
   return {
@@ -85,7 +90,8 @@ async function startServer() {
     const startTime = process.hrtime.bigint();
 
     res.on("finish", () => {
-      const durationMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
+      const durationMs =
+        Number(process.hrtime.bigint() - startTime) / 1_000_000;
       const log = {
         reqId: getRequestId(req),
         traceId: getTraceContext(req)?.traceId,
@@ -125,9 +131,12 @@ async function startServer() {
 
   app.get("/debug/build", (req, res) => {
     const adminToken = process.env.ADMIN_TOKEN;
-    const providedToken = req.header("X-Admin-Token");
+    const parsedHeaders = debugBuildHeadersSchema.safeParse(req.headers);
+    const providedToken = parsedHeaders.success
+      ? parsedHeaders.data["x-admin-token"]
+      : undefined;
 
-    if (!adminToken || providedToken !== adminToken) {
+    if (!adminToken || !providedToken || providedToken !== adminToken) {
       return res.sendStatus(403);
     }
 
@@ -269,7 +278,9 @@ async function startServer() {
   if (oauthServerUrl) {
     registerOAuthRoutes(app);
   } else {
-    console.info("[OAuth] OAUTH_SERVER_URL not set, skipping OAuth route initialization");
+    console.info(
+      "[OAuth] OAUTH_SERVER_URL not set, skipping OAuth route initialization"
+    );
   }
   registerChatRoutes(app);
   app.use(

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,14 +1,24 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
-import { ZodError } from "zod";
+import { z, ZodError } from "zod";
 import { normalizeLang } from "./i18n";
 import { createWebhookHandlers } from "./webhookHandlers";
 import { resetWebhookReplayProtection } from "./webhookReplayProtection";
-import { detectAck, getGreetingResponse, summarizeWebhook } from "./webhookHelpers";
+import {
+  detectAck,
+  getGreetingResponse,
+  summarizeWebhook,
+} from "./webhookHelpers";
 import { facebookWebhookPayloadSchema } from "./webhookSchemas";
 
 const PRIVACY_POLICY_URL = process.env.PRIVACY_POLICY_URL?.trim() || "<link>";
 const DEFAULT_LANG = normalizeLang(process.env.DEFAULT_MESSENGER_LANG);
+
+const webhookVerificationQuerySchema = z.object({
+  "hub.mode": z.literal("subscribe"),
+  "hub.verify_token": z.string().min(1),
+  "hub.challenge": z.string().min(1),
+});
 
 const handlers = createWebhookHandlers({
   defaultLang: DEFAULT_LANG,
@@ -28,28 +38,29 @@ export function resetMessengerEventDedupe(): void {
   resetWebhookReplayProtection();
 }
 
-export async function processFacebookWebhookPayload(payload: unknown): Promise<void> {
+export async function processFacebookWebhookPayload(
+  payload: unknown
+): Promise<void> {
   await handlers.processFacebookWebhookPayload(payload);
 }
 
 export function registerMetaWebhookRoutes(app: express.Express): void {
   const handleVerification: express.RequestHandler = (req, res) => {
-    const mode = req.query["hub.mode"];
-    const verifyToken = req.query["hub.verify_token"];
-    const challenge = req.query["hub.challenge"];
     const configuredToken = process.env.FB_VERIFY_TOKEN?.trim();
+    const parsedQuery = webhookVerificationQuerySchema.safeParse(req.query);
 
     if (
       !configuredToken ||
-      mode !== "subscribe" ||
-      typeof verifyToken !== "string" ||
-      verifyToken !== configuredToken ||
-      typeof challenge !== "string"
+      !parsedQuery.success ||
+      parsedQuery.data["hub.verify_token"] !== configuredToken
     ) {
       return res.sendStatus(403);
     }
 
-    return res.status(200).type("text/plain").send(challenge);
+    return res
+      .status(200)
+      .type("text/plain")
+      .send(parsedQuery.data["hub.challenge"]);
   };
 
   app.use("/webhook", webhookLimiter);

--- a/server/_core/oauth.ts
+++ b/server/_core/oauth.ts
@@ -1,6 +1,7 @@
 import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
 import { parse as parseCookieHeader } from "cookie";
 import type { Express, Request, Response } from "express";
+import { z } from "zod";
 import * as db from "../db";
 import { getSessionCookieOptions } from "./cookies";
 
@@ -10,6 +11,16 @@ type OAuthStatePayload = {
   nonce: string;
   redirectUri: string;
 };
+
+const oauthCallbackQuerySchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(1),
+});
+
+const oauthStateSchema = z.object({
+  nonce: z.string().min(16),
+  redirectUri: z.string().url(),
+});
 
 function getQueryParam(req: Request, key: string): string | undefined {
   const value = req.query[key];
@@ -29,32 +40,30 @@ function getCookieValue(req: Request, key: string): string | undefined {
 
 function clearOAuthStateCookie(req: Request, res: Response) {
   const cookieOptions = getSessionCookieOptions(req);
-  res.clearCookie(OAUTH_STATE_COOKIE_NAME, { ...cookieOptions, path: "/api/oauth/callback", sameSite: "lax" });
+  res.clearCookie(OAUTH_STATE_COOKIE_NAME, {
+    ...cookieOptions,
+    path: "/api/oauth/callback",
+    sameSite: "lax",
+  });
 }
 export function parseOAuthState(state: string): OAuthStatePayload | null {
   try {
     const decoded = Buffer.from(state, "base64").toString("utf8");
-    const parsed = JSON.parse(decoded) as Partial<OAuthStatePayload>;
-
-    if (
-      typeof parsed.redirectUri !== "string" ||
-      parsed.redirectUri.length === 0 ||
-      typeof parsed.nonce !== "string" ||
-      parsed.nonce.length < 16
-    ) {
+    const parsed = oauthStateSchema.safeParse(JSON.parse(decoded));
+    if (!parsed.success) {
       return null;
     }
 
-    return {
-      redirectUri: parsed.redirectUri,
-      nonce: parsed.nonce,
-    };
+    return parsed.data;
   } catch {
     return null;
   }
 }
 
-export function validateOAuthState(req: Request, state: string): OAuthStatePayload | null {
+export function validateOAuthState(
+  req: Request,
+  state: string
+): OAuthStatePayload | null {
   const parsedState = parseOAuthState(state);
   if (!parsedState) {
     return null;
@@ -71,14 +80,18 @@ export function validateOAuthState(req: Request, state: string): OAuthStatePaylo
 export function registerOAuthRoutes(app: Express) {
   app.get("/api/oauth/callback", (req: Request, res: Response) => {
     void (async () => {
-      const code = getQueryParam(req, "code");
-      const state = getQueryParam(req, "state");
+      const parsedQuery = oauthCallbackQuerySchema.safeParse({
+        code: getQueryParam(req, "code"),
+        state: getQueryParam(req, "state"),
+      });
 
-      if (!code || !state) {
+      if (!parsedQuery.success) {
         clearOAuthStateCookie(req, res);
         res.status(400).json({ error: "code and state are required" });
         return;
       }
+
+      const { code, state } = parsedQuery.data;
 
       const validatedState = validateOAuthState(req, state);
       if (!validatedState) {
@@ -89,7 +102,10 @@ export function registerOAuthRoutes(app: Express) {
 
       try {
         const { sdk } = await import("./sdk");
-        const tokenResponse = await sdk.exchangeCodeForToken(code, validatedState.redirectUri);
+        const tokenResponse = await sdk.exchangeCodeForToken(
+          code,
+          validatedState.redirectUri
+        );
         const userInfo = await sdk.getUserInfo(tokenResponse.accessToken);
 
         if (!userInfo.openId) {
@@ -112,7 +128,10 @@ export function registerOAuthRoutes(app: Express) {
         });
 
         const cookieOptions = getSessionCookieOptions(req);
-        res.cookie(COOKIE_NAME, sessionToken, { ...cookieOptions, maxAge: ONE_YEAR_MS });
+        res.cookie(COOKIE_NAME, sessionToken, {
+          ...cookieOptions,
+          maxAge: ONE_YEAR_MS,
+        });
         clearOAuthStateCookie(req, res);
 
         res.redirect(302, "/");

--- a/server/_core/webhookSchemas.ts
+++ b/server/_core/webhookSchemas.ts
@@ -1,58 +1,101 @@
 import { z } from "zod";
 
-const messengerAttachmentSchema = z.object({
-  type: z.string().optional(),
-  payload: z
-    .object({
-      url: z.string().url().optional(),
-    })
-    .passthrough()
-    .optional(),
-}).passthrough();
+const nonEmptyString = z.string().trim().min(1);
 
-const messengerMessageSchema = z.object({
-  mid: z.string().min(1).optional(),
-  is_echo: z.boolean().optional(),
-  text: z.string().optional(),
-  quick_reply: z.object({
-    payload: z.string().min(1).optional(),
-  }).passthrough().optional(),
-  attachments: z.array(messengerAttachmentSchema).optional(),
-}).passthrough();
+const messengerAttachmentSchema = z
+  .object({
+    type: nonEmptyString.optional(),
+    payload: z
+      .object({
+        url: z.string().url().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
 
-const messengerEventSchema = z.object({
-  sender: z.object({
-    id: z.string().min(1).optional(),
-    locale: z.string().optional(),
-  }).passthrough().optional(),
-  recipient: z.object({
-    id: z.string().min(1).optional(),
-  }).passthrough().optional(),
-  message: messengerMessageSchema.optional(),
-  postback: z.object({
-    title: z.string().optional(),
-    payload: z.string().optional(),
-    referral: z.object({
-      ref: z.string().optional(),
-    }).passthrough().optional(),
-  }).passthrough().optional(),
-  referral: z.object({
-    ref: z.string().optional(),
-  }).passthrough().optional(),
-  timestamp: z.number().finite().nonnegative().optional(),
-  delivery: z.unknown().optional(),
-  read: z.unknown().optional(),
-}).passthrough();
+const messengerMessageSchema = z
+  .object({
+    mid: nonEmptyString.optional(),
+    is_echo: z.boolean().optional(),
+    text: z.string().optional(),
+    quick_reply: z
+      .object({
+        payload: nonEmptyString.optional(),
+      })
+      .passthrough()
+      .optional(),
+    attachments: z.array(messengerAttachmentSchema).optional(),
+  })
+  .passthrough();
 
-export const facebookWebhookPayloadSchema = z.object({
-  object: z.string().min(1),
-  entry: z.array(
-    z.object({
-      id: z.string().optional(),
-      time: z.number().finite().optional(),
-      messaging: z.array(messengerEventSchema).default([]),
-    }).passthrough(),
-  ).default([]),
-}).passthrough();
+const messengerEventSchema = z
+  .object({
+    sender: z
+      .object({
+        id: nonEmptyString,
+        locale: z.string().optional(),
+      })
+      .passthrough(),
+    recipient: z
+      .object({
+        id: nonEmptyString,
+      })
+      .passthrough(),
+    message: messengerMessageSchema.optional(),
+    postback: z
+      .object({
+        title: z.string().optional(),
+        payload: z.string().optional(),
+        referral: z
+          .object({
+            ref: z.string().optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    referral: z
+      .object({
+        ref: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    timestamp: z.number().int().nonnegative().optional(),
+    delivery: z.unknown().optional(),
+    read: z.unknown().optional(),
+  })
+  .passthrough()
+  .refine(
+    event =>
+      Boolean(
+        event.message ||
+        event.postback ||
+        event.referral ||
+        event.delivery ||
+        event.read
+      ),
+    {
+      message: "messaging event must include at least one Messenger event type",
+    }
+  );
 
-export type FacebookWebhookPayload = z.infer<typeof facebookWebhookPayloadSchema>;
+const webhookEntrySchema = z
+  .object({
+    id: nonEmptyString.optional(),
+    time: z.number().int().nonnegative().optional(),
+    messaging: z.array(messengerEventSchema).default([]),
+  })
+  .passthrough();
+
+export const facebookWebhookPayloadSchema = z
+  .object({
+    object: z.literal("page"),
+    entry: z.array(webhookEntrySchema).min(1),
+  })
+  .passthrough();
+
+export type FacebookWebhookPayload = z.infer<
+  typeof facebookWebhookPayloadSchema
+>;


### PR DESCRIPTION
### Motivation
- Strengthen input validation across HTTP entry points and user-controlled inputs to reduce parsing errors and tighten security boundaries. 
- Add more granular validation for Facebook webhook payloads beyond the existing `facebookWebhookPayloadSchema` to catch malformed or unexpected messaging events early.

### Description
- Added Zod query validation for the OAuth callback flow in `server/_core/oauth.ts` with `oauthCallbackQuerySchema` and replaced manual state decoding with `oauthStateSchema` for safer `state` handling. 
- Added Zod query validation for GitHub admin callback in `server/_core/githubAdmin.ts` via `githubCallbackQuerySchema` and perform schema checks before state/cookie comparison and token exchange. 
- Added Zod header validation for `/debug/build` in `server/_core/index.ts` to safely parse `x-admin-token` before performing auth checks. 
- Hardened webhook verification and payload validation in `server/_core/messengerWebhook.ts` and `server/_core/webhookSchemas.ts` by validating `/webhook` verification query params and introducing stricter webhook payload schemas (required `object: "page"`, non-empty `entry`, stricter sender/recipient/timestamp/quick-reply/attachment checks, and an event-level refinement that requires at least one event payload). 

### Testing
- Formatted modified files with `pnpm -s prettier --write server/_core/oauth.ts server/_core/githubAdmin.ts server/_core/index.ts server/_core/messengerWebhook.ts server/_core/webhookSchemas.ts` which completed successfully. 
- Ran component tests including `pnpm -s vitest run server/messengerWebhook.validation.test.ts --testTimeout=20000` which passed. 
- Ran the broader server test suites with `pnpm -s vitest run server/oauthNonce.test.ts server/githubAdmin.test.ts server/chat.validation.test.ts server/messengerWebhook.verification.test.ts` and all relevant tests passed (no failing tests remained after fixes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12b7157848325aaece9d922983d77)