### PR TITLE
ci: prevent audit step from blocking pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,6 @@ jobs:
       - name: Build
         run: pnpm run build
 
-      - name: Audit production dependencies
+      - name: Audit production dependencies (non-blocking)
+        continue-on-error: true
         run: pnpm audit --prod --audit-level=high --ignore-registry-errors


### PR DESCRIPTION
### Motivation
- Keep the production `pnpm audit` in CI for visibility while preventing transient registry/auth/audit endpoint issues from causing whole PRs to fail.

### Description
- Updated `.github/workflows/ci.yml` to rename the audit step and add `continue-on-error: true` so `pnpm audit --prod --audit-level=high --ignore-registry-errors` runs but will not fail the job.

### Testing
- Ran `pnpm -s lint`, `pnpm -s test`, and `pnpm -s build` locally and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b16c8eb5548325b4a00e6820ee3101)