### PR TITLE
Add in-memory generated image store and publish flow with optional object storage

### DIFF
--- a/server/_core/generatedImageStore.ts
+++ b/server/_core/generatedImageStore.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_ITEMS = 200;
+
+type StoredImage = {
+  buffer: Buffer;
+  contentType: string;
+  expiresAt: number;
+};
+
+const generatedImages = new Map<string, StoredImage>();
+
+function getTtlMs(): number {
+  const raw = Number.parseInt(process.env.GENERATED_IMAGE_TTL_MS ?? "", 10);
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+
+  return DEFAULT_TTL_MS;
+}
+
+function getMaxItems(): number {
+  const raw = Number.parseInt(process.env.GENERATED_IMAGE_MAX_ITEMS ?? "", 10);
+  if (Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+
+  return DEFAULT_MAX_ITEMS;
+}
+
+function pruneExpired(now = Date.now()): void {
+  for (const [token, value] of generatedImages.entries()) {
+    if (value.expiresAt <= now) {
+      generatedImages.delete(token);
+    }
+  }
+}
+
+function pruneOverflow(): void {
+  const maxItems = getMaxItems();
+  if (generatedImages.size <= maxItems) {
+    return;
+  }
+
+  const overBy = generatedImages.size - maxItems;
+  const keys = generatedImages.keys();
+  for (let i = 0; i < overBy; i += 1) {
+    const next = keys.next();
+    if (next.done) {
+      break;
+    }
+    generatedImages.delete(next.value);
+  }
+}
+
+export function putGeneratedImage(buffer: Buffer, contentType = "image/jpeg"): string {
+  const now = Date.now();
+  pruneExpired(now);
+
+  const token = randomUUID();
+  generatedImages.set(token, {
+    buffer,
+    contentType,
+    expiresAt: now + getTtlMs(),
+  });
+
+  pruneOverflow();
+
+  return token;
+}
+
+export function getGeneratedImage(token: string): { buffer: Buffer; contentType: string } | null {
+  const now = Date.now();
+  const stored = generatedImages.get(token);
+  if (!stored) {
+    return null;
+  }
+
+  if (stored.expiresAt <= now) {
+    generatedImages.delete(token);
+    return null;
+  }
+
+  return {
+    buffer: stored.buffer,
+    contentType: stored.contentType,
+  };
+}
+
+export function buildGeneratedImageUrl(baseUrl: string, token: string): string {
+  return `${baseUrl}/generated/${encodeURIComponent(token)}.jpg`;
+}
+
+export function clearGeneratedImageStore(): void {
+  generatedImages.clear();
+}

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -5,6 +5,8 @@ import { STYLE_TO_DEMO_FILE, type Style } from "./messengerStyles";
 import fs from "fs/promises";
 import path from "path";
 import { safeLen, sha256 } from "./imageProof";
+import { buildGeneratedImageUrl, putGeneratedImage } from "./generatedImageStore";
+import { storagePut } from "../storage";
 
 export type GeneratorMode = "mock" | "openai";
 
@@ -91,33 +93,20 @@ function getRequiredPublicBaseUrl(): string {
   return baseUrl;
 }
 
-async function persistGeneratedJpg(buffer: Buffer, style: Style): Promise<string> {
-  const filename = `leaderbot-${style}-${Date.now()}.jpg`;
-  const relativeFilePath = path.join("generated", filename);
-  const publicRelativeFilePath = relativeFilePath.replaceAll(path.sep, "/");
-  const absoluteDirPath = path.resolve(process.cwd(), "public", "generated");
-  const absoluteFilePath = path.resolve(process.cwd(), "public", relativeFilePath);
-
-  await fs.mkdir(absoluteDirPath, { recursive: true });
-  await removeGeneratedWebpArtifacts(absoluteDirPath);
-  await fs.writeFile(absoluteFilePath, buffer);
-
-  const stats = await fs.stat(absoluteFilePath);
-  if (stats.size <= 0) {
-    throw new OpenAiGenerationError("Generated image file is empty");
-  }
-
-  return publicRelativeFilePath;
+function hasObjectStorageConfig(): boolean {
+  return Boolean(process.env.BUILT_IN_FORGE_API_URL?.trim() && process.env.BUILT_IN_FORGE_API_KEY?.trim());
 }
 
-async function removeGeneratedWebpArtifacts(dirPath: string): Promise<void> {
-  const entries = await fs.readdir(dirPath, { withFileTypes: true }).catch(() => []);
+async function publishGeneratedImage(jpegBuffer: Buffer, style: Style): Promise<string> {
+  if (hasObjectStorageConfig()) {
+    const key = `generated/${style}/${Date.now()}-${randomUUID()}.jpg`;
+    const { url } = await storagePut(key, jpegBuffer, "image/jpeg");
+    return url;
+  }
 
-  await Promise.all(
-    entries
-      .filter(entry => entry.isFile() && entry.name.endsWith(".webp"))
-      .map(entry => fs.unlink(path.join(dirPath, entry.name)).catch(() => undefined))
-  );
+  const token = putGeneratedImage(jpegBuffer, "image/jpeg");
+  const publicBaseUrl = getRequiredPublicBaseUrl();
+  return buildGeneratedImageUrl(publicBaseUrl, token);
 }
 
 function ensureJpegBuffer(buffer: Buffer): Buffer {
@@ -547,15 +536,18 @@ export class OpenAiImageGenerator implements ImageGenerator {
       }
 
       const imageBufferResult = Buffer.from(base64Image, "base64");
+      if (imageBufferResult.length <= 0) {
+        throw new OpenAiGenerationError("OpenAI response image data was empty after base64 decode");
+      }
+
       const jpegBuffer = ensureJpegBuffer(imageBufferResult);
       const uploadStartedAt = Date.now();
-      const relativeFilePath = await persistGeneratedJpg(jpegBuffer, input.style);
+      const imageUrl = await publishGeneratedImage(jpegBuffer, input.style);
       const uploadOrServeMs = Date.now() - uploadStartedAt;
       partialMetrics.uploadOrServeMs = uploadOrServeMs;
-      const publicBaseUrl = getRequiredPublicBaseUrl();
 
       return {
-        imageUrl: `${publicBaseUrl}/${relativeFilePath}`,
+        imageUrl,
         proof: {
           incomingLen,
           incomingSha256,

--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -17,6 +17,7 @@ import { assertPrivacyConfig } from "./privacy";
 import { getGeneratorStartupConfig } from "./image-generation";
 import { applySecurityHeaders } from "./securityHeaders";
 import { registerGitHubAdminRoutes } from "./githubAdmin";
+import { getGeneratedImage } from "./generatedImageStore";
 import { isDebugLogEnabled } from "./logLevel";
 import { ensureStateStoreReady } from "./stateStore";
 import {
@@ -360,10 +361,17 @@ async function startServer() {
     "/demo",
     express.static(path.join(publicDir, "demo"), { fallthrough: false })
   );
-  app.use(
-    "/generated",
-    express.static(path.join(publicDir, "generated"), { fallthrough: false })
-  );
+  app.get("/generated/:token.jpg", (req, res) => {
+    const generatedImage = getGeneratedImage(req.params.token);
+    if (!generatedImage) {
+      res.status(404).send("Not found");
+      return;
+    }
+
+    res.setHeader("Content-Type", generatedImage.contentType);
+    res.setHeader("Cache-Control", "private, no-store, max-age=0");
+    res.status(200).send(generatedImage.buffer);
+  });
   app.use(express.static(publicDir));
 
   if (process.env.NODE_ENV !== "production") {

--- a/server/_core/vite.ts
+++ b/server/_core/vite.ts
@@ -54,7 +54,7 @@ export async function setupVite(app: Express, server: Server, createViteServer: 
   });
 }
 
-export function serveStatic(app: Express, staticRoot?: string, generatedRoot?: string) {
+export function serveStatic(app: Express, staticRoot?: string) {
   app.use(createGlobalHttpRateLimiter());
 
   app.use(rateLimit({windowMs:DEFAULT_WINDOW_MS,limit:DEFAULT_MAX_REQUESTS,standardHeaders:true,legacyHeaders:false}));
@@ -71,15 +71,6 @@ export function serveStatic(app: Express, staticRoot?: string, generatedRoot?: s
       `Could not find a build directory. Tried: ${distPathCandidates.join(", ")}. Make sure to build the client first.`
     );
     return;
-  }
-
-  const generatedPathCandidates = generatedRoot
-    ? [path.resolve(generatedRoot)]
-    : [path.resolve(process.cwd(), "public", "generated")];
-  const generatedPath = generatedPathCandidates.find((candidate) => fs.existsSync(candidate));
-
-  if (generatedPath) {
-    app.use("/generated", express.static(generatedPath));
   }
 
   app.use(express.static(distPath));

--- a/server/generatedImageStore.test.ts
+++ b/server/generatedImageStore.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildGeneratedImageUrl, clearGeneratedImageStore, getGeneratedImage, putGeneratedImage } from "./_core/generatedImageStore";
+
+describe("generatedImageStore", () => {
+  afterEach(() => {
+    clearGeneratedImageStore();
+    delete process.env.GENERATED_IMAGE_TTL_MS;
+  });
+
+  it("stores generated images in memory and retrieves them by token", () => {
+    const token = putGeneratedImage(Buffer.from([1, 2, 3]), "image/jpeg");
+    const stored = getGeneratedImage(token);
+
+    expect(stored).not.toBeNull();
+    expect(stored?.contentType).toBe("image/jpeg");
+    expect(stored?.buffer).toEqual(Buffer.from([1, 2, 3]));
+  });
+
+  it("returns null after TTL expires", async () => {
+    process.env.GENERATED_IMAGE_TTL_MS = "5";
+    const token = putGeneratedImage(Buffer.from([9]), "image/jpeg");
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(getGeneratedImage(token)).toBeNull();
+  });
+
+  it("builds generated URL with token", () => {
+    const url = buildGeneratedImageUrl("https://example.com", "abc-123");
+    expect(url).toBe("https://example.com/generated/abc-123.jpg");
+  });
+});

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import fs from "fs/promises";
-import path from "path";
 import { InvalidSourceImageUrlError, OpenAiImageGenerator } from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
 
@@ -66,7 +64,7 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
     expect(result.metrics.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
@@ -144,7 +142,7 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -201,7 +199,7 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
   });
 
   it("blocks hosts outside SOURCE_IMAGE_ALLOWED_HOSTS before fetch", async () => {
@@ -305,43 +303,6 @@ describe("OpenAi image-to-image proof", () => {
     delete process.env.NODE_ENV;
   });
 
-  it("removes leftover generated webp files", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
-
-    const generatedDir = path.resolve(process.cwd(), "public", "generated");
-    await fs.mkdir(generatedDir, { recursive: true });
-    await fs.writeFile(path.join(generatedDir, "old-artifact.webp"), Buffer.from("webp"));
-
-    const fixture = Buffer.alloc(7000, 9);
-    const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "image/jpeg" }),
-          arrayBuffer: async () => fixture,
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
-    });
-
-    vi.stubGlobal("fetch", fetchMock);
-
-    const generator = new OpenAiImageGenerator();
-    await generator.generate({
-      style: "disco",
-      sourceImageUrl: "https://img.example/source.jpg",
-      userKey: "user-1",
-      reqId: "req-4",
-    });
-
-    await expect(fs.access(path.join(generatedDir, "old-artifact.webp"))).rejects.toThrow();
-  });
 
   it("retries OpenAI edits request on retryable status codes", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
@@ -387,7 +348,7 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -495,7 +456,43 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-disco-\d+\.jpg$/);
+    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("fails when OpenAI base64 payload decodes to an empty image buffer", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fixture = Buffer.alloc(7000, 9);
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: "!!!" }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-empty-output-buffer",
+      }),
+    ).rejects.toThrow("OpenAI response image data was empty after base64 decode");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/server/imageService.storage.test.ts
+++ b/server/imageService.storage.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
+
+function toUrlString(url: string | URL): string {
+  return typeof url === "string" ? url : url.toString();
+}
+
+describe("OpenAi image delivery via object storage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
+    delete process.env.BUILT_IN_FORGE_API_URL;
+    delete process.env.BUILT_IN_FORGE_API_KEY;
+    delete process.env.APP_BASE_URL;
+  });
+
+  it("uploads generated image to storage and returns signed URL", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+    process.env.BUILT_IN_FORGE_API_URL = "https://forge.example";
+    process.env.BUILT_IN_FORGE_API_KEY = "forge-secret";
+
+    const { OpenAiImageGenerator } = await import("./_core/imageService");
+
+    const sourceImage = Buffer.alloc(7000, 8);
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => sourceImage,
+        } as Response;
+      }
+
+      if (toUrlString(url) === "https://api.openai.com/v1/images/edits") {
+        return {
+          ok: true,
+          json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+        } as Response;
+      }
+
+      if (toUrlString(url).startsWith("https://forge.example/v1/storage/upload?path=generated%2Fdisco%2F")) {
+        expect(init?.method).toBe("POST");
+        expect(init?.headers).toEqual({ Authorization: "Bearer forge-secret" });
+        expect(init?.body).toBeInstanceOf(FormData);
+
+        return {
+          ok: true,
+          json: async () => ({ url: "https://cdn.example/generated/disco.jpg?signature=abc" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch url: ${toUrlString(url)}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    const result = await generator.generate({
+      style: "disco",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-storage-1",
+    });
+
+    expect(result.imageUrl).toBe("https://cdn.example/generated/disco.jpg?signature=abc");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -690,7 +690,7 @@ describe("messenger webhook dedupe", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(sendImageMock).toHaveBeenCalledWith(
       "openai-success-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/leaderbot-[a-z0-9-]+-\d+\.jpg$/),
+      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
     );
   });
 

--- a/server/serveStatic.production.test.ts
+++ b/server/serveStatic.production.test.ts
@@ -17,13 +17,6 @@ function createTempBuild() {
   return dir;
 }
 
-
-function createGeneratedAssets() {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "leaderbot-generated-"));
-  tempDirs.push(dir);
-  fs.writeFileSync(path.join(dir, "sample.jpg"), Buffer.from([255, 216, 255, 224]));
-  return dir;
-}
 async function listen(app: express.Express) {
   return await new Promise<{
     baseUrl: string;
@@ -92,28 +85,6 @@ describe("serveStatic production mode", () => {
       });
       expect(webhookResponse.status).toBe(200);
       expect(await webhookResponse.json()).toEqual({ received: true });
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("serves generated JPGs from /generated with image content type", async () => {
-    const app = express();
-    const staticDir = createTempBuild();
-    const generatedDir = createGeneratedAssets();
-
-    serveStatic(app, staticDir, generatedDir);
-
-    const server = await listen(app);
-
-    try {
-      const generatedResponse = await fetch(`${server.baseUrl}/generated/sample.jpg`);
-      expect(generatedResponse.status).toBe(200);
-      expect(generatedResponse.headers.get("content-type")).toContain("image/jpeg");
-
-      const missingGeneratedResponse = await fetch(`${server.baseUrl}/generated/missing.jpg`);
-      expect(missingGeneratedResponse.status).toBe(200);
-      expect(missingGeneratedResponse.headers.get("content-type")).toContain("text/html");
     } finally {
       await server.close();
     }


### PR DESCRIPTION
### Motivation
- Provide a lightweight way to serve OpenAI-generated images without writing files to disk and support optional object storage integration via environment configuration. 
- Prevent leaking generated assets on disk and make generated image URLs stable and secure with TTL and capacity controls. 

### Description
- Add `server/_core/generatedImageStore.ts` implementing an in-memory store with TTL, max-items eviction, `putGeneratedImage`, `getGeneratedImage`, `buildGeneratedImageUrl`, and `clearGeneratedImageStore`.
- Replace filesystem-based persistence in the image generation path with `publishGeneratedImage`, which uploads to built-in object storage via `storagePut` when `BUILT_IN_FORGE_API_URL`/`BUILT_IN_FORGE_API_KEY` are set, otherwise stores the JPEG in the in-memory store and returns a token URL built with `buildGeneratedImageUrl`.
- Add runtime `/generated/:token.jpg` handler in `server/_core/index.ts` to serve images from the in-memory store with appropriate headers and 404 handling, and remove static-serving of a `public/generated` folder from production static setup in `vite.ts`.
- Harden OpenAI response handling by validating the base64-decoded image buffer is non-empty and throw a clear `OpenAiGenerationError` if it decodes to empty.
- Update tests and add new tests: `server/generatedImageStore.test.ts` for the in-memory store, `server/imageService.storage.test.ts` for object-storage upload flow, and adjust expectations in `imageService.proof.test.ts` and other tests to match the new generated URL format.

### Testing
- Ran unit tests with `vitest`, including `generatedImageStore.test.ts`, `imageService.storage.test.ts`, and the updated `imageService.proof.test.ts`, and the updated suite passed locally. 
- Verified the OpenAI decode validation path via the added test that asserts an error is thrown when base64 decodes to an empty buffer. 
- Confirmed storage integration behavior by stubbing `fetch` in `imageService.storage.test.ts` and asserting the returned signed URL is used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b444e62e048325b81509f99c4b0d80)