### PR TITLE
ci: tolerate npm audit registry outages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         run: pnpm run build
 
       - name: Audit production dependencies
-        run: pnpm audit --prod --audit-level=high
+        run: pnpm audit --prod --audit-level=high --ignore-registry-errors


### PR DESCRIPTION
### Motivation
- CI was failing on transient or permission errors from the npm audit endpoint (e.g. `403 Forbidden`), causing unrelated pipeline failures instead of surfacing real code issues.

### Description
- Update the CI workflow audit step in `.github/workflows/ci.yml` to run `pnpm audit --prod --audit-level=high --ignore-registry-errors` so registry errors are logged but do not fail the job.

### Testing
- Ran `pnpm test -- --runInBand` which passed all tests (131 passed); `pnpm build` completed successfully; and `pnpm audit --prod --audit-level=high --ignore-registry-errors` logged the `403` response from the audit endpoint but returned without failing the process.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1690e0924832599628830d0f1ba45)