### PR TITLE
Refactor server/_core into domain entrypoints

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,3 +184,14 @@ See README env section for operationally relevant variables.
 - Inbound dedupe reduces duplicate event processing.
 - Generation failures produce user-facing retry options.
 - Health endpoints + version endpoint support simple monitoring.
+
+## 8) Core module boundaries
+
+To keep `server/_core` from growing into a single flat namespace, domain entrypoints are now grouped by responsibility:
+
+- `server/_core/auth/index.ts` for auth-related bootstrap imports (OAuth route registration and auth env assertions).
+- `server/_core/messenger/index.ts` for webhook ingress concerns (raw-body capture, signature verification, webhook route registration).
+- `server/_core/image-generation/index.ts` for image-generator startup wiring.
+
+These entrypoints let server bootstrap code import by domain while remaining backward compatible with existing module files.
+

--- a/server/_core/auth/index.ts
+++ b/server/_core/auth/index.ts
@@ -1,0 +1,2 @@
+export { registerOAuthRoutes } from "../oauth";
+export { assertAuthConfig } from "../env";

--- a/server/_core/image-generation/index.ts
+++ b/server/_core/image-generation/index.ts
@@ -1,0 +1,1 @@
+export { getGeneratorStartupConfig } from "../imageService";

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -3,21 +3,20 @@ import express from "express";
 import path from "path";
 import { createServer } from "http";
 import { createExpressMiddleware } from "@trpc/server/adapters/express";
-import { registerOAuthRoutes } from "./oauth";
+import { assertAuthConfig, registerOAuthRoutes } from "./auth";
 import { registerChatRoutes } from "./chat";
 import { appRouter } from "../routers";
 import { createContext } from "./context";
 import { serveStatic } from "./vite";
-import { registerMetaWebhookRoutes } from "./messengerWebhook";
-import { assertPrivacyConfig } from "./privacy";
-import { getGeneratorStartupConfig } from "./imageService";
-import { assertAuthConfig } from "./env";
-import { applySecurityHeaders } from "./securityHeaders";
-import { registerGitHubAdminRoutes } from "./githubAdmin";
 import {
   captureMetaWebhookRawBody,
+  registerMetaWebhookRoutes,
   verifyMetaWebhookSignature,
-} from "./webhookSignatureVerification";
+} from "./messenger";
+import { assertPrivacyConfig } from "./privacy";
+import { getGeneratorStartupConfig } from "./image-generation";
+import { applySecurityHeaders } from "./securityHeaders";
+import { registerGitHubAdminRoutes } from "./githubAdmin";
 import { isDebugLogEnabled } from "./logLevel";
 import { ensureStateStoreReady } from "./stateStore";
 import {

--- a/server/_core/messenger/index.ts
+++ b/server/_core/messenger/index.ts
@@ -1,0 +1,5 @@
+export { registerMetaWebhookRoutes } from "../messengerWebhook";
+export {
+  captureMetaWebhookRawBody,
+  verifyMetaWebhookSignature,
+} from "../webhookSignatureVerification";


### PR DESCRIPTION
### Motivation

- Prevent `server/_core` from becoming a flat, monolithic namespace by introducing small domain entrypoints that group related bootstrap imports. 

### Description

- Add `server/_core/auth/index.ts` to re-export auth-related bootstrap exports (`registerOAuthRoutes`, `assertAuthConfig`).
- Add `server/_core/messenger/index.ts` to re-export webhook ingress utilities (`captureMetaWebhookRawBody`, `verifyMetaWebhookSignature`, `registerMetaWebhookRoutes`).
- Add `server/_core/image-generation/index.ts` to re-export image generator startup wiring (`getGeneratorStartupConfig`).
- Update `server/_core/index.ts` to import the above domain entrypoints instead of importing those modules directly. 
- Document the new "Core module boundaries" section in `docs/architecture.md` to explain the new boundaries and rationale.

### Testing

- Ran `pnpm check` (TypeScript `tsc --noEmit`) which succeeded. 
- Ran `pnpm lint:server` (`eslint server`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12c56ae9c832588c23c77b84ae4d7)