### PR TITLE
Refactor messenger state normalization and webhook handler flow/error handling

### DIFF
--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -78,13 +78,7 @@ const QUICK_REPLIES_BY_STATE: Record<ConversationState, StateQuickReply[]> = {
   ],
 };
 
-type LegacyMessengerState = {
-  currentStep?: MessengerFlowState;
-  lastImage?: string | null;
-  style?: string | null;
-};
-
-type PartialState = Partial<MessengerUserState> & LegacyMessengerState;
+type PartialState = Partial<MessengerUserState>;
 
 function looksLikeUserKey(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value);
@@ -126,10 +120,10 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
 function normalizeState(psid: string, value: PartialState | null | undefined): MessengerUserState {
   const resolvedPsid = value?.psid ?? psid;
   const fallback = createDefaultState(resolvedPsid);
-  const stage = value?.stage ?? value?.state ?? value?.currentStep ?? fallback.stage;
-  const lastPhoto = value?.lastPhoto ?? value?.lastPhotoUrl ?? fallback.lastPhoto;
-  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? value?.style ?? fallback.selectedStyle;
-  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? value?.lastImage ?? fallback.lastGeneratedUrl;
+  const stage = value?.stage ?? value?.state ?? fallback.stage;
+  const lastPhoto = value?.lastPhotoUrl ?? value?.lastPhoto ?? fallback.lastPhotoUrl;
+  const selectedStyle = value?.selectedStyle ?? value?.chosenStyle ?? fallback.selectedStyle;
+  const lastGeneratedUrl = value?.lastGeneratedUrl ?? value?.lastImageUrl ?? fallback.lastGeneratedUrl;
 
   return {
     ...fallback,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -47,6 +47,13 @@ type HandlerDeps = {
   privacyPolicyUrl: string;
 };
 
+type MessengerEventContext = {
+  psid: string;
+  userId: string;
+  reqId: string;
+  lang: Lang;
+};
+
 const GREETINGS = new Set(["hi", "hello", "hey", "yo", "hola"]);
 const SMALLTALK = new Set([
   "how are you",
@@ -62,6 +69,13 @@ const IN_FLIGHT_MESSAGE = "\u23F3 even geduld, ik ben nog bezig met jouw restyle
 const inFlightNoticeSent = new Set();
 
 export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: HandlerDeps) {
+  function createMessengerSender(reqId: string) {
+    return {
+      sendText: async (psid: string, text: string) => sendLoggedText(psid, text, reqId),
+      sendStylePicker: async (psid: string, lang: Lang) => sendStylePicker(psid, lang, reqId),
+    };
+  }
+
   function debugWebhookLog(message: Record<string, unknown>): void {
     if (!isDebugLogEnabled()) {
       return;
@@ -328,24 +342,15 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
           })
         );
 
-        let failureText = t(lang, "generationGenericFailure");
-        if (error instanceof MissingInputImageError) {
-          await sendLoggedText(psid, t(lang, "missingInputImage"), reqId);
-          await setFlowState(psid, "AWAITING_PHOTO");
+        const errorResponse = getGenerationErrorResponse(error, lang);
+        await sendLoggedText(psid, errorResponse.introText, reqId);
+        await setFlowState(psid, errorResponse.nextState);
+
+        if (!errorResponse.failureText) {
           return;
-        } else if (
-          error instanceof MissingOpenAiApiKeyError ||
-          error instanceof MissingAppBaseUrlError
-        ) {
-          failureText = t(lang, "generationUnavailable");
-        } else if (error instanceof GenerationTimeoutError) {
-          failureText = t(lang, "generationTimeout");
         }
 
-        await sendLoggedText(psid, t(lang, "failure"), reqId);
-        await setFlowState(psid, "FAILURE");
-
-        await sendLoggedQuickReplies(psid, failureText, [
+        await sendLoggedQuickReplies(psid, errorResponse.failureText, [
           {
             content_type: "text",
             title: t(lang, "retryThisStyle"),
@@ -367,27 +372,59 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
     inFlightNoticeSent.delete(psid);
   }
 
-  async function handleStyleSelection(
-    psid: string,
-    userId: string,
-    selectedStyle: Style,
-    reqId: string,
-    lang: Lang
-  ): Promise<void> {
-    const state = await getOrCreateState(psid);
+  function getGenerationErrorResponse(error: unknown, lang: Lang): {
+    introText: string;
+    failureText?: string;
+    nextState: ConversationState;
+  } {
+    if (error instanceof MissingInputImageError) {
+      return {
+        introText: t(lang, "missingInputImage"),
+        nextState: "AWAITING_PHOTO",
+      };
+    }
+
+    if (error instanceof MissingOpenAiApiKeyError || error instanceof MissingAppBaseUrlError) {
+      return {
+        introText: t(lang, "failure"),
+        failureText: t(lang, "generationUnavailable"),
+        nextState: "FAILURE",
+      };
+    }
+
+    if (error instanceof GenerationTimeoutError) {
+      return {
+        introText: t(lang, "failure"),
+        failureText: t(lang, "generationTimeout"),
+        nextState: "FAILURE",
+      };
+    }
+
+    return {
+      introText: t(lang, "failure"),
+      failureText: t(lang, "generationGenericFailure"),
+      nextState: "FAILURE",
+    };
+  }
+
+  async function handleStyleSelection(ctx: MessengerEventContext, selectedStyle: Style): Promise<void> {
+    const sender = createMessengerSender(ctx.reqId);
+    const state = await getOrCreateState(ctx.psid);
+    const lang = ctx.lang;
+
     if (state.stage === "PROCESSING") {
-      await maybeSendInFlightMessage(psid, reqId);
+      await maybeSendInFlightMessage(ctx.psid, ctx.reqId);
       return;
     }
 
-    await setChosenStyle(psid, selectedStyle);
+    await setChosenStyle(ctx.psid, selectedStyle);
     if (!state.lastPhotoUrl) {
-      await setFlowState(psid, "AWAITING_PHOTO");
-      await sendLoggedText(psid, t(lang, "styleWithoutPhoto"), reqId);
+      await setFlowState(ctx.psid, "AWAITING_PHOTO");
+      await sender.sendText(ctx.psid, t(lang, "styleWithoutPhoto"));
       return;
     }
 
-    await runStyleGeneration(psid, userId, selectedStyle, reqId, lang);
+    await runStyleGeneration(ctx.psid, ctx.userId, selectedStyle, ctx.reqId, lang);
   }
 
   async function handlePayload(
@@ -411,7 +448,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
 
     const selectedStyle = stylePayloadToStyle(payload);
     if (selectedStyle) {
-      await handleStyleSelection(psid, userId, selectedStyle, reqId, lang);
+      await handleStyleSelection({ psid, userId, reqId, lang }, selectedStyle);
       return;
     }
 
@@ -427,7 +464,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
       const retryStyle = chosenStyle ? parseStyle(chosenStyle) : undefined;
 
       if (retryStyle) {
-        await handleStyleSelection(psid, userId, retryStyle, reqId, lang);
+        await handleStyleSelection({ psid, userId, reqId, lang }, retryStyle);
         return;
       }
 

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -350,7 +350,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
           return;
         }
 
-        await sendLoggedQuickReplies(psid, errorResponse.failureText, [
+        const retryReplies: Parameters<typeof sendQuickReplies>[2] = [
           {
             content_type: "text",
             title: t(lang, "retryThisStyle"),
@@ -361,7 +361,9 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
             title: t(lang, "otherStyle"),
             payload: "CHOOSE_STYLE",
           },
-        ], reqId);
+        ];
+
+        await sendLoggedQuickReplies(psid, errorResponse.failureText, retryReplies, reqId);
       }
     });
 


### PR DESCRIPTION
### Motivation

- Remove legacy state field mappings and simplify state normalization to avoid relying on deprecated keys.
- Centralize generation error handling to produce consistent user-facing messages and next-state transitions.
- Improve webhook handler structure by encapsulating sender logic and passing a compact event context to style selection.

### Description

- Dropped the `LegacyMessengerState` type and removed legacy fallbacks from `normalizeState`, consolidating which keys determine `stage`, `lastPhoto`, `selectedStyle`, and `lastGeneratedUrl` and using `createDefaultState` as the fallback. 
- Adjusted `normalizeState` mappings so `lastPhotoUrl`/`lastPhoto` and `lastGeneratedUrl` are resolved with the new consistent precedence. 
- Introduced `MessengerEventContext` and `createMessengerSender` to encapsulate `reqId`-scoped sending helpers and refactored `handleStyleSelection` to accept the context and use the sender. 
- Extracted `getGenerationErrorResponse` which maps error types (`MissingInputImageError`, `MissingOpenAiApiKeyError`, `MissingAppBaseUrlError`, `GenerationTimeoutError`, and default) to `introText`, optional `failureText`, and `nextState`, and replaced ad-hoc error handling in generation flow with this function. 
- Updated payload handling to construct and pass the new context where `handleStyleSelection` is invoked, and replaced direct calls to `sendStylePicker`/`sendLoggedText` with the encapsulated sender in the refactored path.

### Testing

- Ran the TypeScript typecheck and project build with `tsc` and the build succeeded. 
- Executed the unit test suite and integration tests related to webhook handling and state normalization and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b12c75b738832595719d48db767522)