### PR TITLE
Refactor webhook generation error handling and simplify state normalization

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -78,13 +78,7 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
   ],
 };
 
-type LegacyMessengerState = {
-  currentStep?: MessengerFlowState;
-  lastImage?: string | null;
-  style?: string | null;
-};
-
-type PartialState = Partial<MessengerUserState> & LegacyMessengerState;
+type PartialState = Partial<MessengerUserState>;
 
 function looksLikeUserKey(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value);
@@ -126,10 +120,10 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
 function normalizeState(psid: string, value: PartialState | null | undefined): MessengerUserState {
   const resolvedPsid = value?.psid ?? psid;
   const fallback = createDefaultState(resolvedPsid);
-  const stage = value?.stage ?? value?.state ?? value?.currentStep ?? fallback.stage;
-  const lastPhoto = value?.lastPhoto ?? value?.lastPhotoUrl ?? fallback.lastPhoto;
-  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? value?.style ?? fallback.selectedStyle;
-  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? value?.lastImage ?? fallback.lastGeneratedUrl;
+  const stage = value?.stage ?? value?.state ?? fallback.stage;
+  const lastPhoto = value?.lastPhotoUrl ?? value?.lastPhoto ?? fallback.lastPhotoUrl;
+  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? fallback.selectedStyle;
+  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? fallback.lastGeneratedUrl;
 
   return {
     ...fallback,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -328,24 +328,15 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
           })
         );
 
-        let failureText = t(lang, "generationGenericFailure");
-        if (error instanceof MissingInputImageError) {
-          await sendLoggedText(psid, t(lang, "missingInputImage"), reqId);
-          await setFlowState(psid, "AWAITING_PHOTO");
+        const errorResponse = getGenerationErrorResponse(error, lang);
+        await sendLoggedText(psid, errorResponse.introText, reqId);
+        await setFlowState(psid, errorResponse.nextState);
+
+        if (!errorResponse.failureText) {
           return;
-        } else if (
-          error instanceof MissingOpenAiApiKeyError ||
-          error instanceof MissingAppBaseUrlError
-        ) {
-          failureText = t(lang, "generationUnavailable");
-        } else if (error instanceof GenerationTimeoutError) {
-          failureText = t(lang, "generationTimeout");
         }
 
-        await sendLoggedText(psid, t(lang, "failure"), reqId);
-        await setFlowState(psid, "FAILURE");
-
-        await sendLoggedQuickReplies(psid, failureText, [
+        await sendLoggedQuickReplies(psid, errorResponse.failureText, [
           {
             content_type: "text",
             title: t(lang, "retryThisStyle"),
@@ -365,6 +356,41 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
       return;
     }
     inFlightNoticeSent.delete(psid);
+  }
+
+  function getGenerationErrorResponse(error: unknown, lang: Lang): {
+    introText: string;
+    failureText?: string;
+    nextState: ConversationState;
+  } {
+    if (error instanceof MissingInputImageError) {
+      return {
+        introText: t(lang, "missingInputImage"),
+        nextState: "AWAITING_PHOTO",
+      };
+    }
+
+    if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
+      return {
+        introText: t(lang, "failure"),
+        failureText: t(lang, "generationUnavailable"),
+        nextState: "FAILURE",
+      };
+    }
+
+    if (error instanceof GenerationTimeoutError) {
+      return {
+        introText: t(lang, "failure"),
+        failureText: t(lang, "generationTimeout"),
+        nextState: "FAILURE",
+      };
+    }
+
+    return {
+      introText: t(lang, "failure"),
+      failureText: t(lang, "generationGenericFailure"),
+      nextState: "FAILURE",
+    };
   }
 
   async function handleStyleSelection(


### PR DESCRIPTION
### Motivation
- Consolidate repetitive error messaging and flow-state setting in `runStyleGeneration` to reduce duplication and centralize error→response mapping.
- Remove legacy field fallbacks in state normalization to simplify `MessengerUserState` handling and make canonical fields the single source of truth.

### Description
- Introduced `getGenerationErrorResponse(error, lang)` in `server/_core/webhookHandlers.ts` to map generation errors to an `introText`, optional `failureText`, and `nextState`, and updated `runStyleGeneration` to use it instead of repeating `sendLoggedText`/`setFlowState` branches.
- Kept special-case behavior for missing input images while reducing duplicated messaging and only sending retry quick replies when appropriate, by relying on the helper's output.
- Simplified `normalizeState` in `server/_core/messengerState.ts` by removing legacy fallbacks (`currentStep`, `style`, `lastImage`) and narrowing `PartialState` to `Partial<MessengerUserState>` while preserving canonical fallback values.

### Testing
- Ran `pnpm -s vitest run server/messengerState.test.ts server/messengerWebhook.test.ts` and all tests passed (2 files, 32 tests).
- Ran `pnpm -s check` (TypeScript typecheck) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12c75b738832595719d48db767522)