### PR TITLE
improve-stats-output

### DIFF
--- a/server/_core/bot/features/statsFeature.ts
+++ b/server/_core/bot/features/statsFeature.ts
@@ -14,6 +14,18 @@ function isAdmin(psid: string, userId: string): boolean {
   return allowed.has(psid) || allowed.has(userId);
 }
 
+function formatUptime(totalSeconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+
+  return `${minutes}m`;
+}
+
 export const statsFeature: BotFeature = {
   name: "stats",
   async onText(context) {
@@ -26,19 +38,22 @@ export const statsFeature: BotFeature = {
     }
 
     const stats = context.getRuntimeStats();
-    const avgLatency =
-      stats.averageGenerationLatencyMs === null
-        ? "n/a"
-        : `${stats.averageGenerationLatencyMs}ms`;
+    const avgLatency = `${stats.averageGenerationLatencyMs ?? 0}ms`;
+    const uptime = formatUptime(process.uptime());
 
     await context.sendText(
       [
-        `📊 ${stats.date}`,
-        `images generated: ${stats.imagesGeneratedToday}`,
-        `active users: ${stats.activeUsersToday}`,
-        `errors: ${stats.errorCountToday}`,
-        `avg latency: ${avgLatency}`,
-        "note: node-local debug metrics (reset on restart; not cross-instance)",
+        "Leaderbot Stats",
+        "",
+        `Images generated: ${stats.imagesGeneratedToday}`,
+        `Users: ${stats.activeUsersToday}`,
+        `Styles used: ${stats.stylesUsedToday}`,
+        `Errors: ${stats.errorCountToday}`,
+        `Avg latency: ${avgLatency}`,
+        "",
+        `Bot uptime: ${uptime}`,
+        "",
+        `Node-local stats for ${stats.date}`,
       ].join("\n")
     );
 

--- a/server/_core/botRuntimeStats.ts
+++ b/server/_core/botRuntimeStats.ts
@@ -1,7 +1,10 @@
+import type { Style } from "./messengerStyles";
+
 export type GenerationStatsSnapshot = {
   date: string;
   imagesGeneratedToday: number;
   activeUsersToday: number;
+  stylesUsedToday: number;
   errorCountToday: number;
   averageGenerationLatencyMs: number | null;
 };
@@ -12,6 +15,7 @@ type DayStats = {
   latencyTotalMs: number;
   latencyCount: number;
   activeUsers: Set<string>;
+  stylesUsed: Set<Style>;
 };
 
 const statsByDay = new Map<string, DayStats>();
@@ -33,6 +37,7 @@ function getDayStats(now = Date.now()): DayStats {
     latencyTotalMs: 0,
     latencyCount: 0,
     activeUsers: new Set<string>(),
+    stylesUsed: new Set<Style>(),
   };
   statsByDay.set(day, created);
   return created;
@@ -42,9 +47,10 @@ export function recordActiveUserToday(userId: string, now = Date.now()): void {
   getDayStats(now).activeUsers.add(userId);
 }
 
-export function recordGenerationSuccess(latencyMs: number, now = Date.now()): void {
+export function recordGenerationSuccess(style: Style, latencyMs: number, now = Date.now()): void {
   const stats = getDayStats(now);
   stats.imagesGenerated += 1;
+  stats.stylesUsed.add(style);
 
   if (Number.isFinite(latencyMs) && latencyMs >= 0) {
     stats.latencyTotalMs += latencyMs;
@@ -64,6 +70,7 @@ export function getTodayRuntimeStats(now = Date.now()): GenerationStatsSnapshot 
     date: day,
     imagesGeneratedToday: stats.imagesGenerated,
     activeUsersToday: stats.activeUsers.size,
+    stylesUsedToday: stats.stylesUsed.size,
     errorCountToday: stats.errors,
     averageGenerationLatencyMs:
       stats.latencyCount > 0 ? Math.round(stats.latencyTotalMs / stats.latencyCount) : null,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -450,7 +450,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
         await increment(psid);
         await setLastGenerated(psid, imageUrl);
         await setLastGenerationContext(psid, { style, prompt: promptHint });
-        recordGenerationSuccess(metrics.totalMs);
+        recordGenerationSuccess(style, metrics.totalMs);
         await sendStateQuickReplies(psid, "RESULT_READY", t(lang, "success"), reqId);
         await setFlowState(psid, "IDLE");
       } catch (error) {

--- a/server/botFeatures.unit.test.ts
+++ b/server/botFeatures.unit.test.ts
@@ -3,6 +3,7 @@ import { ensureDefaultBotFeaturesRegistered } from "./_core/bot/defaultFeatures"
 import { assistantCommandsFeature } from "./_core/bot/features/assistantCommandsFeature";
 import { remixFeature } from "./_core/bot/features/remixFeature";
 import { rateLimitFeature } from "./_core/bot/features/rateLimitFeature";
+import { statsFeature } from "./_core/bot/features/statsFeature";
 import { styleCommandsFeature } from "./_core/bot/features/styleCommandsFeature";
 import type { BotTextContext } from "./_core/botContext";
 import type { MessengerUserState } from "./_core/messengerState";
@@ -48,6 +49,7 @@ function makeContext(overrides: Partial<BotTextContext> = {}): BotTextContext {
       date: "2026-01-01",
       imagesGeneratedToday: 0,
       activeUsersToday: 0,
+      stylesUsedToday: 0,
       errorCountToday: 0,
       averageGenerationLatencyMs: null,
     }),
@@ -271,5 +273,71 @@ describe("assistantCommandsFeature", () => {
     expect(result).toEqual({ handled: true });
     expect(setFlowState).toHaveBeenCalledWith("AWAITING_PHOTO");
     expect(sendText).toHaveBeenCalledOnce();
+  });
+});
+
+describe("statsFeature", () => {
+  it("returns a readable admin-only stats block", async () => {
+    process.env.MESSENGER_ADMIN_IDS = "p1";
+    const sendText = vi.fn(async () => undefined);
+    const uptimeSpy = vi.spyOn(process, "uptime").mockReturnValue(3 * 3600 + 12 * 60);
+
+    try {
+      const result = await statsFeature.onText?.(
+        makeContext({
+          messageText: "/stats",
+          normalizedText: "/stats",
+          sendText,
+          getRuntimeStats: () => ({
+            date: "2026-03-16",
+            imagesGeneratedToday: 0,
+            activeUsersToday: 0,
+            stylesUsedToday: 0,
+            errorCountToday: 0,
+            averageGenerationLatencyMs: null,
+          }),
+        }),
+      );
+
+      expect(result).toEqual({ handled: true });
+      expect(sendText).toHaveBeenCalledWith(
+        [
+          "Leaderbot Stats",
+          "",
+          "Images generated: 0",
+          "Users: 0",
+          "Styles used: 0",
+          "Errors: 0",
+          "Avg latency: 0ms",
+          "",
+          "Bot uptime: 3h 12m",
+          "",
+          "Node-local stats for 2026-03-16",
+        ].join("\n"),
+      );
+    } finally {
+      uptimeSpy.mockRestore();
+      delete process.env.MESSENGER_ADMIN_IDS;
+    }
+  });
+
+  it("falls through for non-admin users", async () => {
+    process.env.MESSENGER_ADMIN_IDS = "someone-else";
+    const sendText = vi.fn(async () => undefined);
+
+    try {
+      const result = await statsFeature.onText?.(
+        makeContext({
+          messageText: "/stats",
+          normalizedText: "/stats",
+          sendText,
+        }),
+      );
+
+      expect(result).toEqual({ handled: false });
+      expect(sendText).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.MESSENGER_ADMIN_IDS;
+    }
   });
 });


### PR DESCRIPTION
 Stats behavior:

  - /stats now returns a cleaner block like:
      - Leaderbot Stats
      - Images generated
      - Users
      - Styles used
      - Errors
      - Avg latency
      - Bot uptime
  - no undefined
  - no n/a
  - still node-local runtime stats
  - still admin-only

  Tests:

  - added server/webhookHelpers.styleNormalization.test.ts
  - updated server/messengerStyles.test.ts
  - updated server/messengerState.test.ts
  - updated server/botFeatures.unit.test.ts
  - updated server/imageService.proof.test.ts
  - updated server/messengerWebhook.test.ts

  Notes:

  - no broad refactor
  - existing styles keep current behavior
  - /stats intentionally still requires the explicit /stats command form