### PR TITLE
feat: add Norman Blackwell style preset

### DIFF
--- a/server/_core/conversationalEditInterpreter.ts
+++ b/server/_core/conversationalEditInterpreter.ts
@@ -147,10 +147,7 @@ async function callResponsesApi(
   throw new Error("edit_interpreter_retry_exhausted");
 }
 
-function buildSystemPrompt(input: {
-  lang: Lang;
-  lastStyle?: Style;
-}): string {
+function buildSystemPrompt(input: { lang: Lang; lastStyle?: Style }): string {
   const language = input.lang === "en" ? "English" : "Dutch";
   const lastStyle = input.lastStyle ?? "unknown";
 
@@ -159,7 +156,7 @@ function buildSystemPrompt(input: {
     `The user language is ${language}.`,
     `The last known style is ${lastStyle}.`,
     "Only return JSON with no markdown.",
-    'Schema: {"shouldEdit":boolean,"style":"caricature"|"gold"|"petals"|"clouds"|"cinematic"|"disco"|"cyberpunk"|null,"promptHint":string|null}.',
+    'Schema: {"shouldEdit":boolean,"style":"caricature"|"gold"|"petals"|"clouds"|"cinematic"|"disco"|"cyberpunk"|"norman-blackwell"|null,"promptHint":string|null}.',
     "Set shouldEdit=true only when the user is asking to change the previous image.",
     "Use style only when the user explicitly asks for a known style or it is clearly implied.",
     "Put the visual change request into promptHint in concise plain text.",
@@ -186,7 +183,8 @@ function parseDecision(rawText: string): ConversationalEditDecision | null {
       parsed.style === "clouds" ||
       parsed.style === "cinematic" ||
       parsed.style === "disco" ||
-      parsed.style === "cyberpunk"
+      parsed.style === "cyberpunk" ||
+      parsed.style === "norman-blackwell"
         ? parsed.style
         : undefined;
 
@@ -227,6 +225,9 @@ export function looksLikePossibleEditRequest(text: string): boolean {
     "clouds",
     "disco",
     "cyberpunk",
+    "norman",
+    "blackwell",
+    "norman blackwell",
     "caricature",
     "background",
     "remove",

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -5,7 +5,10 @@ import { type Style } from "./messengerStyles";
 import fs from "fs/promises";
 import path from "path";
 import { safeLen, sha256 } from "./imageProof";
-import { buildGeneratedImageUrl, putGeneratedImage } from "./generatedImageStore";
+import {
+  buildGeneratedImageUrl,
+  putGeneratedImage,
+} from "./generatedImageStore";
 import { storagePut } from "../storage";
 
 export type GeneratorMode = "openai";
@@ -19,7 +22,12 @@ export interface ImageGenerator {
     reqId: string;
   }): Promise<{
     imageUrl: string;
-    proof: { incomingLen: number; incomingSha256: string; openaiInputLen: number; openaiInputSha256: string };
+    proof: {
+      incomingLen: number;
+      incomingSha256: string;
+      openaiInputLen: number;
+      openaiInputSha256: string;
+    };
     metrics: GenerationMetrics;
   }>;
 }
@@ -39,7 +47,9 @@ export type GenerationMetrics = {
   totalMs: number;
 };
 
-type ErrorWithGenerationMetrics = Error & { generationMetrics?: GenerationMetrics };
+type ErrorWithGenerationMetrics = Error & {
+  generationMetrics?: GenerationMetrics;
+};
 
 const MIN_INPUT_IMAGE_BYTES = 5 * 1024;
 const FB_IMAGE_FETCH_RETRY_LIMIT = 1;
@@ -48,13 +58,17 @@ const OPENAI_RETRY_BASE_MS_DEFAULT = 500;
 const OPENAI_TIMEOUT_MS_DEFAULT = 30_000;
 
 function getConfiguredBaseUrl(): string | undefined {
-  const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
+  const configuredBaseUrl =
+    process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
 
   if (!configuredBaseUrl || !/^https?:\/\//.test(configuredBaseUrl)) {
     return undefined;
   }
 
-  if (process.env.NODE_ENV === "production" && !configuredBaseUrl.startsWith("https://")) {
+  if (
+    process.env.NODE_ENV === "production" &&
+    !configuredBaseUrl.startsWith("https://")
+  ) {
     console.error("APP_BASE_URL must use https:// in production", {
       hasConfiguredBaseUrl: true,
       protocol: configuredBaseUrl.split(":")[0],
@@ -64,7 +78,6 @@ function getConfiguredBaseUrl(): string | undefined {
 
   return configuredBaseUrl.replace(/\/$/, "");
 }
-
 
 function getRequiredPublicBaseUrl(): string {
   const baseUrl = getConfiguredBaseUrl();
@@ -77,10 +90,16 @@ function getRequiredPublicBaseUrl(): string {
 }
 
 function hasObjectStorageConfig(): boolean {
-  return Boolean(process.env.BUILT_IN_FORGE_API_URL?.trim() && process.env.BUILT_IN_FORGE_API_KEY?.trim());
+  return Boolean(
+    process.env.BUILT_IN_FORGE_API_URL?.trim() &&
+    process.env.BUILT_IN_FORGE_API_KEY?.trim()
+  );
 }
 
-async function publishGeneratedImage(jpegBuffer: Buffer, style: Style): Promise<string> {
+async function publishGeneratedImage(
+  jpegBuffer: Buffer,
+  style: Style
+): Promise<string> {
   if (hasObjectStorageConfig()) {
     const key = `generated/${style}/${Date.now()}-${randomUUID()}.jpg`;
     const { url } = await storagePut(key, jpegBuffer, "image/jpeg");
@@ -95,7 +114,10 @@ function ensureJpegBuffer(buffer: Buffer): Buffer {
   return buffer;
 }
 
-export function getGeneratorStartupConfig(): { mode: GeneratorMode; resolvedBaseUrl: string | undefined } {
+export function getGeneratorStartupConfig(): {
+  mode: GeneratorMode;
+  resolvedBaseUrl: string | undefined;
+} {
   return {
     mode: "openai",
     resolvedBaseUrl: getConfiguredBaseUrl(),
@@ -108,7 +130,9 @@ function buildStylePrompt(style: Style, promptHint?: string): string {
       ? "Apply a classic oil painting portrait style to this photo, with visible brush strokes, textured canvas, painterly lighting, rich color depth, and a fine-art museum feel."
       : style === "cyberpunk"
         ? "Apply cyberpunk aesthetic, neon-lit futuristic city, glowing signs, high contrast, cinematic sci-fi atmosphere, detailed digital art to this photo."
-        : `Apply ${style} style to this photo.`;
+        : style === "norman-blackwell"
+          ? "Apply a Norman Blackwell portrait style to this photo, with nostalgic mid-century editorial illustration, warm Americana storytelling, painterly realism, expressive faces, soft brushwork, and a vintage magazine cover feel."
+          : `Apply ${style} style to this photo.`;
 
   const trimmedPromptHint = promptHint?.trim();
   if (!trimmedPromptHint) {
@@ -160,14 +184,20 @@ function wait(ms: number): Promise<void> {
   });
 }
 
-function finalizeMetrics(startedAt: number, partial: Omit<GenerationMetrics, "totalMs"> = {}): GenerationMetrics {
+function finalizeMetrics(
+  startedAt: number,
+  partial: Omit<GenerationMetrics, "totalMs"> = {}
+): GenerationMetrics {
   return {
     ...partial,
     totalMs: Date.now() - startedAt,
   };
 }
 
-function attachGenerationMetrics(error: unknown, metrics: GenerationMetrics): unknown {
+function attachGenerationMetrics(
+  error: unknown,
+  metrics: GenerationMetrics
+): unknown {
   if (error instanceof Error) {
     (error as ErrorWithGenerationMetrics).generationMetrics = metrics;
   }
@@ -175,7 +205,9 @@ function attachGenerationMetrics(error: unknown, metrics: GenerationMetrics): un
   return error;
 }
 
-export function getGenerationMetrics(error: unknown): GenerationMetrics | undefined {
+export function getGenerationMetrics(
+  error: unknown
+): GenerationMetrics | undefined {
   if (error instanceof Error) {
     return (error as ErrorWithGenerationMetrics).generationMetrics;
   }
@@ -204,7 +236,10 @@ function parseAllowedHostsFromEnv(): string[] {
 
 function isPrivateIPv4(ip: string): boolean {
   const parts = ip.split(".").map(x => Number(x));
-  if (parts.length !== 4 || parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)) {
+  if (
+    parts.length !== 4 ||
+    parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
     return true;
   }
 
@@ -219,7 +254,10 @@ function isPrivateIPv4(ip: string): boolean {
   return false;
 }
 
-function hostnameMatchesAllowedHost(hostname: string, allowedHost: string): boolean {
+function hostnameMatchesAllowedHost(
+  hostname: string,
+  allowedHost: string
+): boolean {
   return hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
 }
 
@@ -237,14 +275,23 @@ function isBlockedHostname(hostname: string): boolean {
   if (ipType === 6) {
     if (h === "::1") return true;
     if (h.startsWith("fc") || h.startsWith("fd")) return true;
-    if (h.startsWith("fe8") || h.startsWith("fe9") || h.startsWith("fea") || h.startsWith("feb")) return true;
+    if (
+      h.startsWith("fe8") ||
+      h.startsWith("fe9") ||
+      h.startsWith("fea") ||
+      h.startsWith("feb")
+    )
+      return true;
     return true;
   }
 
   return false;
 }
 
-export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: string): URL {
+export function validateSourceImageUrlOrThrow(
+  sourceImageUrl: string,
+  reqId?: string
+): URL {
   let parsedUrl: URL;
 
   try {
@@ -256,40 +303,70 @@ export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: st
 
   const hostname = parsedUrl.hostname.toLowerCase();
   if (parsedUrl.protocol !== "https:") {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_https", protocol: parsedUrl.protocol });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "non_https",
+      protocol: parsedUrl.protocol,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (parsedUrl.username || parsedUrl.password) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "credentials_in_url" });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "credentials_in_url",
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (parsedUrl.port && parsedUrl.port !== "443") {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_standard_port", port: parsedUrl.port });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "non_standard_port",
+      port: parsedUrl.port,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (isBlockedHostname(hostname)) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "blocked_hostname", hostname });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "blocked_hostname",
+      hostname,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   const allowedHosts = parseAllowedHostsFromEnv();
   if (allowedHosts.length === 0) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "allowlist_not_configured" });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "allowlist_not_configured",
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
-  if (!allowedHosts.some(allowedHost => hostnameMatchesAllowedHost(hostname, allowedHost))) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "host_not_allowed", hostname });
+  if (
+    !allowedHosts.some(allowedHost =>
+      hostnameMatchesAllowedHost(hostname, allowedHost)
+    )
+  ) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "host_not_allowed",
+      hostname,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   return parsedUrl;
 }
 
-async function fetchWithTimeout(input: URL, init: RequestInit | undefined, timeoutMs: number): Promise<Response> {
+async function fetchWithTimeout(
+  input: URL,
+  init: RequestInit | undefined,
+  timeoutMs: number
+): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => {
     controller.abort();
@@ -306,14 +383,20 @@ async function fetchWithTimeout(input: URL, init: RequestInit | undefined, timeo
   }
 }
 
-async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string): Promise<{
+async function downloadSourceImageOrThrow(
+  sourceImageUrl: string,
+  reqId: string
+): Promise<{
   imageBuffer: Buffer;
   contentType: string;
   incomingLen: number;
   incomingSha256: string;
   fbImageFetchMs: number;
 }> {
-  const validatedSourceImageUrl = validateSourceImageUrlOrThrow(sourceImageUrl, reqId);
+  const validatedSourceImageUrl = validateSourceImageUrlOrThrow(
+    sourceImageUrl,
+    reqId
+  );
   const timeoutMs = getInboundImageTimeoutMs();
   let totalFetchMs = 0;
 
@@ -321,8 +404,13 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
     const attemptStartedAt = Date.now();
 
     try {
-      const response = await fetchWithTimeout(validatedSourceImageUrl, { redirect: "manual" }, timeoutMs);
-      const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+      const response = await fetchWithTimeout(
+        validatedSourceImageUrl,
+        { redirect: "manual" },
+        timeoutMs
+      );
+      const contentType =
+        response.headers.get("content-type") ?? "application/octet-stream";
 
       if (isRedirectStatus(response.status)) {
         console.warn("SOURCE_IMAGE_URL_BLOCKED", {
@@ -337,13 +425,26 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       if (!response.ok) {
         totalFetchMs += Date.now() - attemptStartedAt;
 
-        if (attempt < FB_IMAGE_FETCH_RETRY_LIMIT && isRetryableResponseStatus(response.status)) {
-          console.debug("FB_IMAGE_FETCH_RETRY", { reqId, attempt: attempt + 1, status: response.status });
+        if (
+          attempt < FB_IMAGE_FETCH_RETRY_LIMIT &&
+          isRetryableResponseStatus(response.status)
+        ) {
+          console.debug("FB_IMAGE_FETCH_RETRY", {
+            reqId,
+            attempt: attempt + 1,
+            status: response.status,
+          });
           continue;
         }
 
-        console.error("MISSING_INPUT_IMAGE", { reqId, reason: "download_failed", status: response.status });
-        throw new MissingInputImageError(`Failed to download source image (${response.status})`);
+        console.error("MISSING_INPUT_IMAGE", {
+          reqId,
+          reason: "download_failed",
+          status: response.status,
+        });
+        throw new MissingInputImageError(
+          `Failed to download source image (${response.status})`
+        );
       }
 
       const imageBuffer = Buffer.from(await response.arrayBuffer());
@@ -368,8 +469,14 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       }
 
       if (incomingByteLen < MIN_INPUT_IMAGE_BYTES) {
-        console.error("MISSING_INPUT_IMAGE", { reqId, reason: "too_small", byte_len: incomingByteLen });
-        throw new MissingInputImageError(`Source image too small (${incomingByteLen} bytes)`);
+        console.error("MISSING_INPUT_IMAGE", {
+          reqId,
+          reason: "too_small",
+          byte_len: incomingByteLen,
+        });
+        throw new MissingInputImageError(
+          `Source image too small (${incomingByteLen} bytes)`
+        );
       }
 
       return {
@@ -380,13 +487,19 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
         fbImageFetchMs: totalFetchMs,
       };
     } catch (error) {
-      if (error instanceof MissingInputImageError || error instanceof InvalidSourceImageUrlError) {
+      if (
+        error instanceof MissingInputImageError ||
+        error instanceof InvalidSourceImageUrlError
+      ) {
         throw error;
       }
 
       totalFetchMs += Date.now() - attemptStartedAt;
 
-      if (attempt < FB_IMAGE_FETCH_RETRY_LIMIT && isTransientNetworkError(error)) {
+      if (
+        attempt < FB_IMAGE_FETCH_RETRY_LIMIT &&
+        isTransientNetworkError(error)
+      ) {
         console.debug("FB_IMAGE_FETCH_RETRY", {
           reqId,
           attempt: attempt + 1,
@@ -398,7 +511,10 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       if (isTransientNetworkError(error)) {
         console.error("MISSING_INPUT_IMAGE", {
           reqId,
-          reason: error instanceof Error && error.name === "AbortError" ? "download_timeout" : "download_network_error",
+          reason:
+            error instanceof Error && error.name === "AbortError"
+              ? "download_timeout"
+              : "download_network_error",
         });
         throw new MissingInputImageError("Failed to download source image");
       }
@@ -411,9 +527,20 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
 }
 
 export class OpenAiImageGenerator implements ImageGenerator {
-  async generate(input: { style: Style; sourceImageUrl?: string; promptHint?: string; userKey: string; reqId: string }): Promise<{
+  async generate(input: {
+    style: Style;
+    sourceImageUrl?: string;
+    promptHint?: string;
+    userKey: string;
+    reqId: string;
+  }): Promise<{
     imageUrl: string;
-    proof: { incomingLen: number; incomingSha256: string; openaiInputLen: number; openaiInputSha256: string };
+    proof: {
+      incomingLen: number;
+      incomingSha256: string;
+      openaiInputLen: number;
+      openaiInputSha256: string;
+    };
     metrics: GenerationMetrics;
   }> {
     const startedAt = Date.now();
@@ -423,7 +550,10 @@ export class OpenAiImageGenerator implements ImageGenerator {
     }
 
     if (!input.sourceImageUrl) {
-      console.error("MISSING_INPUT_IMAGE", { reqId: input.reqId, reason: "missing_source_url" });
+      console.error("MISSING_INPUT_IMAGE", {
+        reqId: input.reqId,
+        reason: "missing_source_url",
+      });
       throw new MissingInputImageError("sourceImageUrl is required");
     }
 
@@ -432,7 +562,13 @@ export class OpenAiImageGenerator implements ImageGenerator {
     }
 
     try {
-      const { imageBuffer, contentType, incomingLen, incomingSha256, fbImageFetchMs } = await downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId);
+      const {
+        imageBuffer,
+        contentType,
+        incomingLen,
+        incomingSha256,
+        fbImageFetchMs,
+      } = await downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId);
       partialMetrics.fbImageFetchMs = fbImageFetchMs;
       const openAiInputHash = sha256(imageBuffer);
       const openAiInputByteLen = safeLen(imageBuffer);
@@ -448,7 +584,11 @@ export class OpenAiImageGenerator implements ImageGenerator {
         formData.set("prompt", prompt);
         formData.set("size", "1024x1024");
         formData.set("output_format", "jpeg");
-        formData.set("image", new Blob([new Uint8Array(imageBuffer)], { type: contentType }), "source-image");
+        formData.set(
+          "image",
+          new Blob([new Uint8Array(imageBuffer)], { type: contentType }),
+          "source-image"
+        );
         return formData;
       };
 
@@ -465,13 +605,19 @@ export class OpenAiImageGenerator implements ImageGenerator {
               },
               body: createOpenAiFormData(),
             },
-            openAiTimeoutMs,
+            openAiTimeoutMs
           );
         } catch (error) {
-          partialMetrics.openAiMs = (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
+          partialMetrics.openAiMs =
+            (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
           if (attempt < openAiRetryLimit && isTransientNetworkError(error)) {
             const waitMs = openAiRetryBaseMs * 2 ** attempt;
-            console.warn("OPENAI_GENERATION_RETRY", { reqId: input.reqId, attempt: attempt + 1, waitMs, reason: (error as Error).name });
+            console.warn("OPENAI_GENERATION_RETRY", {
+              reqId: input.reqId,
+              attempt: attempt + 1,
+              waitMs,
+              reason: (error as Error).name,
+            });
             await wait(waitMs);
             continue;
           }
@@ -479,14 +625,23 @@ export class OpenAiImageGenerator implements ImageGenerator {
           throw error;
         }
 
-        partialMetrics.openAiMs = (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
+        partialMetrics.openAiMs =
+          (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
         if (response.ok) {
           break;
         }
 
-        if (attempt < openAiRetryLimit && isRetryableResponseStatus(response.status)) {
+        if (
+          attempt < openAiRetryLimit &&
+          isRetryableResponseStatus(response.status)
+        ) {
           const waitMs = openAiRetryBaseMs * 2 ** attempt;
-          console.warn("OPENAI_GENERATION_RETRY", { reqId: input.reqId, attempt: attempt + 1, waitMs, status: response.status });
+          console.warn("OPENAI_GENERATION_RETRY", {
+            reqId: input.reqId,
+            attempt: attempt + 1,
+            waitMs,
+            status: response.status,
+          });
           await wait(waitMs);
           continue;
         }
@@ -495,26 +650,36 @@ export class OpenAiImageGenerator implements ImageGenerator {
       }
 
       if (!response) {
-        throw new OpenAiGenerationError("OpenAI request failed before receiving a response");
+        throw new OpenAiGenerationError(
+          "OpenAI request failed before receiving a response"
+        );
       }
 
       if (!response.ok) {
         throw attachGenerationMetrics(
-          new OpenAiGenerationError(`OpenAI request failed (${response.status} ${response.statusText})`),
-          finalizeMetrics(startedAt, partialMetrics),
+          new OpenAiGenerationError(
+            `OpenAI request failed (${response.status} ${response.statusText})`
+          ),
+          finalizeMetrics(startedAt, partialMetrics)
         );
       }
 
-      const result = (await response.json()) as { data?: Array<{ b64_json?: string }> };
+      const result = (await response.json()) as {
+        data?: Array<{ b64_json?: string }>;
+      };
       const base64Image = result.data?.[0]?.b64_json;
 
       if (!base64Image) {
-        throw new OpenAiGenerationError("OpenAI response did not include base64 image data");
+        throw new OpenAiGenerationError(
+          "OpenAI response did not include base64 image data"
+        );
       }
 
       const imageBufferResult = Buffer.from(base64Image, "base64");
       if (imageBufferResult.length <= 0) {
-        throw new OpenAiGenerationError("OpenAI response image data was empty after base64 decode");
+        throw new OpenAiGenerationError(
+          "OpenAI response image data was empty after base64 decode"
+        );
       }
 
       const jpegBuffer = ensureJpegBuffer(imageBufferResult);
@@ -537,15 +702,24 @@ export class OpenAiImageGenerator implements ImageGenerator {
       if ((error as { name?: string })?.name === "AbortError") {
         throw attachGenerationMetrics(
           new GenerationTimeoutError("OpenAI generation timed out"),
-          finalizeMetrics(startedAt, partialMetrics),
+          finalizeMetrics(startedAt, partialMetrics)
         );
       }
 
-      throw attachGenerationMetrics(error, finalizeMetrics(startedAt, getGenerationMetrics(error) ?? partialMetrics));
+      throw attachGenerationMetrics(
+        error,
+        finalizeMetrics(
+          startedAt,
+          getGenerationMetrics(error) ?? partialMetrics
+        )
+      );
     }
   }
 }
 
-export function createImageGenerator(mode: GeneratorMode = "openai"): { mode: GeneratorMode; generator: ImageGenerator } {
+export function createImageGenerator(mode: GeneratorMode = "openai"): {
+  mode: GeneratorMode;
+  generator: ImageGenerator;
+} {
   return { mode, generator: new OpenAiImageGenerator() };
 }

--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -6,7 +6,8 @@ export type Style =
   | "cinematic"
   | "disco"
   | "cyberpunk"
-  | "oil-paint";
+  | "oil-paint"
+  | "norman-blackwell";
 
 export type StyleId =
   | "STYLE_CARICATURE"
@@ -17,6 +18,7 @@ export type StyleId =
   | "STYLE_DISCO"
   | "STYLE_CLOUDS"
   | "STYLE_CYBERPUNK"
+  | "STYLE_NORMAN_BLACKWELL"
   | "gold";
 
 export type StyleConfig = {
@@ -62,6 +64,12 @@ export const STYLE_CONFIGS: StyleConfig[] = [
     payload: "STYLE_CYBERPUNK",
     style: "cyberpunk",
     label: "🌃 Cyberpunk",
+  },
+  {
+    id: "STYLE_NORMAN_BLACKWELL",
+    payload: "STYLE_NORMAN_BLACKWELL",
+    style: "norman-blackwell",
+    label: "📰 Norman Blackwell",
   },
   {
     id: "STYLE_DISCO",

--- a/server/_core/webhookHelpers.ts
+++ b/server/_core/webhookHelpers.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { normalizeLang, t, type Lang } from "./i18n";
-import { getQuickRepliesForState, type ConversationState } from "./messengerState";
+import {
+  getQuickRepliesForState,
+  type ConversationState,
+} from "./messengerState";
 import { type Style } from "./messengerStyles";
 
 export type FacebookWebhookEvent = {
@@ -49,6 +52,7 @@ export const STYLE_OPTIONS: Style[] = [
   "cinematic",
   "oil-paint",
   "cyberpunk",
+  "norman-blackwell",
   "disco",
   "clouds",
 ];
@@ -60,6 +64,7 @@ export const STYLE_LABELS: Record<Style, string> = {
   cinematic: "Cinematic",
   "oil-paint": "Oil Paint",
   cyberpunk: "Cyberpunk",
+  "norman-blackwell": "Norman Blackwell",
   disco: "Disco",
   clouds: "Clouds",
 };
@@ -68,14 +73,12 @@ const STYLE_ALIASES: Record<string, Style> = {
   "oil paint": "oil-paint",
   "oil painting": "oil-paint",
   "oil-paint": "oil-paint",
+  "norman blackwell": "norman-blackwell",
+  blackwell: "norman-blackwell",
 };
 
 function normalizeStyleToken(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ");
+  return input.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
 }
 
 export type AckKind = "like" | "ok" | "thanks" | "emoji";
@@ -87,7 +90,7 @@ type GreetingResponse =
 export function getEventDedupeKey(
   event: FacebookWebhookEvent,
   userKey: string,
-  entryId?: string,
+  entryId?: string
 ): string | undefined {
   const messageId = event.message?.mid?.trim();
   if (messageId) {
@@ -100,10 +103,17 @@ export function getEventDedupeKey(
       return "none";
     }
 
-    return createHash("sha256").update(normalizedValue).digest("hex").slice(0, 12);
+    return createHash("sha256")
+      .update(normalizedValue)
+      .digest("hex")
+      .slice(0, 12);
   };
 
-  const eventType = event.message ? "message" : event.postback ? "postback" : "other";
+  const eventType = event.message
+    ? "message"
+    : event.postback
+      ? "postback"
+      : "other";
   const postbackPayloadHash = hashToken(event.postback?.payload);
   const quickReplyPayloadHash = hashToken(event.message?.quick_reply?.payload);
   const hasText = event.message?.text?.trim() ? "1" : "0";
@@ -114,10 +124,12 @@ export function getEventDedupeKey(
       counts.set(type, (counts.get(type) ?? 0) + 1);
     }
 
-    return Array.from(counts.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([type, count]) => `${type}:${count}`)
-      .join(",") || "none";
+    return (
+      Array.from(counts.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([type, count]) => `${type}:${count}`)
+        .join(",") || "none"
+    );
   })();
   const fallbackEventFingerprint = [
     eventType,
@@ -141,8 +153,11 @@ export function getEventDedupeKey(
 }
 
 export function summarizeWebhook(payload: unknown): WebhookSummary {
-  const entries = Array.isArray((payload as { entry?: unknown[] } | null | undefined)?.entry)
-    ? (payload as { entry: Array<{ messaging?: FacebookWebhookEvent[] }> }).entry
+  const entries = Array.isArray(
+    (payload as { entry?: unknown[] } | null | undefined)?.entry
+  )
+    ? (payload as { entry: Array<{ messaging?: FacebookWebhookEvent[] }> })
+        .entry
     : [];
 
   const events = entries.flatMap(entry => {
@@ -153,8 +168,8 @@ export function summarizeWebhook(payload: unknown): WebhookSummary {
         new Set(
           (event.message?.attachments ?? [])
             .map(attachment => attachment.type?.trim())
-            .filter((type): type is string => Boolean(type)),
-        ),
+            .filter((type): type is string => Boolean(type))
+        )
       );
 
       let type: WebhookSummaryEvent["type"] = "unknown";
@@ -182,20 +197,28 @@ export function summarizeWebhook(payload: unknown): WebhookSummary {
 
   return {
     object:
-      typeof (payload as { object?: unknown } | null | undefined)?.object === "string"
-        ? ((payload as { object: string }).object)
+      typeof (payload as { object?: unknown } | null | undefined)?.object ===
+      "string"
+        ? (payload as { object: string }).object
         : undefined,
     entryCount: entries.length,
     events,
   };
 }
 
-export function getGreetingResponse(state: ConversationState, lang: Lang = normalizeLang(process.env.DEFAULT_MESSENGER_LANG)): GreetingResponse {
+export function getGreetingResponse(
+  state: ConversationState,
+  lang: Lang = normalizeLang(process.env.DEFAULT_MESSENGER_LANG)
+): GreetingResponse {
   switch (state) {
     case "PROCESSING":
       return { mode: "text", text: t(lang, "processingBlocked") };
     case "AWAITING_STYLE":
-      return { mode: "quick_replies", state: "AWAITING_STYLE", text: t(lang, "stylePicker") };
+      return {
+        mode: "quick_replies",
+        state: "AWAITING_STYLE",
+        text: t(lang, "stylePicker"),
+      };
     case "RESULT_READY":
       return {
         mode: "quick_replies",
@@ -212,7 +235,11 @@ export function getGreetingResponse(state: ConversationState, lang: Lang = norma
       return { mode: "text", text: t(lang, "textWithoutPhoto") };
     case "IDLE":
     default:
-      return { mode: "quick_replies", state: "IDLE", text: t(lang, "flowExplanation") };
+      return {
+        mode: "quick_replies",
+        state: "IDLE",
+        text: t(lang, "flowExplanation"),
+      };
   }
 }
 
@@ -236,7 +263,10 @@ export function stylePayloadToStyle(payload: string): Style | undefined {
     return undefined;
   }
 
-  const styleKey = payload.slice("STYLE_".length).toLowerCase().replace(/_/g, "-");
+  const styleKey = payload
+    .slice("STYLE_".length)
+    .toLowerCase()
+    .replace(/_/g, "-");
   return normalizeStyle(styleKey);
 }
 
@@ -276,7 +306,10 @@ export function detectAck(raw: string | undefined | null): AckKind | null {
     return "thanks";
   }
 
-  if (text.length > 0 && Array.from(text).every(char => /[\p{Extended_Pictographic}\s]/u.test(char))) {
+  if (
+    text.length > 0 &&
+    Array.from(text).every(char => /[\p{Extended_Pictographic}\s]/u.test(char))
+  ) {
     return "emoji";
   }
 

--- a/server/botFeatures.unit.test.ts
+++ b/server/botFeatures.unit.test.ts
@@ -8,7 +8,9 @@ import type { BotTextContext } from "./_core/botContext";
 import type { MessengerUserState } from "./_core/messengerState";
 import { resetStateStore } from "./_core/messengerState";
 
-function makeState(overrides: Partial<MessengerUserState> = {}): MessengerUserState {
+function makeState(
+  overrides: Partial<MessengerUserState> = {}
+): MessengerUserState {
   return {
     psid: "p1",
     userKey: "u1",
@@ -83,6 +85,24 @@ describe("styleCommandsFeature", () => {
 
     expect(handled).toEqual({ handled: true });
     expect(chooseStyle).toHaveBeenCalledWith("oil-paint");
+  });
+
+  it("accepts /style Norman Blackwell aliases and delegates style selection", async () => {
+    const chooseStyle = vi.fn(async () => undefined);
+    const context = makeContext({
+      state: makeState({
+        lastPhotoUrl: "https://img.example/source.jpg",
+        lastPhoto: "https://img.example/source.jpg",
+      }),
+      messageText: "/style norman blackwell",
+      normalizedText: "/style norman blackwell",
+      chooseStyle,
+    });
+
+    const handled = await styleCommandsFeature.onText?.(context);
+
+    expect(handled).toEqual({ handled: true });
+    expect(chooseStyle).toHaveBeenCalledWith("norman-blackwell");
   });
 
   it("accepts /style cyberpunk and delegates style selection", async () => {
@@ -213,7 +233,9 @@ describe("assistantCommandsFeature", () => {
           hasPhoto: true,
           sendText,
           runStyleGeneration,
-          state: makeState({ lastPhotoUrl: "https://img.example/original.jpg" }),
+          state: makeState({
+            lastPhotoUrl: "https://img.example/original.jpg",
+          }),
         })
       );
 
@@ -252,7 +274,9 @@ describe("statsFeature", () => {
   it("returns a readable admin-only stats block", async () => {
     process.env.MESSENGER_ADMIN_IDS = "p1";
     const sendText = vi.fn(async () => undefined);
-    const uptimeSpy = vi.spyOn(process, "uptime").mockReturnValue(3 * 3600 + 12 * 60);
+    const uptimeSpy = vi
+      .spyOn(process, "uptime")
+      .mockReturnValue(3 * 3600 + 12 * 60);
 
     try {
       const result = await statsFeature.onText?.(
@@ -268,7 +292,7 @@ describe("statsFeature", () => {
             errorCountToday: 0,
             averageGenerationLatencyMs: null,
           }),
-        }),
+        })
       );
 
       expect(result).toEqual({ handled: true });
@@ -285,7 +309,7 @@ describe("statsFeature", () => {
           "Bot uptime: 3h 12m",
           "",
           "Node-local stats for 2026-03-16",
-        ].join("\n"),
+        ].join("\n")
       );
     } finally {
       uptimeSpy.mockRestore();
@@ -303,7 +327,7 @@ describe("statsFeature", () => {
           messageText: "/stats",
           normalizedText: "/stats",
           sendText,
-        }),
+        })
       );
 
       expect(result).toEqual({ handled: false });

--- a/server/conversationalEditInterpreter.test.ts
+++ b/server/conversationalEditInterpreter.test.ts
@@ -28,6 +28,7 @@ describe("conversational edit interpreter", () => {
   it("detects likely edit requests before calling the model", () => {
     expect(looksLikePossibleEditRequest("make it darker")).toBe(true);
     expect(looksLikePossibleEditRequest("meer cinematic")).toBe(true);
+    expect(looksLikePossibleEditRequest("make it norman blackwell")).toBe(true);
     expect(looksLikePossibleEditRequest("what can you do?")).toBe(false);
   });
 

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { InvalidSourceImageUrlError, OpenAiImageGenerator } from "./_core/imageService";
+import {
+  InvalidSourceImageUrlError,
+  OpenAiImageGenerator,
+} from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
 
-const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
+const GENERATED_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
 
 function toUrlString(url: string | URL): string {
   return typeof url === "string" ? url : url.toString();
@@ -44,7 +48,9 @@ describe("OpenAi image-to-image proof", () => {
       expect(imageBlob).toBeInstanceOf(Blob);
       const imageBuffer = Buffer.from(await (imageBlob as Blob).arrayBuffer());
       expect(sha256(imageBuffer)).toBe(fixtureHash);
-      expect(formData.get("prompt")).toContain("Apply disco style to this photo");
+      expect(formData.get("prompt")).toContain(
+        "Apply disco style to this photo"
+      );
       expect(formData.get("output_format")).toBe("jpeg");
 
       return {
@@ -64,7 +70,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
@@ -87,8 +95,12 @@ describe("OpenAi image-to-image proof", () => {
       }
 
       const formData = init?.body as FormData;
-      expect(formData.get("prompt")).toContain("Apply disco style to this photo.");
-      expect(formData.get("prompt")).toContain("Additional direction: neon rain.");
+      expect(formData.get("prompt")).toContain(
+        "Apply disco style to this photo."
+      );
+      expect(formData.get("prompt")).toContain(
+        "Additional direction: neon rain."
+      );
 
       return {
         ok: true,
@@ -145,6 +157,48 @@ describe("OpenAi image-to-image proof", () => {
       sourceImageUrl: "https://img.example/source.jpg",
       userKey: "user-1",
       reqId: "req-cyberpunk-prompt",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the Norman Blackwell preset prompt for OpenAI edits", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fixture = Buffer.alloc(7000, 9);
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      const formData = init?.body as FormData;
+      const prompt = String(formData.get("prompt"));
+      expect(prompt).toContain("Norman Blackwell portrait style");
+      expect(prompt).toContain("nostalgic mid-century editorial illustration");
+      expect(prompt).toContain("warm Americana storytelling");
+      expect(prompt).toContain("vintage magazine cover feel");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "norman-blackwell",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-norman-blackwell-prompt",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -223,7 +277,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-2",
-      }),
+      })
     ).rejects.toThrow("Source image too small");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -236,7 +290,10 @@ describe("OpenAi image-to-image proof", () => {
 
     const fixture = Buffer.alloc(7000, 9);
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg" && fetchMock.mock.calls.length === 1) {
+      if (
+        toUrlString(url) === "https://img.example/source.jpg" &&
+        fetchMock.mock.calls.length === 1
+      ) {
         throw new TypeError("temporary network failure");
       }
 
@@ -265,7 +322,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -284,7 +343,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://127.0.0.1/source.jpg",
         userKey: "user-1",
         reqId: "req-private-ip",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -322,7 +381,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
   });
 
   it("blocks hosts outside SOURCE_IMAGE_ALLOWED_HOSTS before fetch", async () => {
@@ -340,7 +401,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://other.example/source.jpg",
         userKey: "user-1",
         reqId: "req-deny-allowlist",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -361,7 +422,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://user:pass@img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-embedded-credentials",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -382,7 +443,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example:8443/source.jpg",
         userKey: "user-1",
         reqId: "req-non-standard-port",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -419,13 +480,12 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-insecure-app-base-url",
-      }),
+      })
     ).rejects.toThrow("APP_BASE_URL is missing or invalid");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     delete process.env.NODE_ENV;
   });
-
 
   it("retries OpenAI edits request on retryable status codes", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
@@ -471,7 +531,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -489,7 +551,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-no-allowlist",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -526,13 +588,13 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-redirect-error",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       expect.any(URL),
-      expect.objectContaining({ redirect: "manual" }),
+      expect.objectContaining({ redirect: "manual" })
     );
   });
 
@@ -579,7 +641,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -613,8 +677,10 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-empty-output-buffer",
-      }),
-    ).rejects.toThrow("OpenAI response image data was empty after base64 decode");
+      })
+    ).rejects.toThrow(
+      "OpenAI response image data was empty after base64 decode"
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/server/messengerStyles.test.ts
+++ b/server/messengerStyles.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { STYLE_CONFIGS, getStyleById, isStylePayload } from "./_core/messengerStyles";
+import {
+  STYLE_CONFIGS,
+  getStyleById,
+  isStylePayload,
+} from "./_core/messengerStyles";
 
 describe("messengerStyles", () => {
   it("exposes canonical style configs", () => {
@@ -10,6 +14,7 @@ describe("messengerStyles", () => {
       "cinematic",
       "oil-paint",
       "cyberpunk",
+      "norman-blackwell",
       "disco",
       "clouds",
     ]);
@@ -19,9 +24,13 @@ describe("messengerStyles", () => {
     expect(isStylePayload("STYLE_CINEMATIC")).toBe(true);
     expect(isStylePayload("STYLE_OIL_PAINT")).toBe(true);
     expect(isStylePayload("STYLE_CYBERPUNK")).toBe(true);
+    expect(isStylePayload("STYLE_NORMAN_BLACKWELL")).toBe(true);
     expect(isStylePayload("UNKNOWN_STYLE")).toBe(false);
     expect(getStyleById("STYLE_OIL_PAINT").label).toContain("Oil Paint");
     expect(getStyleById("STYLE_CYBERPUNK").label).toContain("Cyberpunk");
+    expect(getStyleById("STYLE_NORMAN_BLACKWELL").label).toContain(
+      "Norman Blackwell"
+    );
     expect(getStyleById("STYLE_DISCO").label).toContain("Disco");
   });
 });

--- a/server/webhookHelpers.styleNormalization.test.ts
+++ b/server/webhookHelpers.styleNormalization.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { normalizeStyle, parseReferralStyle, parseStyle, stylePayloadToStyle } from "./_core/webhookHelpers";
+import {
+  normalizeStyle,
+  parseReferralStyle,
+  parseStyle,
+  stylePayloadToStyle,
+} from "./_core/webhookHelpers";
 
 describe("style normalization", () => {
   it("normalizes oil paint aliases to the canonical oil-paint key", () => {
@@ -14,4 +19,14 @@ describe("style normalization", () => {
     expect(stylePayloadToStyle("STYLE_OIL_PAINT")).toBe("oil-paint");
     expect(parseReferralStyle("style_oil-paint")).toBe("oil-paint");
   });
+});
+
+it("normalizes Norman Blackwell aliases to the canonical key", () => {
+  expect(normalizeStyle("Norman Blackwell")).toBe("norman-blackwell");
+  expect(normalizeStyle("blackwell")).toBe("norman-blackwell");
+  expect(parseStyle("norman blackwell")).toBe("norman-blackwell");
+  expect(stylePayloadToStyle("STYLE_NORMAN_BLACKWELL")).toBe(
+    "norman-blackwell"
+  );
+  expect(parseReferralStyle("style_norman-blackwell")).toBe("norman-blackwell");
 });


### PR DESCRIPTION
### Motivation
- Provide a new, shareable preset style "Norman Blackwell" so users can select it like other canonical styles and get a tailored image-generation prompt.
- Ensure the new style is recognized across normalization, commands, conversational edit flows, and image-generation so remixing and CLI-style selections work consistently.

### Description
- Added a new canonical style `norman-blackwell` with payload `STYLE_NORMAN_BLACKWELL` and label `📰 Norman Blackwell` in `server/_core/messengerStyles.ts`.
- Wired the style into normalization and labels in `server/_core/webhookHelpers.ts`, including aliases `"norman blackwell"` and `blackwell` so `normalizeStyle`, referral parsing and `/style` commands resolve correctly.
- Added a dedicated OpenAI edits prompt for the style in `server/_core/imageService.ts` that describes the Norman Blackwell portrait aesthetic, and extended conversational edit schema/recognition in `server/_core/conversationalEditInterpreter.ts` so interpreter responses and heuristics accept the new style.
- Added and updated tests covering the registry, normalization, `/style` command handling, image-service prompt generation, and conversational-edit detection in the corresponding `server/*.test.ts` files.

### Testing
- Ran the targeted test suite with `pnpm vitest run server/messengerStyles.test.ts server/webhookHelpers.styleNormalization.test.ts server/botFeatures.unit.test.ts server/imageService.proof.test.ts server/conversationalEditInterpreter.test.ts` and all tests passed (`5 files`, `38 tests` passed).
- Verified style-specific image prompt behavior via `server/imageService.proof.test.ts` which asserts the Norman Blackwell preset is included in the generated OpenAI edits `prompt`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac2ed08d48325bcc42ce3ab6f7742)