### PR TITLE
add-oil-paint-style

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -104,9 +104,11 @@ export function getGeneratorStartupConfig(): { mode: GeneratorMode; resolvedBase
 
 function buildStylePrompt(style: Style, promptHint?: string): string {
   const basePrompt =
-    style === "cyberpunk"
-      ? "Apply cyberpunk aesthetic, neon-lit futuristic city, glowing signs, high contrast, cinematic sci-fi atmosphere, detailed digital art to this photo."
-      : `Apply ${style} style to this photo.`;
+    style === "oil-paint"
+      ? "Apply a classic oil painting portrait style to this photo, with visible brush strokes, textured canvas, painterly lighting, rich color depth, and a fine-art museum feel."
+      : style === "cyberpunk"
+        ? "Apply cyberpunk aesthetic, neon-lit futuristic city, glowing signs, high contrast, cinematic sci-fi atmosphere, detailed digital art to this photo."
+        : `Apply ${style} style to this photo.`;
 
   const trimmedPromptHint = promptHint?.trim();
   if (!trimmedPromptHint) {

--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -5,13 +5,15 @@ export type Style =
   | "clouds"
   | "cinematic"
   | "disco"
-  | "cyberpunk";
+  | "cyberpunk"
+  | "oil-paint";
 
 export type StyleId =
   | "STYLE_CARICATURE"
   | "STYLE_PETALS"
   | "STYLE_GOLD"
   | "STYLE_CINEMATIC"
+  | "STYLE_OIL_PAINT"
   | "STYLE_DISCO"
   | "STYLE_CLOUDS"
   | "STYLE_CYBERPUNK"
@@ -48,6 +50,12 @@ export const STYLE_CONFIGS: StyleConfig[] = [
     payload: "STYLE_CINEMATIC",
     style: "cinematic",
     label: "🎬 Cinematic",
+  },
+  {
+    id: "STYLE_OIL_PAINT",
+    payload: "STYLE_OIL_PAINT",
+    style: "oil-paint",
+    label: "🖼️ Oil Paint",
   },
   {
     id: "STYLE_CYBERPUNK",

--- a/server/_core/webhookHelpers.ts
+++ b/server/_core/webhookHelpers.ts
@@ -47,6 +47,7 @@ export const STYLE_OPTIONS: Style[] = [
   "petals",
   "gold",
   "cinematic",
+  "oil-paint",
   "cyberpunk",
   "disco",
   "clouds",
@@ -57,10 +58,25 @@ export const STYLE_LABELS: Record<Style, string> = {
   petals: "Petals",
   gold: "Gold",
   cinematic: "Cinematic",
+  "oil-paint": "Oil Paint",
   cyberpunk: "Cyberpunk",
   disco: "Disco",
   clouds: "Clouds",
 };
+
+const STYLE_ALIASES: Record<string, Style> = {
+  "oil paint": "oil-paint",
+  "oil painting": "oil-paint",
+  "oil-paint": "oil-paint",
+};
+
+function normalizeStyleToken(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ");
+}
 
 export type AckKind = "like" | "ok" | "thanks" | "emoji";
 
@@ -201,8 +217,13 @@ export function getGreetingResponse(state: ConversationState, lang: Lang = norma
 }
 
 export function normalizeStyle(input: string): Style | undefined {
-  const normalized = input.trim().toLowerCase();
-  return STYLE_OPTIONS.find(style => style === normalized);
+  const normalized = normalizeStyleToken(input);
+  const alias = STYLE_ALIASES[normalized];
+  if (alias) {
+    return alias;
+  }
+
+  return STYLE_OPTIONS.find(style => normalizeStyleToken(style) === normalized);
 }
 
 export function stylePayloadToStyle(payload: string): Style | undefined {
@@ -215,7 +236,7 @@ export function stylePayloadToStyle(payload: string): Style | undefined {
     return undefined;
   }
 
-  const styleKey = payload.slice("STYLE_".length).toLowerCase();
+  const styleKey = payload.slice("STYLE_".length).toLowerCase().replace(/_/g, "-");
   return normalizeStyle(styleKey);
 }
 

--- a/server/botFeatures.unit.test.ts
+++ b/server/botFeatures.unit.test.ts
@@ -66,6 +66,24 @@ describe("default feature registration", () => {
 });
 
 describe("styleCommandsFeature", () => {
+  it("accepts style aliases and resolves them to the canonical oil-paint key", async () => {
+    const chooseStyle = vi.fn(async () => undefined);
+    const context = makeContext({
+      state: makeState({
+        lastPhotoUrl: "https://img.example/source.jpg",
+        lastPhoto: "https://img.example/source.jpg",
+      }),
+      messageText: "style: oil painting",
+      normalizedText: "style: oil painting",
+      chooseStyle,
+    });
+
+    const handled = await styleCommandsFeature.onText?.(context);
+
+    expect(handled).toEqual({ handled: true });
+    expect(chooseStyle).toHaveBeenCalledWith("oil-paint");
+  });
+
   it("accepts /style cyberpunk and delegates style selection", async () => {
     const chooseStyle = vi.fn(async () => undefined);
     const context = makeContext({

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -150,6 +150,49 @@ describe("OpenAi image-to-image proof", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("uses the oil-paint preset prompt for OpenAI edits", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fixture = Buffer.alloc(7000, 9);
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      const formData = init?.body as FormData;
+      const prompt = String(formData.get("prompt"));
+      expect(prompt).toContain("classic oil painting portrait");
+      expect(prompt).toContain("visible brush strokes");
+      expect(prompt).toContain("textured canvas");
+      expect(prompt).toContain("painterly lighting");
+      expect(prompt).toContain("fine-art museum feel");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "oil-paint",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-oil-paint-prompt",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("hard-fails before OpenAI call when input image is too small", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";

--- a/server/messengerState.test.ts
+++ b/server/messengerState.test.ts
@@ -8,6 +8,7 @@ import {
   setFlowState,
   setPendingImage,
 } from "./_core/messengerState";
+import { STYLE_CONFIGS } from "./_core/messengerStyles";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
@@ -59,15 +60,9 @@ describe("messenger state flow", () => {
       { title: "Privacy", payload: "PRIVACY_INFO" },
     ]);
     expect(getQuickRepliesForState("AWAITING_PHOTO")).toEqual([]);
-    expect(getQuickRepliesForState("AWAITING_STYLE")).toEqual([
-      { title: "🎨 Caricature", payload: "STYLE_CARICATURE" },
-      { title: "🌸 Petals", payload: "STYLE_PETALS" },
-      { title: "✨ Gold", payload: "STYLE_GOLD" },
-      { title: "🎬 Cinematic", payload: "STYLE_CINEMATIC" },
-      { title: "🌃 Cyberpunk", payload: "STYLE_CYBERPUNK" },
-      { title: "🪩 Disco Glow", payload: "STYLE_DISCO" },
-      { title: "☁️ Clouds", payload: "STYLE_CLOUDS" },
-    ]);
+    expect(getQuickRepliesForState("AWAITING_STYLE")).toEqual(
+      STYLE_CONFIGS.map(style => ({ title: style.label, payload: style.payload })),
+    );
     expect(getQuickRepliesForState("PROCESSING")).toEqual([]);
     expect(getQuickRepliesForState("RESULT_READY")).toEqual([
       { title: "Remix", payload: "REMIX_LAST" },

--- a/server/messengerStyles.test.ts
+++ b/server/messengerStyles.test.ts
@@ -8,6 +8,7 @@ describe("messengerStyles", () => {
       "petals",
       "gold",
       "cinematic",
+      "oil-paint",
       "cyberpunk",
       "disco",
       "clouds",
@@ -16,8 +17,10 @@ describe("messengerStyles", () => {
 
   it("validates and resolves style payloads", () => {
     expect(isStylePayload("STYLE_CINEMATIC")).toBe(true);
+    expect(isStylePayload("STYLE_OIL_PAINT")).toBe(true);
     expect(isStylePayload("STYLE_CYBERPUNK")).toBe(true);
     expect(isStylePayload("UNKNOWN_STYLE")).toBe(false);
+    expect(getStyleById("STYLE_OIL_PAINT").label).toContain("Oil Paint");
     expect(getStyleById("STYLE_CYBERPUNK").label).toContain("Cyberpunk");
     expect(getStyleById("STYLE_DISCO").label).toContain("Disco");
   });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -28,6 +28,7 @@ import {
   resetMessengerEventDedupe,
   summarizeWebhook,
 } from "./_core/messengerWebhook";
+import { STYLE_CONFIGS } from "./_core/messengerStyles";
 import { anonymizePsid, getState, resetStateStore, setFlowState } from "./_core/messengerState";
 import { getEventDedupeKey } from "./_core/webhookHelpers";
 import { getBotFeatures } from "./_core/bot/features";
@@ -499,7 +500,7 @@ describe("messenger webhook dedupe", () => {
 
 
   it("returns generated images for all canonical styles through the OpenAI path", async () => {
-    const styles = ["caricature", "petals", "gold", "cinematic", "cyberpunk", "disco", "clouds"] as const;
+    const styles = STYLE_CONFIGS.map(style => style.style);
 
     for (const style of styles) {
       const fetchMock = installOpenAiSuccessFetchMock();
@@ -1268,15 +1269,11 @@ describe("messenger greeting behavior", () => {
     expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
       "style-user",
       "Kies je stijl 👇",
-      [
-        { content_type: "text", title: "🎨 Caricature", payload: "STYLE_CARICATURE" },
-        { content_type: "text", title: "🌸 Petals", payload: "STYLE_PETALS" },
-        { content_type: "text", title: "✨ Gold", payload: "STYLE_GOLD" },
-        { content_type: "text", title: "🎬 Cinematic", payload: "STYLE_CINEMATIC" },
-        { content_type: "text", title: "🌃 Cyberpunk", payload: "STYLE_CYBERPUNK" },
-        { content_type: "text", title: "🪩 Disco Glow", payload: "STYLE_DISCO" },
-        { content_type: "text", title: "☁️ Clouds", payload: "STYLE_CLOUDS" },
-      ],
+      STYLE_CONFIGS.map(style => ({
+        content_type: "text" as const,
+        title: style.label,
+        payload: style.payload,
+      })),
     );
   });
 

--- a/server/webhookHelpers.styleNormalization.test.ts
+++ b/server/webhookHelpers.styleNormalization.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { normalizeStyle, parseReferralStyle, parseStyle, stylePayloadToStyle } from "./_core/webhookHelpers";
+
+describe("style normalization", () => {
+  it("normalizes oil paint aliases to the canonical oil-paint key", () => {
+    expect(normalizeStyle("oil paint")).toBe("oil-paint");
+    expect(normalizeStyle("oil painting")).toBe("oil-paint");
+    expect(normalizeStyle("oil_paint")).toBe("oil-paint");
+    expect(normalizeStyle(" oil-paint ")).toBe("oil-paint");
+  });
+
+  it("applies canonical normalization through parse helpers", () => {
+    expect(parseStyle("oil painting")).toBe("oil-paint");
+    expect(stylePayloadToStyle("STYLE_OIL_PAINT")).toBe("oil-paint");
+    expect(parseReferralStyle("style_oil-paint")).toBe("oil-paint");
+  });
+});


### PR DESCRIPTION
 Add oil-paint as a first-class bot style with canonical normalization and prompt preset.

  This PR introduces a new reusable style preset, oil-paint, and wires it through the existing Messenger style pipeline without broad refactors. The style is now
  recognized as a canonical internal key, supported by payload parsing and alias normalization, and backed by a dedicated OpenAI prompt preset.

  What changed:

  - added oil-paint to the central style registry in server/_core/messengerStyles.ts
  - added canonical payload support via STYLE_OIL_PAINT
  - extended style normalization in server/_core/webhookHelpers.ts so inputs like oil paint, oil painting, oil_paint, and STYLE_OIL_PAINT all resolve to oil-paint
  - added a dedicated oil-paint prompt branch in server/_core/imageService.ts
  - updated config-driven quick reply expectations to reduce future test drift
  - added focused tests for normalization, prompt construction, and bot flow coverage

  Behavior:

  - the bot now recognizes oil-paint as a first-class style
  - text/payload/referral parsing all normalize to the same canonical internal style key: oil-paint
  - style quick replies automatically include the new option through the central config
  - image generation uses a dedicated oil-paint visual preset rather than the generic Apply <style> fallback

  Tests:

  - added server/webhookHelpers.styleNormalization.test.ts
  - updated server/messengerStyles.test.ts
  - updated server/messengerState.test.ts
  - updated server/botFeatures.unit.test.ts
  - updated server/imageService.proof.test.ts
  - updated server/messengerWebhook.test.ts

  Notes:

  - this keeps the change small and aligned with the existing style/prompt architecture
  - no changes were made to unrelated bot flows or feature boundaries