### PR TITLE
Refactor webhook handlers and centralize structured logging

### DIFF
--- a/server/_core/logger.ts
+++ b/server/_core/logger.ts
@@ -1,0 +1,46 @@
+export type LogLevel = "debug" | "info" | "error";
+
+type LogFields = Record<string, unknown>;
+
+type LoggerOptions = {
+  reqId?: string;
+  debugEnabled?: boolean;
+};
+
+function emit(level: Exclude<LogLevel, "debug"> | "debug", fields: LogFields): void {
+  const payload = { level, ...fields };
+  const serialized = JSON.stringify(payload);
+
+  if (level === "error") {
+    console.error(serialized);
+    return;
+  }
+
+  console.log(serialized);
+}
+
+export function createLogger({ reqId, debugEnabled = false }: LoggerOptions) {
+  function withReq(fields: LogFields): LogFields {
+    if (!reqId || fields.reqId) {
+      return fields;
+    }
+
+    return { reqId, ...fields };
+  }
+
+  return {
+    debug(fields: LogFields): void {
+      if (!debugEnabled) {
+        return;
+      }
+
+      emit("debug", withReq(fields));
+    },
+    info(fields: LogFields): void {
+      emit("info", withReq(fields));
+    },
+    error(fields: LogFields): void {
+      emit("error", withReq(fields));
+    },
+  };
+}

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -78,13 +78,7 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
   ],
 };
 
-type LegacyMessengerState = {
-  currentStep?: MessengerFlowState;
-  lastImage?: string | null;
-  style?: string | null;
-};
-
-type PartialState = Partial<MessengerUserState> & LegacyMessengerState;
+type PartialState = Partial<MessengerUserState>;
 
 function looksLikeUserKey(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value);
@@ -126,10 +120,10 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
 function normalizeState(psid: string, value: PartialState | null | undefined): MessengerUserState {
   const resolvedPsid = value?.psid ?? psid;
   const fallback = createDefaultState(resolvedPsid);
-  const stage = value?.stage ?? value?.state ?? value?.currentStep ?? fallback.stage;
-  const lastPhoto = value?.lastPhoto ?? value?.lastPhotoUrl ?? fallback.lastPhoto;
-  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? value?.style ?? fallback.selectedStyle;
-  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? value?.lastImage ?? fallback.lastGeneratedUrl;
+  const stage = value?.stage ?? value?.state ?? fallback.stage;
+  const lastPhoto = value?.lastPhotoUrl ?? value?.lastPhoto ?? fallback.lastPhoto;
+  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? fallback.selectedStyle;
+  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? fallback.lastGeneratedUrl;
 
   return {
     ...fallback,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -41,10 +41,18 @@ import {
 import { hasInFlightGeneration, runGuardedGeneration } from "./generationGuard";
 import { canGenerate, increment } from "./messengerQuota";
 import { isDebugLogEnabled } from "./logLevel";
+import { createLogger } from "./logger";
 
 type HandlerDeps = {
   defaultLang: Lang;
   privacyPolicyUrl: string;
+};
+
+type MessengerEventContext = {
+  psid: string;
+  userId: string;
+  reqId: string;
+  lang: Lang;
 };
 
 const GREETINGS = new Set(["hi", "hello", "hey", "yo", "hola"]);
@@ -59,50 +67,86 @@ const SMALLTALK = new Set([
 ]);
 
 const IN_FLIGHT_MESSAGE = "\u23F3 even geduld, ik ben nog bezig met jouw restyle";
-const inFlightNoticeSent = new Set();
+const inFlightNoticeSent = new Set<string>();
 
-export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: HandlerDeps) {
-  function debugWebhookLog(message: Record<string, unknown>): void {
-    if (!isDebugLogEnabled()) {
+function getAttachmentHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+function createMessengerSender(reqId: string) {
+  const logger = createLogger({ reqId, debugEnabled: isDebugLogEnabled() });
+
+  async function sendLoggedText(psid: string, text: string): Promise<void> {
+    logger.debug({
+      msg: "outgoing_message",
+      kind: "text",
+      psidHash: anonymizePsid(psid).slice(0, 12),
+      text,
+    });
+    await sendText(psid, text);
+  }
+
+  async function sendLoggedQuickReplies(
+    psid: string,
+    text: string,
+    replies: Parameters<typeof sendQuickReplies>[2],
+  ): Promise<void> {
+    logger.debug({
+      msg: "outgoing_message",
+      kind: "quick_replies",
+      psidHash: anonymizePsid(psid).slice(0, 12),
+      text,
+      quickReplies: replies.map(reply => ({
+        title: reply.title,
+        payload: reply.payload,
+      })),
+    });
+    await sendQuickReplies(psid, text, replies);
+  }
+
+  async function sendLoggedImage(psid: string, imageUrl: string): Promise<void> {
+    logger.debug({
+      msg: "outgoing_message",
+      kind: "image",
+      psidHash: anonymizePsid(psid).slice(0, 12),
+      imageUrl,
+    });
+    await sendImage(psid, imageUrl);
+  }
+
+  async function sendStateQuickReplies(
+    psid: string,
+    state: ConversationState,
+    text: string,
+  ): Promise<void> {
+    const replies = toMessengerReplies(state);
+    if (replies.length === 0) {
+      await sendLoggedText(psid, text);
       return;
     }
 
-    console.log(JSON.stringify(message));
+    await sendLoggedQuickReplies(psid, text, replies);
   }
 
-  function getAttachmentHostname(url: string): string | null {
-    try {
-      return new URL(url).hostname || null;
-    } catch {
-      return null;
-    }
-  }
+  return {
+    sendLoggedText,
+    sendLoggedQuickReplies,
+    sendLoggedImage,
+    sendStateQuickReplies,
+  };
+}
 
-  async function maybeSendInFlightMessage(psid: string, reqId: string) {
-    if (!(await hasInFlightGeneration(psid))) {
-      inFlightNoticeSent.delete(psid);
-      return false;
-    }
+function createEventLogger(reqId: string) {
+  const logger = createLogger({ reqId, debugEnabled: isDebugLogEnabled() });
 
-    if (inFlightNoticeSent.has(psid)) {
-      return true;
-    }
-
-    inFlightNoticeSent.add(psid);
-    await sendLoggedText(psid, IN_FLIGHT_MESSAGE, reqId);
-    return true;
-  }
-
-  function logIncomingMessage(
-    psid: string,
-    userId: string,
-    event: FacebookWebhookEvent,
-    reqId: string
-  ): void {
-    debugWebhookLog({
-        level: "debug",
+  return {
+    logIncomingMessage(psid: string, userId: string, event: FacebookWebhookEvent): void {
+      logger.debug({
         msg: "incoming_message",
-        reqId,
         user: toLogUser(userId),
         psidHash: anonymizePsid(psid).slice(0, 12),
         isEcho: Boolean(event.message?.is_echo),
@@ -112,24 +156,20 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
           event.message?.attachments?.map(attachment => ({
             type: attachment.type,
             hasUrl: Boolean(attachment.payload?.url),
-        })) ?? [],
+          })) ?? [],
         postbackPayload: event.postback?.payload ?? null,
         referralRef: event.postback?.referral?.ref ?? event.referral?.ref ?? null,
       });
-  }
-
-  function logUserState(
-    psid: string,
-    userId: string,
-    state: Awaited<ReturnType<typeof getOrCreateState>>,
-    reqId: string,
-    context: string
-  ): void {
-    debugWebhookLog({
-        level: "debug",
+    },
+    logUserState(
+      psid: string,
+      userId: string,
+      state: Awaited<ReturnType<typeof getOrCreateState>>,
+      context: string,
+    ): void {
+      logger.debug({
         msg: "user_state",
         context,
-        reqId,
         user: toLogUser(userId),
         psidHash: anonymizePsid(psid).slice(0, 12),
         stage: state.stage,
@@ -139,364 +179,302 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
         preselectedStyle: state.preselectedStyle ?? null,
         preferredLang: state.preferredLang ?? null,
       });
-  }
-
-  async function sendLoggedText(psid: string, text: string, reqId: string): Promise<void> {
-    debugWebhookLog({
-        level: "debug",
-        msg: "outgoing_message",
-        kind: "text",
-        reqId,
+    },
+    logPhotoReceived(psid: string, imageUrl: string): void {
+      logger.debug({
+        msg: "photo_received",
         psidHash: anonymizePsid(psid).slice(0, 12),
-        text,
+        hasAttachments: true,
+        attachmentHostname: getAttachmentHostname(imageUrl),
       });
-    await sendText(psid, text);
-  }
-
-  async function sendLoggedQuickReplies(
-    psid: string,
-    text: string,
-    replies: Parameters<typeof sendQuickReplies>[2],
-    reqId: string
-  ): Promise<void> {
-    debugWebhookLog({
-        level: "debug",
-        msg: "outgoing_message",
-        kind: "quick_replies",
-        reqId,
+    },
+    logQuotaDecision(psid: string, count: number, allowed: boolean, bypassApplied: boolean): void {
+      logger.info({
+        msg: "quota_decision",
+        action: "check",
         psidHash: anonymizePsid(psid).slice(0, 12),
-        text,
-        quickReplies: replies.map(reply => ({
-          title: reply.title,
-          payload: reply.payload,
-        })),
+        count,
+        limit: 2,
+        bypassApplied,
+        allowed,
       });
-    await sendQuickReplies(psid, text, replies);
-  }
-
-  async function sendLoggedImage(psid: string, imageUrl: string, reqId: string): Promise<void> {
-    debugWebhookLog({
-        level: "debug",
-        msg: "outgoing_message",
-        kind: "image",
-        reqId,
+    },
+    logGenerationSummary(psid: string, style: Style, mode: string, metrics: Record<string, number>): void {
+      logger.info({
+        msg: "generation_summary",
         psidHash: anonymizePsid(psid).slice(0, 12),
-        imageUrl,
+        mode,
+        style,
+        ok: true,
+        fb_image_fetch_ms: metrics.fbImageFetchMs,
+        openai_ms: metrics.openAiMs,
+        upload_or_serve_ms: metrics.uploadOrServeMs,
+        total_ms: metrics.totalMs,
       });
-    await sendImage(psid, imageUrl);
-  }
+    },
+    logProof(fields: Record<string, unknown>): void {
+      logger.info({ msg: "proof_summary", ...fields });
+    },
+    logGenerationError(psid: string, error: unknown): void {
+      logger.error({
+        msg: "openai_call_error",
+        psidHash: anonymizePsid(psid).slice(0, 12),
+        error: error instanceof Error ? error.message : undefined,
+      });
+    },
+  };
+}
 
-  async function sendStateQuickReplies(
-    psid: string,
-    state: ConversationState,
-    text: string,
-    reqId: string
-  ): Promise<void> {
-    const replies = toMessengerReplies(state);
-    if (replies.length === 0) {
-      await sendLoggedText(psid, text, reqId);
-      return;
+export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: HandlerDeps) {
+  async function maybeSendInFlightMessage(ctx: MessengerEventContext): Promise<boolean> {
+    if (!(await hasInFlightGeneration(ctx.psid))) {
+      inFlightNoticeSent.delete(ctx.psid);
+      return false;
     }
 
-    await sendLoggedQuickReplies(psid, text, replies, reqId);
+    if (inFlightNoticeSent.has(ctx.psid)) {
+      return true;
+    }
+
+    const sender = createMessengerSender(ctx.reqId);
+    inFlightNoticeSent.add(ctx.psid);
+    await sender.sendLoggedText(ctx.psid, IN_FLIGHT_MESSAGE);
+    return true;
   }
 
-  async function sendStylePicker(psid: string, lang: Lang, reqId: string): Promise<void> {
-    await sendStateQuickReplies(psid, "AWAITING_STYLE", t(lang, "stylePicker"), reqId);
+  async function sendStylePicker(ctx: MessengerEventContext): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    await sender.sendStateQuickReplies(ctx.psid, "AWAITING_STYLE", t(ctx.lang, "stylePicker"));
   }
 
-  async function sendPhotoReceivedPrompt(
-    psid: string,
-    lang: Lang,
-    reqId: string
-  ): Promise<void> {
-    await sendStylePicker(psid, lang, reqId);
+  async function sendIntro(ctx: MessengerEventContext): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    await sender.sendStateQuickReplies(ctx.psid, "IDLE", t(ctx.lang, "flowExplanation"));
   }
 
-  async function sendIntro(psid: string, lang: Lang, reqId: string): Promise<void> {
-    await sendStateQuickReplies(psid, "IDLE", t(lang, "flowExplanation"), reqId);
-  }
-
-  async function sendReferralPhotoPrompt(
-    psid: string,
-    style: Style,
-    lang: Lang,
-    reqId: string
-  ): Promise<void> {
+  async function sendReferralPhotoPrompt(ctx: MessengerEventContext, style: Style): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
     const styleLabel = STYLE_LABELS[style];
     const text =
-      lang === "en"
+      ctx.lang === "en"
         ? `You came in via ${styleLabel}. Send a photo to start `
         : `Je bent binnengekomen via ${styleLabel}. Stuur een foto om te starten `;
-    await sendLoggedText(psid, text, reqId);
+    await sender.sendLoggedText(ctx.psid, text);
   }
 
-  async function runStyleGeneration(
-    psid: string,
-    userId: string,
-    style: Style,
-    reqId: string,
-    lang: Lang
-  ): Promise<void> {
-    const didRun = await runGuardedGeneration(psid, async () => {
+  async function runStyleGeneration(ctx: MessengerEventContext, style: Style): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    const eventLogger = createEventLogger(ctx.reqId);
+
+    const didRun = await runGuardedGeneration(ctx.psid, async () => {
       const { mode, generator } = createImageGenerator();
-      const allowed = await canGenerate(psid);
-      const quotaState = await getOrCreateState(psid);
+      const allowed = await canGenerate(ctx.psid);
+      const quotaState = await getOrCreateState(ctx.psid);
       const bypassRaw = process.env.MESSENGER_QUOTA_BYPASS_IDS ?? "";
-      const bypassApplied = bypassRaw.includes(psid) || bypassRaw.includes(quotaState.userKey);
-      console.log(JSON.stringify({ level: "info", msg: "quota_decision", action: "check", psidHash: anonymizePsid(psid).slice(0, 12), count: quotaState.quota.count, limit: 2, bypassApplied, allowed }));
+      const bypassApplied = bypassRaw.includes(ctx.psid) || bypassRaw.includes(quotaState.userKey);
+      eventLogger.logQuotaDecision(ctx.psid, quotaState.quota.count, allowed, bypassApplied);
+
       if (!allowed) {
-        await sendLoggedText(psid, lang === "en" ? "You used your free credits for today. Come back tomorrow." : "Je hebt je gratis credits voor vandaag opgebruikt. Kom morgen terug.", reqId);
-        await setFlowState(psid, "AWAITING_STYLE");
+        await sender.sendLoggedText(
+          ctx.psid,
+          ctx.lang === "en"
+            ? "You used your free credits for today. Come back tomorrow."
+            : "Je hebt je gratis credits voor vandaag opgebruikt. Kom morgen terug.",
+        );
+        await setFlowState(ctx.psid, "AWAITING_STYLE");
         return;
       }
 
-      await setFlowState(psid, "PROCESSING");
-      await sendLoggedText(
-        psid,
-        t(lang, "generatingPrompt", { styleLabel: STYLE_LABELS[style] }),
-        reqId
-      );
+      await setFlowState(ctx.psid, "PROCESSING");
+      await sender.sendLoggedText(ctx.psid, t(ctx.lang, "generatingPrompt", { styleLabel: STYLE_LABELS[style] }));
 
-      const state = await getOrCreateState(psid);
-      const lastImageUrl = state.lastPhotoUrl;
+      const state = await getOrCreateState(ctx.psid);
 
       try {
         const { imageUrl, proof, metrics } = await generator.generate({
           style,
-          sourceImageUrl: lastImageUrl ?? undefined,
-          userKey: userId,
-          reqId,
+          sourceImageUrl: state.lastPhotoUrl ?? undefined,
+          userKey: ctx.userId,
+          reqId: ctx.reqId,
         });
 
-        console.info(
-          JSON.stringify({
-            level: "info",
-            msg: "generation_summary",
-            reqId,
-            psidHash: anonymizePsid(psid).slice(0, 12),
-            mode,
-            style,
-            ok: true,
-            fb_image_fetch_ms: metrics.fbImageFetchMs,
-            openai_ms: metrics.openAiMs,
-            upload_or_serve_ms: metrics.uploadOrServeMs,
-            total_ms: metrics.totalMs,
-          })
-        );
+        eventLogger.logGenerationSummary(ctx.psid, style, mode, metrics as Record<string, number>);
+        eventLogger.logProof({
+          style,
+          incomingLen: proof.incomingLen,
+          incomingSha256: proof.incomingSha256,
+          openaiInputLen: proof.openaiInputLen,
+          openaiInputSha256: proof.openaiInputSha256,
+          outputUrl: imageUrl,
+          totalMs: metrics.totalMs,
+          ok: true,
+          psidHash: anonymizePsid(ctx.psid).slice(0, 12),
+        });
 
-        console.log(
-          "PROOF_SUMMARY",
-          JSON.stringify({
-            reqId,
-            psidHash: anonymizePsid(psid).slice(0, 12),
-            style,
-            incomingLen: proof.incomingLen,
-            incomingSha256: proof.incomingSha256,
-            openaiInputLen: proof.openaiInputLen,
-            openaiInputSha256: proof.openaiInputSha256,
-            outputUrl: imageUrl,
-            totalMs: metrics.totalMs,
-            ok: true,
-          })
-        );
-
-        await sendLoggedImage(psid, imageUrl, reqId);
-        await increment(psid);
-        await setLastGenerated(psid, imageUrl);
-        await sendStateQuickReplies(psid, "RESULT_READY", t(lang, "success"), reqId);
-        await setFlowState(psid, "IDLE");
+        await sender.sendLoggedImage(ctx.psid, imageUrl);
+        await increment(ctx.psid);
+        await setLastGenerated(ctx.psid, imageUrl);
+        await sender.sendStateQuickReplies(ctx.psid, "RESULT_READY", t(ctx.lang, "success"));
+        await setFlowState(ctx.psid, "IDLE");
       } catch (error) {
-        console.error("OPENAI_CALL_ERROR", {
-          psidHash: anonymizePsid(psid).slice(0, 12),
-          error: error instanceof Error ? error.message : undefined,
-        });
+        eventLogger.logGenerationError(ctx.psid, error);
 
-        const errorClass =
-          error instanceof Error ? error.constructor.name : "UnknownError";
+        const errorClass = error instanceof Error ? error.constructor.name : "UnknownError";
         const metrics = getGenerationMetrics(error) ?? { totalMs: 0 };
 
-        console.log(
-          "PROOF_SUMMARY",
-          JSON.stringify({
-            reqId,
-            psidHash: anonymizePsid(psid).slice(0, 12),
-            style,
-            ok: false,
-            errorCode: errorClass,
-            totalMs: metrics.totalMs,
-          })
-        );
+        eventLogger.logProof({
+          style,
+          ok: false,
+          errorCode: errorClass,
+          totalMs: metrics.totalMs,
+          psidHash: anonymizePsid(ctx.psid).slice(0, 12),
+        });
 
-        let failureText = t(lang, "generationGenericFailure");
+        let failureText = t(ctx.lang, "generationGenericFailure");
         if (error instanceof MissingInputImageError) {
-          await sendLoggedText(psid, t(lang, "missingInputImage"), reqId);
-          await setFlowState(psid, "AWAITING_PHOTO");
+          await sender.sendLoggedText(ctx.psid, t(ctx.lang, "missingInputImage"));
+          await setFlowState(ctx.psid, "AWAITING_PHOTO");
           return;
-        } else if (
-          error instanceof MissingOpenAiApiKeyError ||
-          error instanceof MissingAppBaseUrlError
-        ) {
-          failureText = t(lang, "generationUnavailable");
-        } else if (error instanceof GenerationTimeoutError) {
-          failureText = t(lang, "generationTimeout");
         }
 
-        await sendLoggedText(psid, t(lang, "failure"), reqId);
-        await setFlowState(psid, "FAILURE");
+        if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
+          failureText = t(ctx.lang, "generationUnavailable");
+        } else if (error instanceof GenerationTimeoutError) {
+          failureText = t(ctx.lang, "generationTimeout");
+        }
 
-        await sendLoggedQuickReplies(psid, failureText, [
+        await sender.sendLoggedText(ctx.psid, t(ctx.lang, "failure"));
+        await setFlowState(ctx.psid, "FAILURE");
+        await sender.sendLoggedQuickReplies(ctx.psid, failureText, [
           {
             content_type: "text",
-            title: t(lang, "retryThisStyle"),
+            title: t(ctx.lang, "retryThisStyle"),
             payload: `RETRY_STYLE_${style}`,
           },
           {
             content_type: "text",
-            title: t(lang, "otherStyle"),
+            title: t(ctx.lang, "otherStyle"),
             payload: "CHOOSE_STYLE",
           },
-        ], reqId);
+        ]);
       }
     });
 
     if (didRun === null) {
-      await maybeSendInFlightMessage(psid, reqId);
+      await maybeSendInFlightMessage(ctx);
       return;
     }
-    inFlightNoticeSent.delete(psid);
+
+    inFlightNoticeSent.delete(ctx.psid);
   }
 
-  async function handleStyleSelection(
-    psid: string,
-    userId: string,
-    selectedStyle: Style,
-    reqId: string,
-    lang: Lang
-  ): Promise<void> {
-    const state = await getOrCreateState(psid);
+  async function handleStyleSelection(ctx: MessengerEventContext, selectedStyle: Style): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    const state = await getOrCreateState(ctx.psid);
     if (state.stage === "PROCESSING") {
-      await maybeSendInFlightMessage(psid, reqId);
+      await maybeSendInFlightMessage(ctx);
       return;
     }
 
-    await setChosenStyle(psid, selectedStyle);
+    await setChosenStyle(ctx.psid, selectedStyle);
     if (!state.lastPhotoUrl) {
-      await setFlowState(psid, "AWAITING_PHOTO");
-      await sendLoggedText(psid, t(lang, "styleWithoutPhoto"), reqId);
+      await setFlowState(ctx.psid, "AWAITING_PHOTO");
+      await sender.sendLoggedText(ctx.psid, t(ctx.lang, "styleWithoutPhoto"));
       return;
     }
 
-    await runStyleGeneration(psid, userId, selectedStyle, reqId, lang);
+    await runStyleGeneration(ctx, selectedStyle);
   }
 
-  async function handlePayload(
-    psid: string,
-    userId: string,
-    payload: string,
-    reqId: string,
-    lang: Lang
-  ): Promise<void> {
-    if (await maybeSendInFlightMessage(psid, reqId)) {
+  async function handlePayload(ctx: MessengerEventContext, payload: string): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+
+    if (await maybeSendInFlightMessage(ctx)) {
       return;
     }
 
     if (payload.startsWith("RETRY_STYLE_")) {
       const retryStyle = normalizeStyle(payload.slice("RETRY_STYLE_".length));
       if (retryStyle) {
-        await runStyleGeneration(psid, userId, retryStyle, reqId, lang);
+        await runStyleGeneration(ctx, retryStyle);
         return;
       }
     }
 
     const selectedStyle = stylePayloadToStyle(payload);
     if (selectedStyle) {
-      await handleStyleSelection(psid, userId, selectedStyle, reqId, lang);
+      await handleStyleSelection(ctx, selectedStyle);
       return;
     }
 
     if (payload === "CHOOSE_STYLE") {
-      await setPreselectedStyle(psid, null);
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendStylePicker(psid, lang, reqId);
+      await setPreselectedStyle(ctx.psid, null);
+      await setFlowState(ctx.psid, "AWAITING_STYLE");
+      await sendStylePicker(ctx);
       return;
     }
 
     if (payload === "RETRY_STYLE") {
-      const chosenStyle = (await getOrCreateState(psid)).selectedStyle;
+      const chosenStyle = (await getOrCreateState(ctx.psid)).selectedStyle;
       const retryStyle = chosenStyle ? parseStyle(chosenStyle) : undefined;
 
       if (retryStyle) {
-        await handleStyleSelection(psid, userId, retryStyle, reqId, lang);
+        await handleStyleSelection(ctx, retryStyle);
         return;
       }
 
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendStylePicker(psid, lang, reqId);
+      await setFlowState(ctx.psid, "AWAITING_STYLE");
+      await sendStylePicker(ctx);
       return;
     }
 
     if (payload === "WHAT_IS_THIS") {
-      await sendLoggedText(psid, t(lang, "flowExplanation"), reqId);
+      await sender.sendLoggedText(ctx.psid, t(ctx.lang, "flowExplanation"));
       return;
     }
 
     if (payload === "PRIVACY_INFO") {
-      await sendLoggedText(psid, t(lang, "privacy", { link: privacyPolicyUrl }), reqId);
+      await sender.sendLoggedText(ctx.psid, t(ctx.lang, "privacy", { link: privacyPolicyUrl }));
       return;
     }
 
-    safeLog("unknown_payload", { user: toLogUser(userId) });
+    safeLog("unknown_payload", { user: toLogUser(ctx.userId) });
   }
 
-  async function handleMessage(
-    psid: string,
-    userId: string,
-    event: FacebookWebhookEvent,
-    reqId: string,
-    lang: Lang
-  ): Promise<void> {
+  async function handleMessage(ctx: MessengerEventContext, event: FacebookWebhookEvent): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    const eventLogger = createEventLogger(ctx.reqId);
     const message = event.message;
     if (!message || message.is_echo) return;
-    await setLastUserMessageAt(psid, event.timestamp ?? Date.now());
+    await setLastUserMessageAt(ctx.psid, event.timestamp ?? Date.now());
 
-    if (await maybeSendInFlightMessage(psid, reqId)) {
+    if (await maybeSendInFlightMessage(ctx)) {
       return;
     }
 
     const quickPayload = message.quick_reply?.payload;
     if (quickPayload) {
-      await handlePayload(psid, userId, quickPayload, reqId, lang);
+      await handlePayload(ctx, quickPayload);
       return;
     }
 
-    const imageAttachment = message.attachments?.find(
-      att => att.type === "image" && att.payload?.url
-    );
+    const imageAttachment = message.attachments?.find(att => att.type === "image" && att.payload?.url);
     if (imageAttachment?.payload?.url) {
-      debugWebhookLog({
-          level: "debug",
-          msg: "photo_received",
-          reqId,
-          psidHash: anonymizePsid(psid).slice(0, 12),
-          hasAttachments: !!message.attachments,
-          attachmentHostname: getAttachmentHostname(imageAttachment.payload.url),
-        });
-
-      const state = await getOrCreateState(psid);
-      logUserState(psid, userId, state, reqId, "image_received");
+      eventLogger.logPhotoReceived(ctx.psid, imageAttachment.payload.url);
+      const state = await getOrCreateState(ctx.psid);
+      eventLogger.logUserState(ctx.psid, ctx.userId, state, "image_received");
       const preselectedStyle = normalizeStyle(state.preselectedStyle ?? "");
-      await setPendingImage(psid, imageAttachment.payload.url);
+      await setPendingImage(ctx.psid, imageAttachment.payload.url);
 
       if (preselectedStyle) {
-        await setPreselectedStyle(psid, null);
-        await setChosenStyle(psid, preselectedStyle);
-        await runStyleGeneration(psid, userId, preselectedStyle, reqId, lang);
+        await setPreselectedStyle(ctx.psid, null);
+        await setChosenStyle(ctx.psid, preselectedStyle);
+        await runStyleGeneration(ctx, preselectedStyle);
         return;
       }
 
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendPhotoReceivedPrompt(psid, lang, reqId);
+      await setFlowState(ctx.psid, "AWAITING_STYLE");
+      await sendStylePicker(ctx);
       return;
     }
 
@@ -514,41 +492,41 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
     }
 
     if (GREETINGS.has(normalizedText) || SMALLTALK.has(normalizedText)) {
-      const state = await getOrCreateState(psid);
-      logUserState(psid, userId, state, reqId, "greeting");
+      const state = await getOrCreateState(ctx.psid);
+      eventLogger.logUserState(ctx.psid, ctx.userId, state, "greeting");
       if (!state.hasSeenIntro && state.stage === "IDLE") {
-        await sendIntro(psid, lang, reqId);
-        await markIntroSeen(psid);
+        await sendIntro(ctx);
+        await markIntroSeen(ctx.psid);
         return;
       }
 
-      const response = getGreetingResponse(state.stage, lang);
+      const response = getGreetingResponse(state.stage, ctx.lang);
       if (response.mode === "text") {
-        await sendLoggedText(psid, response.text, reqId);
+        await sender.sendLoggedText(ctx.psid, response.text);
       } else {
-        await sendStateQuickReplies(psid, response.state, response.text, reqId);
+        await sender.sendStateQuickReplies(ctx.psid, response.state, response.text);
       }
       return;
     }
 
     if (normalizedText === "nieuwe stijl" || normalizedText === "new style") {
-      const quickState = await getOrCreateState(psid);
+      const quickState = await getOrCreateState(ctx.psid);
       if (quickState.lastPhotoUrl) {
-        await setFlowState(psid, "AWAITING_STYLE");
-        await sendStylePicker(psid, lang, reqId);
+        await setFlowState(ctx.psid, "AWAITING_STYLE");
+        await sendStylePicker(ctx);
         return;
       }
     }
 
-    const state = await getOrCreateState(psid);
-    logUserState(psid, userId, state, reqId, "text_message");
+    const state = await getOrCreateState(ctx.psid);
+    eventLogger.logUserState(ctx.psid, ctx.userId, state, "text_message");
     if (!state.lastPhotoUrl) {
-      await setFlowState(psid, "AWAITING_PHOTO");
-      await sendLoggedText(psid, t(lang, "textWithoutPhoto"), reqId);
+      await setFlowState(ctx.psid, "AWAITING_PHOTO");
+      await sender.sendLoggedText(ctx.psid, t(ctx.lang, "textWithoutPhoto"));
       return;
     }
 
-    await sendLoggedText(psid, t(lang, "flowExplanation"), reqId);
+    await sender.sendLoggedText(ctx.psid, t(ctx.lang, "flowExplanation"));
   }
 
   async function handleEvent(event: FacebookWebhookEvent, entryId?: string): Promise<void> {
@@ -557,11 +535,13 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
 
     const userId = toUserKey(psid);
     const reqId = `${psid}-${Date.now()}`;
+    const eventLogger = createEventLogger(reqId);
     const localeLang = normalizeLang(event.sender?.locale);
     const state = await getOrCreateState(psid);
-    logIncomingMessage(psid, userId, event, reqId);
-    logUserState(psid, userId, state, reqId, "handle_event");
+    eventLogger.logIncomingMessage(psid, userId, event);
+    eventLogger.logUserState(psid, userId, state, "handle_event");
     const lang = state.preferredLang || localeLang || defaultLang;
+    const ctx: MessengerEventContext = { psid, userId, reqId, lang };
 
     if (localeLang && localeLang !== state.preferredLang) {
       await setPreferredLang(psid, localeLang);
@@ -579,27 +559,24 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
       }
     }
 
-    const referralStyle = parseReferralStyle(
-      event.postback?.referral?.ref ?? event.referral?.ref
-    );
+    const referralStyle = parseReferralStyle(event.postback?.referral?.ref ?? event.referral?.ref);
     if (referralStyle) {
       await clearPendingImageState(psid);
       await setPreselectedStyle(psid, referralStyle);
       await setFlowState(psid, "AWAITING_PHOTO");
-      return sendReferralPhotoPrompt(psid, referralStyle, lang, reqId);
-    }
-
-    if (event.postback?.payload) {
-      await handlePayload(psid, userId, event.postback.payload, reqId, lang);
+      await sendReferralPhotoPrompt(ctx, referralStyle);
       return;
     }
 
-    await handleMessage(psid, userId, event, reqId, lang);
+    if (event.postback?.payload) {
+      await handlePayload(ctx, event.postback.payload);
+      return;
+    }
+
+    await handleMessage(ctx, event);
   }
 
-  async function processFacebookWebhookPayload(
-    payload: unknown
-  ): Promise<void> {
+  async function processFacebookWebhookPayload(payload: unknown): Promise<void> {
     const entries = Array.isArray((payload as { entry?: unknown[] } | null | undefined)?.entry)
       ? ((payload as { entry: FacebookWebhookEntry[] }).entry ?? [])
       : [];


### PR DESCRIPTION
### Motivation
- Reduce complexity in state normalization by removing legacy migration branches and keep only canonical state fields for clarity and maintainability.
- Improve maintainability and testability of webhook processing by splitting a large monolithic handler into smaller, single-responsibility helpers.
- Centralize logging to ensure consistent JSON-formatted logs, supported log levels, and optional request-scoped IDs for easier observability.

### Description
- Simplified `normalizeState` in `server/_core/messengerState.ts` by removing legacy keys (`currentStep`, `style`, `lastImage`) and consolidating canonical field fallbacks (`stage/state`, `lastPhotoUrl/lastPhoto`, `selectedStyle/chosenStyle`, `lastGeneratedUrl/lastImageUrl`).
- Introduced a new structured logger `createLogger` at `server/_core/logger.ts` that emits JSON logs and exposes `debug`, `info`, and `error` methods with optional `reqId` injection.
- Refactored `createWebhookHandlers` in `server/_core/webhookHandlers.ts` into focused helper factories and functions including `createMessengerSender`, `createEventLogger`, `runStyleGeneration`, `handlePayload`, `handleMessage`, and smaller routing utilities to improve SRP and reduce boilerplate.
- Replaced ad-hoc `console.log`/`console.error` usage in webhook flows with the centralized logger and moved to request-scoped logging where appropriate.

### Testing
- Ran unit/integration tests with `pnpm -s vitest run server/messengerState.test.ts server/messengerWebhook.test.ts` and all tests passed.  
- Test run summary: 2 test files, 32 tests executed, 32 passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12c31995c8325b01c6ab247d86821)