### PR TITLE
docs: add JSDoc/TSDoc documentation standards to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ pnpm db:push
 
 The repository includes focused unit tests for webhook handling, state transitions, signature verification, and image generation behavior under mock/OpenAI configuration.
 
+## Documentation standards
+
+- Prefer JSDoc/TSDoc comments for exported functions, classes, interfaces, and non-trivial internal helpers.
+- Write comments so they are parsable by tooling (for example, typed params/returns and clear behavior notes), making API-document generation easier.
+- Keep documentation comments synchronized with implementation changes; when behavior, inputs, or outputs change, update the docblock in the same PR.
+- Remove stale comments rather than leaving outdated guidance in place.
+
 ## Admin login (GitHub OAuth)
 
 The same server can protect `/admin` using GitHub OAuth and a simple allowlist.


### PR DESCRIPTION
### Motivation
- Encourage consistent, tool-parsable source documentation so exported functions, classes, and interfaces are easy to document, discover, and keep accurate.

### Description
- Add a new **Documentation standards** section to `README.md` that recommends using JSDoc/TSDoc for exported functions, classes, interfaces, and non-trivial helpers and instructs maintainers to keep or remove comments in sync with code changes.

### Testing
- Documentation-only change so no runtime tests were necessary; the `README.md` diff was reviewed locally to confirm the new guidance was added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12be2b8688325832b9e7bbf16b6df)