### PR TITLE
Add 'norman-blackwell' style and wire through generation, normalization, and tests

### DIFF
--- a/server/_core/conversationalEditInterpreter.ts
+++ b/server/_core/conversationalEditInterpreter.ts
@@ -147,10 +147,7 @@ async function callResponsesApi(
   throw new Error("edit_interpreter_retry_exhausted");
 }
 
-function buildSystemPrompt(input: {
-  lang: Lang;
-  lastStyle?: Style;
-}): string {
+function buildSystemPrompt(input: { lang: Lang; lastStyle?: Style }): string {
   const language = input.lang === "en" ? "English" : "Dutch";
   const lastStyle = input.lastStyle ?? "unknown";
 
@@ -159,7 +156,7 @@ function buildSystemPrompt(input: {
     `The user language is ${language}.`,
     `The last known style is ${lastStyle}.`,
     "Only return JSON with no markdown.",
-    'Schema: {"shouldEdit":boolean,"style":"caricature"|"gold"|"petals"|"clouds"|"cinematic"|"disco"|"cyberpunk"|null,"promptHint":string|null}.',
+    'Schema: {"shouldEdit":boolean,"style":"caricature"|"gold"|"petals"|"clouds"|"cinematic"|"disco"|"cyberpunk"|"norman-blackwell"|null,"promptHint":string|null}.',
     "Set shouldEdit=true only when the user is asking to change the previous image.",
     "Use style only when the user explicitly asks for a known style or it is clearly implied.",
     "Put the visual change request into promptHint in concise plain text.",
@@ -186,7 +183,8 @@ function parseDecision(rawText: string): ConversationalEditDecision | null {
       parsed.style === "clouds" ||
       parsed.style === "cinematic" ||
       parsed.style === "disco" ||
-      parsed.style === "cyberpunk"
+      parsed.style === "cyberpunk" ||
+      parsed.style === "norman-blackwell"
         ? parsed.style
         : undefined;
 
@@ -227,6 +225,7 @@ export function looksLikePossibleEditRequest(text: string): boolean {
     "clouds",
     "disco",
     "cyberpunk",
+    "norman blackwell",
     "caricature",
     "background",
     "remove",

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -5,7 +5,10 @@ import { type Style } from "./messengerStyles";
 import fs from "fs/promises";
 import path from "path";
 import { safeLen, sha256 } from "./imageProof";
-import { buildGeneratedImageUrl, putGeneratedImage } from "./generatedImageStore";
+import {
+  buildGeneratedImageUrl,
+  putGeneratedImage,
+} from "./generatedImageStore";
 import { storagePut } from "../storage";
 
 export type GeneratorMode = "openai";
@@ -19,7 +22,12 @@ export interface ImageGenerator {
     reqId: string;
   }): Promise<{
     imageUrl: string;
-    proof: { incomingLen: number; incomingSha256: string; openaiInputLen: number; openaiInputSha256: string };
+    proof: {
+      incomingLen: number;
+      incomingSha256: string;
+      openaiInputLen: number;
+      openaiInputSha256: string;
+    };
     metrics: GenerationMetrics;
   }>;
 }
@@ -39,7 +47,9 @@ export type GenerationMetrics = {
   totalMs: number;
 };
 
-type ErrorWithGenerationMetrics = Error & { generationMetrics?: GenerationMetrics };
+type ErrorWithGenerationMetrics = Error & {
+  generationMetrics?: GenerationMetrics;
+};
 
 const MIN_INPUT_IMAGE_BYTES = 5 * 1024;
 const FB_IMAGE_FETCH_RETRY_LIMIT = 1;
@@ -48,13 +58,17 @@ const OPENAI_RETRY_BASE_MS_DEFAULT = 500;
 const OPENAI_TIMEOUT_MS_DEFAULT = 30_000;
 
 function getConfiguredBaseUrl(): string | undefined {
-  const configuredBaseUrl = process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
+  const configuredBaseUrl =
+    process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
 
   if (!configuredBaseUrl || !/^https?:\/\//.test(configuredBaseUrl)) {
     return undefined;
   }
 
-  if (process.env.NODE_ENV === "production" && !configuredBaseUrl.startsWith("https://")) {
+  if (
+    process.env.NODE_ENV === "production" &&
+    !configuredBaseUrl.startsWith("https://")
+  ) {
     console.error("APP_BASE_URL must use https:// in production", {
       hasConfiguredBaseUrl: true,
       protocol: configuredBaseUrl.split(":")[0],
@@ -64,7 +78,6 @@ function getConfiguredBaseUrl(): string | undefined {
 
   return configuredBaseUrl.replace(/\/$/, "");
 }
-
 
 function getRequiredPublicBaseUrl(): string {
   const baseUrl = getConfiguredBaseUrl();
@@ -77,10 +90,16 @@ function getRequiredPublicBaseUrl(): string {
 }
 
 function hasObjectStorageConfig(): boolean {
-  return Boolean(process.env.BUILT_IN_FORGE_API_URL?.trim() && process.env.BUILT_IN_FORGE_API_KEY?.trim());
+  return Boolean(
+    process.env.BUILT_IN_FORGE_API_URL?.trim() &&
+    process.env.BUILT_IN_FORGE_API_KEY?.trim()
+  );
 }
 
-async function publishGeneratedImage(jpegBuffer: Buffer, style: Style): Promise<string> {
+async function publishGeneratedImage(
+  jpegBuffer: Buffer,
+  style: Style
+): Promise<string> {
   if (hasObjectStorageConfig()) {
     const key = `generated/${style}/${Date.now()}-${randomUUID()}.jpg`;
     const { url } = await storagePut(key, jpegBuffer, "image/jpeg");
@@ -95,7 +114,10 @@ function ensureJpegBuffer(buffer: Buffer): Buffer {
   return buffer;
 }
 
-export function getGeneratorStartupConfig(): { mode: GeneratorMode; resolvedBaseUrl: string | undefined } {
+export function getGeneratorStartupConfig(): {
+  mode: GeneratorMode;
+  resolvedBaseUrl: string | undefined;
+} {
   return {
     mode: "openai",
     resolvedBaseUrl: getConfiguredBaseUrl(),
@@ -108,7 +130,9 @@ function buildStylePrompt(style: Style, promptHint?: string): string {
       ? "Apply a classic oil painting portrait style to this photo, with visible brush strokes, textured canvas, painterly lighting, rich color depth, and a fine-art museum feel."
       : style === "cyberpunk"
         ? "Apply cyberpunk aesthetic, neon-lit futuristic city, glowing signs, high contrast, cinematic sci-fi atmosphere, detailed digital art to this photo."
-        : `Apply ${style} style to this photo.`;
+        : style === "norman-blackwell"
+          ? "Apply a Norman Blackwell portrait style to this photo, with nostalgic mid-century editorial illustration, warm Americana storytelling, painterly realism, expressive faces, soft brushwork, and a vintage magazine cover feel."
+          : `Apply ${style} style to this photo.`;
 
   const trimmedPromptHint = promptHint?.trim();
   if (!trimmedPromptHint) {
@@ -160,14 +184,20 @@ function wait(ms: number): Promise<void> {
   });
 }
 
-function finalizeMetrics(startedAt: number, partial: Omit<GenerationMetrics, "totalMs"> = {}): GenerationMetrics {
+function finalizeMetrics(
+  startedAt: number,
+  partial: Omit<GenerationMetrics, "totalMs"> = {}
+): GenerationMetrics {
   return {
     ...partial,
     totalMs: Date.now() - startedAt,
   };
 }
 
-function attachGenerationMetrics(error: unknown, metrics: GenerationMetrics): unknown {
+function attachGenerationMetrics(
+  error: unknown,
+  metrics: GenerationMetrics
+): unknown {
   if (error instanceof Error) {
     (error as ErrorWithGenerationMetrics).generationMetrics = metrics;
   }
@@ -175,7 +205,9 @@ function attachGenerationMetrics(error: unknown, metrics: GenerationMetrics): un
   return error;
 }
 
-export function getGenerationMetrics(error: unknown): GenerationMetrics | undefined {
+export function getGenerationMetrics(
+  error: unknown
+): GenerationMetrics | undefined {
   if (error instanceof Error) {
     return (error as ErrorWithGenerationMetrics).generationMetrics;
   }
@@ -204,7 +236,10 @@ function parseAllowedHostsFromEnv(): string[] {
 
 function isPrivateIPv4(ip: string): boolean {
   const parts = ip.split(".").map(x => Number(x));
-  if (parts.length !== 4 || parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)) {
+  if (
+    parts.length !== 4 ||
+    parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)
+  ) {
     return true;
   }
 
@@ -219,7 +254,10 @@ function isPrivateIPv4(ip: string): boolean {
   return false;
 }
 
-function hostnameMatchesAllowedHost(hostname: string, allowedHost: string): boolean {
+function hostnameMatchesAllowedHost(
+  hostname: string,
+  allowedHost: string
+): boolean {
   return hostname === allowedHost || hostname.endsWith(`.${allowedHost}`);
 }
 
@@ -237,14 +275,23 @@ function isBlockedHostname(hostname: string): boolean {
   if (ipType === 6) {
     if (h === "::1") return true;
     if (h.startsWith("fc") || h.startsWith("fd")) return true;
-    if (h.startsWith("fe8") || h.startsWith("fe9") || h.startsWith("fea") || h.startsWith("feb")) return true;
+    if (
+      h.startsWith("fe8") ||
+      h.startsWith("fe9") ||
+      h.startsWith("fea") ||
+      h.startsWith("feb")
+    )
+      return true;
     return true;
   }
 
   return false;
 }
 
-export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: string): URL {
+export function validateSourceImageUrlOrThrow(
+  sourceImageUrl: string,
+  reqId?: string
+): URL {
   let parsedUrl: URL;
 
   try {
@@ -256,40 +303,70 @@ export function validateSourceImageUrlOrThrow(sourceImageUrl: string, reqId?: st
 
   const hostname = parsedUrl.hostname.toLowerCase();
   if (parsedUrl.protocol !== "https:") {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_https", protocol: parsedUrl.protocol });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "non_https",
+      protocol: parsedUrl.protocol,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (parsedUrl.username || parsedUrl.password) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "credentials_in_url" });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "credentials_in_url",
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (parsedUrl.port && parsedUrl.port !== "443") {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "non_standard_port", port: parsedUrl.port });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "non_standard_port",
+      port: parsedUrl.port,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   if (isBlockedHostname(hostname)) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "blocked_hostname", hostname });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "blocked_hostname",
+      hostname,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   const allowedHosts = parseAllowedHostsFromEnv();
   if (allowedHosts.length === 0) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "allowlist_not_configured" });
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "allowlist_not_configured",
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
-  if (!allowedHosts.some(allowedHost => hostnameMatchesAllowedHost(hostname, allowedHost))) {
-    console.warn("SOURCE_IMAGE_URL_BLOCKED", { reqId, reason: "host_not_allowed", hostname });
+  if (
+    !allowedHosts.some(allowedHost =>
+      hostnameMatchesAllowedHost(hostname, allowedHost)
+    )
+  ) {
+    console.warn("SOURCE_IMAGE_URL_BLOCKED", {
+      reqId,
+      reason: "host_not_allowed",
+      hostname,
+    });
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
   return parsedUrl;
 }
 
-async function fetchWithTimeout(input: URL, init: RequestInit | undefined, timeoutMs: number): Promise<Response> {
+async function fetchWithTimeout(
+  input: URL,
+  init: RequestInit | undefined,
+  timeoutMs: number
+): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => {
     controller.abort();
@@ -306,14 +383,20 @@ async function fetchWithTimeout(input: URL, init: RequestInit | undefined, timeo
   }
 }
 
-async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string): Promise<{
+async function downloadSourceImageOrThrow(
+  sourceImageUrl: string,
+  reqId: string
+): Promise<{
   imageBuffer: Buffer;
   contentType: string;
   incomingLen: number;
   incomingSha256: string;
   fbImageFetchMs: number;
 }> {
-  const validatedSourceImageUrl = validateSourceImageUrlOrThrow(sourceImageUrl, reqId);
+  const validatedSourceImageUrl = validateSourceImageUrlOrThrow(
+    sourceImageUrl,
+    reqId
+  );
   const timeoutMs = getInboundImageTimeoutMs();
   let totalFetchMs = 0;
 
@@ -321,8 +404,13 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
     const attemptStartedAt = Date.now();
 
     try {
-      const response = await fetchWithTimeout(validatedSourceImageUrl, { redirect: "manual" }, timeoutMs);
-      const contentType = response.headers.get("content-type") ?? "application/octet-stream";
+      const response = await fetchWithTimeout(
+        validatedSourceImageUrl,
+        { redirect: "manual" },
+        timeoutMs
+      );
+      const contentType =
+        response.headers.get("content-type") ?? "application/octet-stream";
 
       if (isRedirectStatus(response.status)) {
         console.warn("SOURCE_IMAGE_URL_BLOCKED", {
@@ -337,13 +425,26 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       if (!response.ok) {
         totalFetchMs += Date.now() - attemptStartedAt;
 
-        if (attempt < FB_IMAGE_FETCH_RETRY_LIMIT && isRetryableResponseStatus(response.status)) {
-          console.debug("FB_IMAGE_FETCH_RETRY", { reqId, attempt: attempt + 1, status: response.status });
+        if (
+          attempt < FB_IMAGE_FETCH_RETRY_LIMIT &&
+          isRetryableResponseStatus(response.status)
+        ) {
+          console.debug("FB_IMAGE_FETCH_RETRY", {
+            reqId,
+            attempt: attempt + 1,
+            status: response.status,
+          });
           continue;
         }
 
-        console.error("MISSING_INPUT_IMAGE", { reqId, reason: "download_failed", status: response.status });
-        throw new MissingInputImageError(`Failed to download source image (${response.status})`);
+        console.error("MISSING_INPUT_IMAGE", {
+          reqId,
+          reason: "download_failed",
+          status: response.status,
+        });
+        throw new MissingInputImageError(
+          `Failed to download source image (${response.status})`
+        );
       }
 
       const imageBuffer = Buffer.from(await response.arrayBuffer());
@@ -368,8 +469,14 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       }
 
       if (incomingByteLen < MIN_INPUT_IMAGE_BYTES) {
-        console.error("MISSING_INPUT_IMAGE", { reqId, reason: "too_small", byte_len: incomingByteLen });
-        throw new MissingInputImageError(`Source image too small (${incomingByteLen} bytes)`);
+        console.error("MISSING_INPUT_IMAGE", {
+          reqId,
+          reason: "too_small",
+          byte_len: incomingByteLen,
+        });
+        throw new MissingInputImageError(
+          `Source image too small (${incomingByteLen} bytes)`
+        );
       }
 
       return {
@@ -380,13 +487,19 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
         fbImageFetchMs: totalFetchMs,
       };
     } catch (error) {
-      if (error instanceof MissingInputImageError || error instanceof InvalidSourceImageUrlError) {
+      if (
+        error instanceof MissingInputImageError ||
+        error instanceof InvalidSourceImageUrlError
+      ) {
         throw error;
       }
 
       totalFetchMs += Date.now() - attemptStartedAt;
 
-      if (attempt < FB_IMAGE_FETCH_RETRY_LIMIT && isTransientNetworkError(error)) {
+      if (
+        attempt < FB_IMAGE_FETCH_RETRY_LIMIT &&
+        isTransientNetworkError(error)
+      ) {
         console.debug("FB_IMAGE_FETCH_RETRY", {
           reqId,
           attempt: attempt + 1,
@@ -398,7 +511,10 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
       if (isTransientNetworkError(error)) {
         console.error("MISSING_INPUT_IMAGE", {
           reqId,
-          reason: error instanceof Error && error.name === "AbortError" ? "download_timeout" : "download_network_error",
+          reason:
+            error instanceof Error && error.name === "AbortError"
+              ? "download_timeout"
+              : "download_network_error",
         });
         throw new MissingInputImageError("Failed to download source image");
       }
@@ -411,9 +527,20 @@ async function downloadSourceImageOrThrow(sourceImageUrl: string, reqId: string)
 }
 
 export class OpenAiImageGenerator implements ImageGenerator {
-  async generate(input: { style: Style; sourceImageUrl?: string; promptHint?: string; userKey: string; reqId: string }): Promise<{
+  async generate(input: {
+    style: Style;
+    sourceImageUrl?: string;
+    promptHint?: string;
+    userKey: string;
+    reqId: string;
+  }): Promise<{
     imageUrl: string;
-    proof: { incomingLen: number; incomingSha256: string; openaiInputLen: number; openaiInputSha256: string };
+    proof: {
+      incomingLen: number;
+      incomingSha256: string;
+      openaiInputLen: number;
+      openaiInputSha256: string;
+    };
     metrics: GenerationMetrics;
   }> {
     const startedAt = Date.now();
@@ -423,7 +550,10 @@ export class OpenAiImageGenerator implements ImageGenerator {
     }
 
     if (!input.sourceImageUrl) {
-      console.error("MISSING_INPUT_IMAGE", { reqId: input.reqId, reason: "missing_source_url" });
+      console.error("MISSING_INPUT_IMAGE", {
+        reqId: input.reqId,
+        reason: "missing_source_url",
+      });
       throw new MissingInputImageError("sourceImageUrl is required");
     }
 
@@ -432,7 +562,13 @@ export class OpenAiImageGenerator implements ImageGenerator {
     }
 
     try {
-      const { imageBuffer, contentType, incomingLen, incomingSha256, fbImageFetchMs } = await downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId);
+      const {
+        imageBuffer,
+        contentType,
+        incomingLen,
+        incomingSha256,
+        fbImageFetchMs,
+      } = await downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId);
       partialMetrics.fbImageFetchMs = fbImageFetchMs;
       const openAiInputHash = sha256(imageBuffer);
       const openAiInputByteLen = safeLen(imageBuffer);
@@ -448,7 +584,11 @@ export class OpenAiImageGenerator implements ImageGenerator {
         formData.set("prompt", prompt);
         formData.set("size", "1024x1024");
         formData.set("output_format", "jpeg");
-        formData.set("image", new Blob([new Uint8Array(imageBuffer)], { type: contentType }), "source-image");
+        formData.set(
+          "image",
+          new Blob([new Uint8Array(imageBuffer)], { type: contentType }),
+          "source-image"
+        );
         return formData;
       };
 
@@ -465,13 +605,19 @@ export class OpenAiImageGenerator implements ImageGenerator {
               },
               body: createOpenAiFormData(),
             },
-            openAiTimeoutMs,
+            openAiTimeoutMs
           );
         } catch (error) {
-          partialMetrics.openAiMs = (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
+          partialMetrics.openAiMs =
+            (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
           if (attempt < openAiRetryLimit && isTransientNetworkError(error)) {
             const waitMs = openAiRetryBaseMs * 2 ** attempt;
-            console.warn("OPENAI_GENERATION_RETRY", { reqId: input.reqId, attempt: attempt + 1, waitMs, reason: (error as Error).name });
+            console.warn("OPENAI_GENERATION_RETRY", {
+              reqId: input.reqId,
+              attempt: attempt + 1,
+              waitMs,
+              reason: (error as Error).name,
+            });
             await wait(waitMs);
             continue;
           }
@@ -479,14 +625,23 @@ export class OpenAiImageGenerator implements ImageGenerator {
           throw error;
         }
 
-        partialMetrics.openAiMs = (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
+        partialMetrics.openAiMs =
+          (partialMetrics.openAiMs ?? 0) + (Date.now() - openAiStartedAt);
         if (response.ok) {
           break;
         }
 
-        if (attempt < openAiRetryLimit && isRetryableResponseStatus(response.status)) {
+        if (
+          attempt < openAiRetryLimit &&
+          isRetryableResponseStatus(response.status)
+        ) {
           const waitMs = openAiRetryBaseMs * 2 ** attempt;
-          console.warn("OPENAI_GENERATION_RETRY", { reqId: input.reqId, attempt: attempt + 1, waitMs, status: response.status });
+          console.warn("OPENAI_GENERATION_RETRY", {
+            reqId: input.reqId,
+            attempt: attempt + 1,
+            waitMs,
+            status: response.status,
+          });
           await wait(waitMs);
           continue;
         }
@@ -495,26 +650,36 @@ export class OpenAiImageGenerator implements ImageGenerator {
       }
 
       if (!response) {
-        throw new OpenAiGenerationError("OpenAI request failed before receiving a response");
+        throw new OpenAiGenerationError(
+          "OpenAI request failed before receiving a response"
+        );
       }
 
       if (!response.ok) {
         throw attachGenerationMetrics(
-          new OpenAiGenerationError(`OpenAI request failed (${response.status} ${response.statusText})`),
-          finalizeMetrics(startedAt, partialMetrics),
+          new OpenAiGenerationError(
+            `OpenAI request failed (${response.status} ${response.statusText})`
+          ),
+          finalizeMetrics(startedAt, partialMetrics)
         );
       }
 
-      const result = (await response.json()) as { data?: Array<{ b64_json?: string }> };
+      const result = (await response.json()) as {
+        data?: Array<{ b64_json?: string }>;
+      };
       const base64Image = result.data?.[0]?.b64_json;
 
       if (!base64Image) {
-        throw new OpenAiGenerationError("OpenAI response did not include base64 image data");
+        throw new OpenAiGenerationError(
+          "OpenAI response did not include base64 image data"
+        );
       }
 
       const imageBufferResult = Buffer.from(base64Image, "base64");
       if (imageBufferResult.length <= 0) {
-        throw new OpenAiGenerationError("OpenAI response image data was empty after base64 decode");
+        throw new OpenAiGenerationError(
+          "OpenAI response image data was empty after base64 decode"
+        );
       }
 
       const jpegBuffer = ensureJpegBuffer(imageBufferResult);
@@ -537,15 +702,24 @@ export class OpenAiImageGenerator implements ImageGenerator {
       if ((error as { name?: string })?.name === "AbortError") {
         throw attachGenerationMetrics(
           new GenerationTimeoutError("OpenAI generation timed out"),
-          finalizeMetrics(startedAt, partialMetrics),
+          finalizeMetrics(startedAt, partialMetrics)
         );
       }
 
-      throw attachGenerationMetrics(error, finalizeMetrics(startedAt, getGenerationMetrics(error) ?? partialMetrics));
+      throw attachGenerationMetrics(
+        error,
+        finalizeMetrics(
+          startedAt,
+          getGenerationMetrics(error) ?? partialMetrics
+        )
+      );
     }
   }
 }
 
-export function createImageGenerator(mode: GeneratorMode = "openai"): { mode: GeneratorMode; generator: ImageGenerator } {
+export function createImageGenerator(mode: GeneratorMode = "openai"): {
+  mode: GeneratorMode;
+  generator: ImageGenerator;
+} {
   return { mode, generator: new OpenAiImageGenerator() };
 }

--- a/server/_core/messengerStyles.ts
+++ b/server/_core/messengerStyles.ts
@@ -6,7 +6,8 @@ export type Style =
   | "cinematic"
   | "disco"
   | "cyberpunk"
-  | "oil-paint";
+  | "oil-paint"
+  | "norman-blackwell";
 
 export type StyleId =
   | "STYLE_CARICATURE"
@@ -17,6 +18,7 @@ export type StyleId =
   | "STYLE_DISCO"
   | "STYLE_CLOUDS"
   | "STYLE_CYBERPUNK"
+  | "STYLE_NORMAN_BLACKWELL"
   | "gold";
 
 export type StyleConfig = {
@@ -62,6 +64,12 @@ export const STYLE_CONFIGS: StyleConfig[] = [
     payload: "STYLE_CYBERPUNK",
     style: "cyberpunk",
     label: "🌃 Cyberpunk",
+  },
+  {
+    id: "STYLE_NORMAN_BLACKWELL",
+    payload: "STYLE_NORMAN_BLACKWELL",
+    style: "norman-blackwell",
+    label: "📰 Norman Blackwell",
   },
   {
     id: "STYLE_DISCO",

--- a/server/_core/webhookHelpers.ts
+++ b/server/_core/webhookHelpers.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { normalizeLang, t, type Lang } from "./i18n";
-import { getQuickRepliesForState, type ConversationState } from "./messengerState";
+import {
+  getQuickRepliesForState,
+  type ConversationState,
+} from "./messengerState";
 import { type Style } from "./messengerStyles";
 
 export type FacebookWebhookEvent = {
@@ -49,6 +52,7 @@ export const STYLE_OPTIONS: Style[] = [
   "cinematic",
   "oil-paint",
   "cyberpunk",
+  "norman-blackwell",
   "disco",
   "clouds",
 ];
@@ -60,6 +64,7 @@ export const STYLE_LABELS: Record<Style, string> = {
   cinematic: "Cinematic",
   "oil-paint": "Oil Paint",
   cyberpunk: "Cyberpunk",
+  "norman-blackwell": "Norman Blackwell",
   disco: "Disco",
   clouds: "Clouds",
 };
@@ -68,14 +73,12 @@ const STYLE_ALIASES: Record<string, Style> = {
   "oil paint": "oil-paint",
   "oil painting": "oil-paint",
   "oil-paint": "oil-paint",
+  "norman blackwell": "norman-blackwell",
+  blackwell: "norman-blackwell",
 };
 
 function normalizeStyleToken(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[_-]+/g, " ")
-    .replace(/\s+/g, " ");
+  return input.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
 }
 
 export type AckKind = "like" | "ok" | "thanks" | "emoji";
@@ -87,7 +90,7 @@ type GreetingResponse =
 export function getEventDedupeKey(
   event: FacebookWebhookEvent,
   userKey: string,
-  entryId?: string,
+  entryId?: string
 ): string | undefined {
   const messageId = event.message?.mid?.trim();
   if (messageId) {
@@ -100,10 +103,17 @@ export function getEventDedupeKey(
       return "none";
     }
 
-    return createHash("sha256").update(normalizedValue).digest("hex").slice(0, 12);
+    return createHash("sha256")
+      .update(normalizedValue)
+      .digest("hex")
+      .slice(0, 12);
   };
 
-  const eventType = event.message ? "message" : event.postback ? "postback" : "other";
+  const eventType = event.message
+    ? "message"
+    : event.postback
+      ? "postback"
+      : "other";
   const postbackPayloadHash = hashToken(event.postback?.payload);
   const quickReplyPayloadHash = hashToken(event.message?.quick_reply?.payload);
   const hasText = event.message?.text?.trim() ? "1" : "0";
@@ -114,10 +124,12 @@ export function getEventDedupeKey(
       counts.set(type, (counts.get(type) ?? 0) + 1);
     }
 
-    return Array.from(counts.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([type, count]) => `${type}:${count}`)
-      .join(",") || "none";
+    return (
+      Array.from(counts.entries())
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([type, count]) => `${type}:${count}`)
+        .join(",") || "none"
+    );
   })();
   const fallbackEventFingerprint = [
     eventType,
@@ -141,8 +153,11 @@ export function getEventDedupeKey(
 }
 
 export function summarizeWebhook(payload: unknown): WebhookSummary {
-  const entries = Array.isArray((payload as { entry?: unknown[] } | null | undefined)?.entry)
-    ? (payload as { entry: Array<{ messaging?: FacebookWebhookEvent[] }> }).entry
+  const entries = Array.isArray(
+    (payload as { entry?: unknown[] } | null | undefined)?.entry
+  )
+    ? (payload as { entry: Array<{ messaging?: FacebookWebhookEvent[] }> })
+        .entry
     : [];
 
   const events = entries.flatMap(entry => {
@@ -153,8 +168,8 @@ export function summarizeWebhook(payload: unknown): WebhookSummary {
         new Set(
           (event.message?.attachments ?? [])
             .map(attachment => attachment.type?.trim())
-            .filter((type): type is string => Boolean(type)),
-        ),
+            .filter((type): type is string => Boolean(type))
+        )
       );
 
       let type: WebhookSummaryEvent["type"] = "unknown";
@@ -182,20 +197,28 @@ export function summarizeWebhook(payload: unknown): WebhookSummary {
 
   return {
     object:
-      typeof (payload as { object?: unknown } | null | undefined)?.object === "string"
-        ? ((payload as { object: string }).object)
+      typeof (payload as { object?: unknown } | null | undefined)?.object ===
+      "string"
+        ? (payload as { object: string }).object
         : undefined,
     entryCount: entries.length,
     events,
   };
 }
 
-export function getGreetingResponse(state: ConversationState, lang: Lang = normalizeLang(process.env.DEFAULT_MESSENGER_LANG)): GreetingResponse {
+export function getGreetingResponse(
+  state: ConversationState,
+  lang: Lang = normalizeLang(process.env.DEFAULT_MESSENGER_LANG)
+): GreetingResponse {
   switch (state) {
     case "PROCESSING":
       return { mode: "text", text: t(lang, "processingBlocked") };
     case "AWAITING_STYLE":
-      return { mode: "quick_replies", state: "AWAITING_STYLE", text: t(lang, "stylePicker") };
+      return {
+        mode: "quick_replies",
+        state: "AWAITING_STYLE",
+        text: t(lang, "stylePicker"),
+      };
     case "RESULT_READY":
       return {
         mode: "quick_replies",
@@ -212,7 +235,11 @@ export function getGreetingResponse(state: ConversationState, lang: Lang = norma
       return { mode: "text", text: t(lang, "textWithoutPhoto") };
     case "IDLE":
     default:
-      return { mode: "quick_replies", state: "IDLE", text: t(lang, "flowExplanation") };
+      return {
+        mode: "quick_replies",
+        state: "IDLE",
+        text: t(lang, "flowExplanation"),
+      };
   }
 }
 
@@ -236,7 +263,10 @@ export function stylePayloadToStyle(payload: string): Style | undefined {
     return undefined;
   }
 
-  const styleKey = payload.slice("STYLE_".length).toLowerCase().replace(/_/g, "-");
+  const styleKey = payload
+    .slice("STYLE_".length)
+    .toLowerCase()
+    .replace(/_/g, "-");
   return normalizeStyle(styleKey);
 }
 
@@ -276,7 +306,10 @@ export function detectAck(raw: string | undefined | null): AckKind | null {
     return "thanks";
   }
 
-  if (text.length > 0 && Array.from(text).every(char => /[\p{Extended_Pictographic}\s]/u.test(char))) {
+  if (
+    text.length > 0 &&
+    Array.from(text).every(char => /[\p{Extended_Pictographic}\s]/u.test(char))
+  ) {
     return "emoji";
   }
 

--- a/server/botFeatures.unit.test.ts
+++ b/server/botFeatures.unit.test.ts
@@ -8,7 +8,9 @@ import type { BotTextContext } from "./_core/botContext";
 import type { MessengerUserState } from "./_core/messengerState";
 import { resetStateStore } from "./_core/messengerState";
 
-function makeState(overrides: Partial<MessengerUserState> = {}): MessengerUserState {
+function makeState(
+  overrides: Partial<MessengerUserState> = {}
+): MessengerUserState {
   return {
     psid: "p1",
     userKey: "u1",
@@ -83,6 +85,24 @@ describe("styleCommandsFeature", () => {
 
     expect(handled).toEqual({ handled: true });
     expect(chooseStyle).toHaveBeenCalledWith("oil-paint");
+  });
+
+  it("accepts /style Norman Blackwell aliases and delegates style selection", async () => {
+    const chooseStyle = vi.fn(async () => undefined);
+    const context = makeContext({
+      state: makeState({
+        lastPhotoUrl: "https://img.example/source.jpg",
+        lastPhoto: "https://img.example/source.jpg",
+      }),
+      messageText: "/style norman blackwell",
+      normalizedText: "/style norman blackwell",
+      chooseStyle,
+    });
+
+    const handled = await styleCommandsFeature.onText?.(context);
+
+    expect(handled).toEqual({ handled: true });
+    expect(chooseStyle).toHaveBeenCalledWith("norman-blackwell");
   });
 
   it("accepts /style cyberpunk and delegates style selection", async () => {
@@ -213,7 +233,9 @@ describe("assistantCommandsFeature", () => {
           hasPhoto: true,
           sendText,
           runStyleGeneration,
-          state: makeState({ lastPhotoUrl: "https://img.example/original.jpg" }),
+          state: makeState({
+            lastPhotoUrl: "https://img.example/original.jpg",
+          }),
         })
       );
 
@@ -252,7 +274,9 @@ describe("statsFeature", () => {
   it("returns a readable admin-only stats block", async () => {
     process.env.MESSENGER_ADMIN_IDS = "p1";
     const sendText = vi.fn(async () => undefined);
-    const uptimeSpy = vi.spyOn(process, "uptime").mockReturnValue(3 * 3600 + 12 * 60);
+    const uptimeSpy = vi
+      .spyOn(process, "uptime")
+      .mockReturnValue(3 * 3600 + 12 * 60);
 
     try {
       const result = await statsFeature.onText?.(
@@ -268,7 +292,7 @@ describe("statsFeature", () => {
             errorCountToday: 0,
             averageGenerationLatencyMs: null,
           }),
-        }),
+        })
       );
 
       expect(result).toEqual({ handled: true });
@@ -285,7 +309,7 @@ describe("statsFeature", () => {
           "Bot uptime: 3h 12m",
           "",
           "Node-local stats for 2026-03-16",
-        ].join("\n"),
+        ].join("\n")
       );
     } finally {
       uptimeSpy.mockRestore();
@@ -303,7 +327,7 @@ describe("statsFeature", () => {
           messageText: "/stats",
           normalizedText: "/stats",
           sendText,
-        }),
+        })
       );
 
       expect(result).toEqual({ handled: false });

--- a/server/conversationalEditInterpreter.test.ts
+++ b/server/conversationalEditInterpreter.test.ts
@@ -28,6 +28,7 @@ describe("conversational edit interpreter", () => {
   it("detects likely edit requests before calling the model", () => {
     expect(looksLikePossibleEditRequest("make it darker")).toBe(true);
     expect(looksLikePossibleEditRequest("meer cinematic")).toBe(true);
+    expect(looksLikePossibleEditRequest("make it norman blackwell")).toBe(true);
     expect(looksLikePossibleEditRequest("what can you do?")).toBe(false);
   });
 

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { InvalidSourceImageUrlError, OpenAiImageGenerator } from "./_core/imageService";
+import {
+  InvalidSourceImageUrlError,
+  OpenAiImageGenerator,
+} from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
 
-const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
+const GENERATED_IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
 
 function toUrlString(url: string | URL): string {
   return typeof url === "string" ? url : url.toString();
@@ -44,7 +48,9 @@ describe("OpenAi image-to-image proof", () => {
       expect(imageBlob).toBeInstanceOf(Blob);
       const imageBuffer = Buffer.from(await (imageBlob as Blob).arrayBuffer());
       expect(sha256(imageBuffer)).toBe(fixtureHash);
-      expect(formData.get("prompt")).toContain("Apply disco style to this photo");
+      expect(formData.get("prompt")).toContain(
+        "Apply disco style to this photo"
+      );
       expect(formData.get("output_format")).toBe("jpeg");
 
       return {
@@ -64,7 +70,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.totalMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
@@ -87,8 +95,12 @@ describe("OpenAi image-to-image proof", () => {
       }
 
       const formData = init?.body as FormData;
-      expect(formData.get("prompt")).toContain("Apply disco style to this photo.");
-      expect(formData.get("prompt")).toContain("Additional direction: neon rain.");
+      expect(formData.get("prompt")).toContain(
+        "Apply disco style to this photo."
+      );
+      expect(formData.get("prompt")).toContain(
+        "Additional direction: neon rain."
+      );
 
       return {
         ok: true,
@@ -145,6 +157,48 @@ describe("OpenAi image-to-image proof", () => {
       sourceImageUrl: "https://img.example/source.jpg",
       userKey: "user-1",
       reqId: "req-cyberpunk-prompt",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the Norman Blackwell preset prompt for OpenAI edits", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+
+    const fixture = Buffer.alloc(7000, 9);
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url) === "https://img.example/source.jpg") {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => fixture,
+        } as Response;
+      }
+
+      const formData = init?.body as FormData;
+      const prompt = String(formData.get("prompt"));
+      expect(prompt).toContain("Norman Blackwell portrait style");
+      expect(prompt).toContain("nostalgic mid-century editorial illustration");
+      expect(prompt).toContain("warm Americana storytelling");
+      expect(prompt).toContain("vintage magazine cover feel");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "norman-blackwell",
+      sourceImageUrl: "https://img.example/source.jpg",
+      userKey: "user-1",
+      reqId: "req-norman-blackwell-prompt",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -223,7 +277,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-2",
-      }),
+      })
     ).rejects.toThrow("Source image too small");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -236,7 +290,10 @@ describe("OpenAi image-to-image proof", () => {
 
     const fixture = Buffer.alloc(7000, 9);
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg" && fetchMock.mock.calls.length === 1) {
+      if (
+        toUrlString(url) === "https://img.example/source.jpg" &&
+        fetchMock.mock.calls.length === 1
+      ) {
         throw new TypeError("temporary network failure");
       }
 
@@ -265,7 +322,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.fbImageFetchMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -284,7 +343,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://127.0.0.1/source.jpg",
         userKey: "user-1",
         reqId: "req-private-ip",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -322,7 +381,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
   });
 
   it("blocks hosts outside SOURCE_IMAGE_ALLOWED_HOSTS before fetch", async () => {
@@ -340,7 +401,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://other.example/source.jpg",
         userKey: "user-1",
         reqId: "req-deny-allowlist",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -361,7 +422,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://user:pass@img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-embedded-credentials",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -382,7 +443,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example:8443/source.jpg",
         userKey: "user-1",
         reqId: "req-non-standard-port",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -419,13 +480,12 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-insecure-app-base-url",
-      }),
+      })
     ).rejects.toThrow("APP_BASE_URL is missing or invalid");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     delete process.env.NODE_ENV;
   });
-
 
   it("retries OpenAI edits request on retryable status codes", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
@@ -471,7 +531,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -489,7 +551,7 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-no-allowlist",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -526,13 +588,13 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-redirect-error",
-      }),
+      })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       expect.any(URL),
-      expect.objectContaining({ redirect: "manual" }),
+      expect.objectContaining({ redirect: "manual" })
     );
   });
 
@@ -579,7 +641,9 @@ describe("OpenAi image-to-image proof", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(result.imageUrl).toMatch(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/);
+    expect(result.imageUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
     expect(result.metrics.openAiMs).toBeGreaterThanOrEqual(0);
   });
 
@@ -613,8 +677,10 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-empty-output-buffer",
-      }),
-    ).rejects.toThrow("OpenAI response image data was empty after base64 decode");
+      })
+    ).rejects.toThrow(
+      "OpenAI response image data was empty after base64 decode"
+    );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });

--- a/server/messengerStyles.test.ts
+++ b/server/messengerStyles.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { STYLE_CONFIGS, getStyleById, isStylePayload } from "./_core/messengerStyles";
+import {
+  STYLE_CONFIGS,
+  getStyleById,
+  isStylePayload,
+} from "./_core/messengerStyles";
 
 describe("messengerStyles", () => {
   it("exposes canonical style configs", () => {
@@ -10,6 +14,7 @@ describe("messengerStyles", () => {
       "cinematic",
       "oil-paint",
       "cyberpunk",
+      "norman-blackwell",
       "disco",
       "clouds",
     ]);
@@ -19,9 +24,13 @@ describe("messengerStyles", () => {
     expect(isStylePayload("STYLE_CINEMATIC")).toBe(true);
     expect(isStylePayload("STYLE_OIL_PAINT")).toBe(true);
     expect(isStylePayload("STYLE_CYBERPUNK")).toBe(true);
+    expect(isStylePayload("STYLE_NORMAN_BLACKWELL")).toBe(true);
     expect(isStylePayload("UNKNOWN_STYLE")).toBe(false);
     expect(getStyleById("STYLE_OIL_PAINT").label).toContain("Oil Paint");
     expect(getStyleById("STYLE_CYBERPUNK").label).toContain("Cyberpunk");
+    expect(getStyleById("STYLE_NORMAN_BLACKWELL").label).toContain(
+      "Norman Blackwell"
+    );
     expect(getStyleById("STYLE_DISCO").label).toContain("Disco");
   });
 });

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -1,6 +1,21 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-const { sendImageMock, sendQuickRepliesMock, sendTextMock, safeLogMock, generateMessengerReplyMock } = vi.hoisted(() => ({
+const {
+  sendImageMock,
+  sendQuickRepliesMock,
+  sendTextMock,
+  safeLogMock,
+  generateMessengerReplyMock,
+} = vi.hoisted(() => ({
   sendImageMock: vi.fn(async () => undefined),
   sendQuickRepliesMock: vi.fn(async () => undefined),
   sendTextMock: vi.fn(async () => undefined),
@@ -29,7 +44,12 @@ import {
   summarizeWebhook,
 } from "./_core/messengerWebhook";
 import { STYLE_CONFIGS } from "./_core/messengerStyles";
-import { anonymizePsid, getState, resetStateStore, setFlowState } from "./_core/messengerState";
+import {
+  anonymizePsid,
+  getState,
+  resetStateStore,
+  setFlowState,
+} from "./_core/messengerState";
 import { getEventDedupeKey } from "./_core/webhookHelpers";
 import { getBotFeatures } from "./_core/bot/features";
 
@@ -106,7 +126,11 @@ describe("webhook summary logging", () => {
               message: {
                 text: "super secret text",
                 is_echo: true,
-                attachments: [{ type: "image" }, { type: "audio" }, { payload: { url: "https://a" } }],
+                attachments: [
+                  { type: "image" },
+                  { type: "audio" },
+                  { payload: { url: "https://a" } },
+                ],
               },
             },
             {
@@ -188,8 +212,12 @@ describe("messenger webhook dedupe", () => {
   });
 
   it("registers built-in bot features", () => {
-    expect(getBotFeatures().map(feature => feature.name)).toContain("rateLimit");
-    expect(getBotFeatures().map(feature => feature.name)).toContain("styleCommands");
+    expect(getBotFeatures().map(feature => feature.name)).toContain(
+      "rateLimit"
+    );
+    expect(getBotFeatures().map(feature => feature.name)).toContain(
+      "styleCommands"
+    );
   });
 
   it("processes a message.mid only once", async () => {
@@ -201,7 +229,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "psid-123" },
               message: {
                 mid: "m_abc123",
-                attachments: [{ type: "image", payload: { url: "https://img.example/a.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/a.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -226,7 +259,12 @@ describe("messenger webhook dedupe", () => {
               message: {
                 mid: "mid-shared",
                 is_echo: true,
-                attachments: [{ type: "image", payload: { url: "https://img.example/echo.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/echo.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -242,7 +280,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "echo-user" },
               message: {
                 mid: "mid-shared",
-                attachments: [{ type: "image", payload: { url: "https://img.example/real.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/real.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -263,7 +306,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "psid-456" },
               timestamp: 1730000000000,
               message: {
-                attachments: [{ type: "image", payload: { url: "https://img.example/b.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/b.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -285,10 +333,12 @@ describe("messenger webhook dedupe", () => {
         sender: { id: "psid-same-ts" },
         timestamp,
         message: {
-          attachments: [{ type: "image", payload: { url: "https://img.example/a.jpg" } }],
+          attachments: [
+            { type: "image", payload: { url: "https://img.example/a.jpg" } },
+          ],
         },
       },
-      "psid-same-ts",
+      "psid-same-ts"
     );
 
     const textEventKey = getEventDedupeKey(
@@ -299,7 +349,7 @@ describe("messenger webhook dedupe", () => {
           text: "hello",
         },
       },
-      "psid-same-ts",
+      "psid-same-ts"
     );
 
     expect(imageEventKey).toBeDefined();
@@ -315,7 +365,11 @@ describe("messenger webhook dedupe", () => {
     };
 
     const first = getEventDedupeKey(duplicateEvent, "psid-dup-ts", "entry-dup");
-    const second = getEventDedupeKey(duplicateEvent, "psid-dup-ts", "entry-dup");
+    const second = getEventDedupeKey(
+      duplicateEvent,
+      "psid-dup-ts",
+      "entry-dup"
+    );
 
     expect(first).toBe(second);
     expect(first).toContain("entry:entry-dup");
@@ -333,7 +387,7 @@ describe("messenger webhook dedupe", () => {
         },
       },
       "anonymized-user-key",
-      "entry-sensitive",
+      "entry-sensitive"
     );
 
     expect(key).toBeDefined();
@@ -355,7 +409,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "psid-replay" },
               timestamp: 1730000000004,
               message: {
-                attachments: [{ type: "image", payload: { url: "https://img.example/replay.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/replay.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -379,7 +438,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "psid-entry-fallback" },
               timestamp: 1730000000001,
               message: {
-                attachments: [{ type: "image", payload: { url: "https://img.example/c.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/c.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -398,7 +462,9 @@ describe("messenger webhook dedupe", () => {
   });
 
   it("does not emit photo debug logs when debug logging is disabled", async () => {
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
 
     try {
       const expectedPsidHash = anonymizePsid("psid-host-log").slice(0, 12);
@@ -429,7 +495,7 @@ describe("messenger webhook dedupe", () => {
         .find(
           value =>
             typeof value === "string" &&
-            value.includes("\"msg\":\"photo_received\"")
+            value.includes('"msg":"photo_received"')
         );
 
       expect(photoReceivedCall).toBeUndefined();
@@ -497,8 +563,6 @@ describe("messenger webhook dedupe", () => {
     expect(getState(userId)?.lastUserMessageAt).toBe(1730000000123);
   });
 
-
-
   it("returns generated images for all canonical styles through the OpenAI path", async () => {
     const styles = STYLE_CONFIGS.map(style => style.style);
 
@@ -518,12 +582,20 @@ describe("messenger webhook dedupe", () => {
                 sender: { id: `style-user-${style}` },
                 message: {
                   mid: `mid-photo-${style}`,
-                  attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: { url: "https://img.example/source.jpg" },
+                    },
+                  ],
                 },
               },
               {
                 sender: { id: `style-user-${style}` },
-                message: { mid: `mid-style-${style}`, quick_reply: { payload: style } },
+                message: {
+                  mid: `mid-style-${style}`,
+                  quick_reply: { payload: style },
+                },
               },
             ],
           },
@@ -533,11 +605,12 @@ describe("messenger webhook dedupe", () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(sendImageMock).toHaveBeenCalledWith(
         `style-user-${style}`,
-        expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+        expect.stringMatching(
+          /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+        )
       );
     }
   });
-
 
   it("uses canonical quick-reply payload and APP_BASE_URL for image attachments", async () => {
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
@@ -551,7 +624,12 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "canonical-payload-user" },
               message: {
                 mid: "mid-photo-canonical",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
             {
@@ -568,7 +646,75 @@ describe("messenger webhook dedupe", () => {
 
     expect(sendImageMock).toHaveBeenCalledWith(
       "canonical-payload-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
+    );
+  });
+
+  it("routes STYLE_NORMAN_BLACKWELL quick replies through the same payload flow", async () => {
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const sourceImage = Buffer.alloc(6000, 7);
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      if (toUrlString(url).startsWith("https://img.example/")) {
+        return {
+          ok: true,
+          headers: new Headers({ "content-type": "image/jpeg" }),
+          arrayBuffer: async () => sourceImage,
+        } as Response;
+      }
+
+      const formData = init?.body as FormData;
+      expect(String(formData.get("prompt"))).toContain(
+        "Norman Blackwell portrait style"
+      );
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "norman-payload-user" },
+              message: {
+                mid: "mid-photo-norman-payload",
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
+              },
+            },
+            {
+              sender: { id: "norman-payload-user" },
+              message: {
+                mid: "mid-style-norman-payload",
+                quick_reply: { payload: "STYLE_NORMAN_BLACKWELL" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sendImageMock).toHaveBeenCalledWith(
+      "norman-payload-user",
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
+    );
+    expect(getState(anonymizePsid("norman-payload-user"))?.selectedStyle).toBe(
+      "norman-blackwell"
     );
   });
 
@@ -583,12 +729,20 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "mock-image-user" },
               message: {
                 mid: "mid-photo-1",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "mock-image-user" },
-              message: { mid: "mid-style-1", quick_reply: { payload: "disco" } },
+              message: {
+                mid: "mid-style-1",
+                quick_reply: { payload: "disco" },
+              },
             },
           ],
         },
@@ -597,15 +751,21 @@ describe("messenger webhook dedupe", () => {
 
     expect(sendImageMock).toHaveBeenCalledWith(
       "mock-image-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
     );
     expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
       "mock-image-user",
       "Klaar ✅",
       [
-        { content_type: "text", title: "Nieuwe stijl", payload: "CHOOSE_STYLE" },
+        {
+          content_type: "text",
+          title: "Nieuwe stijl",
+          payload: "CHOOSE_STYLE",
+        },
         { content_type: "text", title: "Privacy", payload: "PRIVACY_INFO" },
-      ],
+      ]
     );
   });
 
@@ -620,26 +780,50 @@ describe("messenger webhook dedupe", () => {
               sender: { id: "openai-missing-key-user" },
               message: {
                 mid: "mid-photo-openai-missing",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "openai-missing-key-user" },
-              message: { mid: "mid-style-openai-missing", quick_reply: { payload: "disco" } },
+              message: {
+                mid: "mid-style-openai-missing",
+                quick_reply: { payload: "disco" },
+              },
             },
           ],
         },
       ],
     });
 
-    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith("openai-missing-key-user", "AI generation isn’t enabled yet.", [
-      { content_type: "text", title: "Opnieuw", payload: "RETRY_STYLE_disco" },
-      { content_type: "text", title: "Andere", payload: "CHOOSE_STYLE" },
-    ]);
+    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
+      "openai-missing-key-user",
+      "AI generation isn’t enabled yet.",
+      [
+        {
+          content_type: "text",
+          title: "Opnieuw",
+          payload: "RETRY_STYLE_disco",
+        },
+        { content_type: "text", title: "Andere", payload: "CHOOSE_STYLE" },
+      ]
+    );
     expect(sendImageMock).not.toHaveBeenCalled();
     expect(sendTextMock).toHaveBeenCalledTimes(2);
-    expect(sendTextMock).toHaveBeenNthCalledWith(1, "openai-missing-key-user", "Ik maak nu je Disco-stijl.");
-    expect(sendTextMock).toHaveBeenNthCalledWith(2, "openai-missing-key-user", "Oeps. Probeer nog een stijl.");
+    expect(sendTextMock).toHaveBeenNthCalledWith(
+      1,
+      "openai-missing-key-user",
+      "Ik maak nu je Disco-stijl."
+    );
+    expect(sendTextMock).toHaveBeenNthCalledWith(
+      2,
+      "openai-missing-key-user",
+      "Oeps. Probeer nog een stijl."
+    );
   });
 
   it("reaches OpenAI generator path with API key", async () => {
@@ -674,12 +858,20 @@ describe("messenger webhook dedupe", () => {
                 sender: { id: "openai-success-user" },
                 message: {
                   mid: "mid-photo-openai-success",
-                  attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: { url: "https://img.example/source.jpg" },
+                    },
+                  ],
                 },
               },
               {
                 sender: { id: "openai-success-user" },
-                message: { mid: "mid-style-openai-success", quick_reply: { payload: "gold" } },
+                message: {
+                  mid: "mid-style-openai-success",
+                  quick_reply: { payload: "gold" },
+                },
               },
             ],
           },
@@ -692,12 +884,11 @@ describe("messenger webhook dedupe", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(sendImageMock).toHaveBeenCalledWith(
       "openai-success-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
     );
   });
-
-
-
 
   it("keeps failure context and retries selected style with prior photo", async () => {
     delete process.env.OPENAI_API_KEY;
@@ -713,12 +904,20 @@ describe("messenger webhook dedupe", () => {
               sender: { id: psid },
               message: {
                 mid: "mid-photo-retry-failure",
-                attachments: [{ type: "image", payload: { url: "https://img.example/retry.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/retry.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: psid },
-              message: { mid: "mid-style-retry-failure", quick_reply: { payload: "gold" } },
+              message: {
+                mid: "mid-style-retry-failure",
+                quick_reply: { payload: "gold" },
+              },
             },
           ],
         },
@@ -753,12 +952,12 @@ describe("messenger webhook dedupe", () => {
     expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
       psid,
       "What style should I use?",
-      expect.anything(),
+      expect.anything()
     );
     expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
       psid,
       "Pick a style using the buttons below 🙂",
-      expect.anything(),
+      expect.anything()
     );
     expect(sendQuickRepliesMock).toHaveBeenCalledWith(
       psid,
@@ -766,7 +965,7 @@ describe("messenger webhook dedupe", () => {
       [
         { content_type: "text", title: "Opnieuw", payload: "RETRY_STYLE_gold" },
         { content_type: "text", title: "Andere", payload: "CHOOSE_STYLE" },
-      ],
+      ]
     );
   });
   it("shows timeout message when OpenAI generation exceeds timeout", async () => {
@@ -799,12 +998,20 @@ describe("messenger webhook dedupe", () => {
                 sender: { id: "openai-timeout-user" },
                 message: {
                   mid: "mid-photo-openai-timeout",
-                  attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: { url: "https://img.example/source.jpg" },
+                    },
+                  ],
                 },
               },
               {
                 sender: { id: "openai-timeout-user" },
-                message: { mid: "mid-style-openai-timeout", quick_reply: { payload: "clouds" } },
+                message: {
+                  mid: "mid-style-openai-timeout",
+                  quick_reply: { payload: "clouds" },
+                },
               },
             ],
           },
@@ -814,17 +1021,30 @@ describe("messenger webhook dedupe", () => {
       vi.unstubAllGlobals();
     }
 
-    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith("openai-timeout-user", "This took too long.", [
-      { content_type: "text", title: "Opnieuw", payload: "RETRY_STYLE_clouds" },
-      { content_type: "text", title: "Andere", payload: "CHOOSE_STYLE" },
-    ]);
+    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
+      "openai-timeout-user",
+      "This took too long.",
+      [
+        {
+          content_type: "text",
+          title: "Opnieuw",
+          payload: "RETRY_STYLE_clouds",
+        },
+        { content_type: "text", title: "Andere", payload: "CHOOSE_STYLE" },
+      ]
+    );
   });
 
   it("style click during generation does not start a second run", async () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
 
-    let resolveFetch: ((value: { ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }) => void) | undefined;
+    let resolveFetch:
+      | ((value: {
+          ok: boolean;
+          json: () => Promise<{ data: Array<{ b64_json: string }> }>;
+        }) => void)
+      | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn((url: string | URL) => {
       if (toUrlString(url) === "https://img.example/source.jpg") {
@@ -835,7 +1055,10 @@ describe("messenger webhook dedupe", () => {
         } as Response);
       }
 
-      return new Promise<{ ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }>(resolve => {
+      return new Promise<{
+        ok: boolean;
+        json: () => Promise<{ data: Array<{ b64_json: string }> }>;
+      }>(resolve => {
         resolveFetch = resolve;
       });
     });
@@ -850,7 +1073,12 @@ describe("messenger webhook dedupe", () => {
                 sender: { id: "busy-user" },
                 message: {
                   mid: "mid-photo-busy",
-                  attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: { url: "https://img.example/source.jpg" },
+                    },
+                  ],
                 },
               },
             ],
@@ -864,7 +1092,10 @@ describe("messenger webhook dedupe", () => {
             messaging: [
               {
                 sender: { id: "busy-user" },
-                message: { mid: "mid-style-busy-1", quick_reply: { payload: "disco" } },
+                message: {
+                  mid: "mid-style-busy-1",
+                  quick_reply: { payload: "disco" },
+                },
               },
             ],
           },
@@ -887,7 +1118,10 @@ describe("messenger webhook dedupe", () => {
             messaging: [
               {
                 sender: { id: "busy-user" },
-                message: { mid: "mid-style-busy-2", quick_reply: { payload: "gold" } },
+                message: {
+                  mid: "mid-style-busy-2",
+                  quick_reply: { payload: "gold" },
+                },
               },
             ],
           },
@@ -895,7 +1129,10 @@ describe("messenger webhook dedupe", () => {
       });
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
-      expect(sendTextMock).toHaveBeenCalledWith("busy-user", "⏳ even geduld, ik ben nog bezig met jouw restyle");
+      expect(sendTextMock).toHaveBeenCalledWith(
+        "busy-user",
+        "⏳ even geduld, ik ben nog bezig met jouw restyle"
+      );
 
       const generatedImageBytes = Buffer.from("fake-png").toString("base64");
       resolveFetch?.({
@@ -912,7 +1149,12 @@ describe("messenger webhook dedupe", () => {
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
 
-    let resolveFetch: ((value: { ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }) => void) | undefined;
+    let resolveFetch:
+      | ((value: {
+          ok: boolean;
+          json: () => Promise<{ data: Array<{ b64_json: string }> }>;
+        }) => void)
+      | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn((url: string | URL) => {
       if (toUrlString(url) === "https://img.example/source.jpg") {
@@ -923,7 +1165,10 @@ describe("messenger webhook dedupe", () => {
         } as Response);
       }
 
-      return new Promise<{ ok: boolean; json: () => Promise<{ data: Array<{ b64_json: string }> }> }>(resolve => {
+      return new Promise<{
+        ok: boolean;
+        json: () => Promise<{ data: Array<{ b64_json: string }> }>;
+      }>(resolve => {
         resolveFetch = resolve;
       });
     });
@@ -938,7 +1183,12 @@ describe("messenger webhook dedupe", () => {
                 sender: { id: "busy-user-text" },
                 message: {
                   mid: "mid-photo-busy-text",
-                  attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                  attachments: [
+                    {
+                      type: "image",
+                      payload: { url: "https://img.example/source.jpg" },
+                    },
+                  ],
                 },
               },
             ],
@@ -952,7 +1202,10 @@ describe("messenger webhook dedupe", () => {
             messaging: [
               {
                 sender: { id: "busy-user-text" },
-                message: { mid: "mid-style-busy-text-1", quick_reply: { payload: "disco" } },
+                message: {
+                  mid: "mid-style-busy-text-1",
+                  quick_reply: { payload: "disco" },
+                },
               },
             ],
           },
@@ -974,7 +1227,10 @@ describe("messenger webhook dedupe", () => {
             messaging: [
               {
                 sender: { id: "busy-user-text" },
-                message: { mid: "mid-style-busy-text-2", quick_reply: { payload: "gold" } },
+                message: {
+                  mid: "mid-style-busy-text-2",
+                  quick_reply: { payload: "gold" },
+                },
               },
             ],
           },
@@ -997,7 +1253,6 @@ describe("messenger webhook dedupe", () => {
       vi.unstubAllGlobals();
     }
   });
-
 });
 
 describe("messenger text brain rollout", () => {
@@ -1026,7 +1281,12 @@ describe("messenger text brain rollout", () => {
               sender: { id: "legacy-user" },
               message: {
                 mid: "mid-legacy-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/legacy.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/legacy.jpg" },
+                  },
+                ],
               },
             },
             {
@@ -1041,7 +1301,7 @@ describe("messenger text brain rollout", () => {
     expect(generateMessengerReplyMock).not.toHaveBeenCalled();
     expect(sendTextMock).toHaveBeenLastCalledWith(
       "legacy-user",
-      "Stuur een foto en ik maak er een speciale versie van in een andere stijl — het is gratis.",
+      "Stuur een foto en ik maak er een speciale versie van in een andere stijl — het is gratis."
     );
   });
 
@@ -1061,12 +1321,20 @@ describe("messenger text brain rollout", () => {
               sender: { id: "responses-user" },
               message: {
                 mid: "mid-responses-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/responses.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/responses.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "responses-user" },
-              message: { mid: "mid-responses-text", text: "Wat kan ik nu doen?" },
+              message: {
+                mid: "mid-responses-text",
+                text: "Wat kan ik nu doen?",
+              },
             },
           ],
         },
@@ -1081,12 +1349,14 @@ describe("messenger text brain rollout", () => {
         hasPhoto: true,
         stage: "AWAITING_STYLE",
         text: "Wat kan ik nu doen?",
-      }),
+      })
     );
-    expect(generateMessengerReplyMock.mock.calls[0]?.[0]?.userKey).not.toBe("responses-user");
+    expect(generateMessengerReplyMock.mock.calls[0]?.[0]?.userKey).not.toBe(
+      "responses-user"
+    );
     expect(sendTextMock).toHaveBeenLastCalledWith(
       "responses-user",
-      "Kies een stijl via de knoppen hieronder.",
+      "Kies een stijl via de knoppen hieronder."
     );
   });
 
@@ -1102,7 +1372,12 @@ describe("messenger text brain rollout", () => {
               sender: { id: "canary-miss-user" },
               message: {
                 mid: "mid-canary-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/canary.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/canary.jpg" },
+                  },
+                ],
               },
             },
             {
@@ -1117,7 +1392,7 @@ describe("messenger text brain rollout", () => {
     expect(generateMessengerReplyMock).not.toHaveBeenCalled();
     expect(sendTextMock).toHaveBeenLastCalledWith(
       "canary-miss-user",
-      "Stuur een foto en ik maak er een speciale versie van in een andere stijl — het is gratis.",
+      "Stuur een foto en ik maak er een speciale versie van in een andere stijl — het is gratis."
     );
   });
 
@@ -1145,9 +1420,11 @@ describe("messenger text brain rollout", () => {
     expect(generateMessengerReplyMock).toHaveBeenCalledTimes(1);
     expect(sendTextMock).toHaveBeenLastCalledWith(
       "responses-fallback-user",
-      "Stuur gerust een foto, dan kan ik een stijl voor je maken.",
+      "Stuur gerust een foto, dan kan ik een stijl voor je maken."
     );
-    expect(getState(anonymizePsid("responses-fallback-user"))?.stage).toBe("AWAITING_PHOTO");
+    expect(getState(anonymizePsid("responses-fallback-user"))?.stage).toBe(
+      "AWAITING_PHOTO"
+    );
   });
 
   it("falls back to deterministic text when responses service throws", async () => {
@@ -1170,9 +1447,11 @@ describe("messenger text brain rollout", () => {
 
     expect(sendTextMock).toHaveBeenLastCalledWith(
       "responses-error-user",
-      "Stuur gerust een foto, dan kan ik een stijl voor je maken.",
+      "Stuur gerust een foto, dan kan ik een stijl voor je maken."
     );
-    expect(getState(anonymizePsid("responses-error-user"))?.stage).toBe("AWAITING_PHOTO");
+    expect(getState(anonymizePsid("responses-error-user"))?.stage).toBe(
+      "AWAITING_PHOTO"
+    );
   });
 
   it("does not affect attachment/style/image generation path when responses engine is enabled", async () => {
@@ -1188,12 +1467,20 @@ describe("messenger text brain rollout", () => {
               sender: { id: "responses-image-user" },
               message: {
                 mid: "mid-responses-image-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/image-path.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/image-path.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "responses-image-user" },
-              message: { mid: "mid-responses-image-style", quick_reply: { payload: "disco" } },
+              message: {
+                mid: "mid-responses-image-style",
+                quick_reply: { payload: "disco" },
+              },
             },
           ],
         },
@@ -1239,7 +1526,7 @@ describe("messenger greeting behavior", () => {
       expect.arrayContaining([
         { content_type: "text", title: "Wat doe ik?", payload: "WHAT_IS_THIS" },
         { content_type: "text", title: "Privacy", payload: "PRIVACY_INFO" },
-      ]),
+      ])
     );
   });
 
@@ -1252,7 +1539,12 @@ describe("messenger greeting behavior", () => {
               sender: { id: "style-user" },
               message: {
                 mid: "mid-style-1",
-                attachments: [{ type: "image", payload: { url: "https://img.example/style.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/style.jpg" },
+                  },
+                ],
               },
             },
             {
@@ -1272,7 +1564,7 @@ describe("messenger greeting behavior", () => {
         content_type: "text" as const,
         title: style.label,
         payload: style.payload,
-      })),
+      }))
     );
   });
 
@@ -1287,12 +1579,20 @@ describe("messenger greeting behavior", () => {
               sender: { id: "transition-order-user" },
               message: {
                 mid: "mid-transition-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "transition-order-user" },
-              message: { mid: "mid-transition-style", quick_reply: { payload: "gold" } },
+              message: {
+                mid: "mid-transition-style",
+                quick_reply: { payload: "gold" },
+              },
             },
           ],
         },
@@ -1303,24 +1603,37 @@ describe("messenger greeting behavior", () => {
       1,
       "transition-order-user",
       "Kies je stijl 👇",
-      expect.any(Array),
+      expect.any(Array)
     );
     expect(sendTextMock).toHaveBeenCalledTimes(1);
-    expect(sendTextMock).toHaveBeenCalledWith("transition-order-user", "Ik maak nu je Gold-stijl.");
+    expect(sendTextMock).toHaveBeenCalledWith(
+      "transition-order-user",
+      "Ik maak nu je Gold-stijl."
+    );
     expect(sendImageMock).toHaveBeenCalledTimes(1);
     expect(sendQuickRepliesMock).toHaveBeenNthCalledWith(
       2,
       "transition-order-user",
       "Klaar ✅",
       [
-        { content_type: "text", title: "Nieuwe stijl", payload: "CHOOSE_STYLE" },
+        {
+          content_type: "text",
+          title: "Nieuwe stijl",
+          payload: "CHOOSE_STYLE",
+        },
         { content_type: "text", title: "Privacy", payload: "PRIVACY_INFO" },
-      ],
+      ]
     );
 
-    expect(sendQuickRepliesMock.mock.invocationCallOrder[0]).toBeLessThan(sendTextMock.mock.invocationCallOrder[0]);
-    expect(sendTextMock.mock.invocationCallOrder[0]).toBeLessThan(sendImageMock.mock.invocationCallOrder[0]);
-    expect(sendImageMock.mock.invocationCallOrder[0]).toBeLessThan(sendQuickRepliesMock.mock.invocationCallOrder[1]);
+    expect(sendQuickRepliesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      sendTextMock.mock.invocationCallOrder[0]
+    );
+    expect(sendTextMock.mock.invocationCallOrder[0]).toBeLessThan(
+      sendImageMock.mock.invocationCallOrder[0]
+    );
+    expect(sendImageMock.mock.invocationCallOrder[0]).toBeLessThan(
+      sendQuickRepliesMock.mock.invocationCallOrder[1]
+    );
   });
 
   it("offers follow-up quick actions when state is RESULT_READY", async () => {
@@ -1341,14 +1654,10 @@ describe("messenger greeting behavior", () => {
       ],
     });
 
-    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
-      psid,
-      "Klaar ✅",
-      [
-        { content_type: "text", title: "Nieuwe stijl", payload: "CHOOSE_STYLE" },
-        { content_type: "text", title: "Privacy", payload: "PRIVACY_INFO" },
-      ],
-    );
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(psid, "Klaar ✅", [
+      { content_type: "text", title: "Nieuwe stijl", payload: "CHOOSE_STYLE" },
+      { content_type: "text", title: "Privacy", payload: "PRIVACY_INFO" },
+    ]);
   });
 
   it("offers retry actions when state is FAILURE", async () => {
@@ -1373,9 +1682,17 @@ describe("messenger greeting behavior", () => {
       psid,
       "Oeps. Probeer nog een stijl.",
       [
-        { content_type: "text", title: "Probeer opnieuw", payload: "RETRY_STYLE" },
-        { content_type: "text", title: "Andere stijl", payload: "CHOOSE_STYLE" },
-      ],
+        {
+          content_type: "text",
+          title: "Probeer opnieuw",
+          payload: "RETRY_STYLE",
+        },
+        {
+          content_type: "text",
+          title: "Andere stijl",
+          payload: "CHOOSE_STYLE",
+        },
+      ]
     );
   });
 });
@@ -1469,7 +1786,7 @@ describe("bot rate limit feature", () => {
 
     expect(sendTextMock).toHaveBeenLastCalledWith(
       senderId,
-      "⏳ Slow down a bit.",
+      "⏳ Slow down a bit."
     );
   });
 });
@@ -1507,7 +1824,7 @@ describe("bot conversational editing feature", () => {
             output_text:
               '{"shouldEdit":true,"style":"gold","promptHint":"make it darker with warm glow"}',
           }),
-          { status: 200 },
+          { status: 200 }
         );
       }
 
@@ -1527,12 +1844,20 @@ describe("bot conversational editing feature", () => {
               sender: { id: "edit-text-user" },
               message: {
                 mid: "mid-edit-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
             {
               sender: { id: "edit-text-user" },
-              message: { mid: "mid-edit-style", quick_reply: { payload: "disco" } },
+              message: {
+                mid: "mid-edit-style",
+                quick_reply: { payload: "disco" },
+              },
             },
           ],
         },
@@ -1549,7 +1874,10 @@ describe("bot conversational editing feature", () => {
           messaging: [
             {
               sender: { id: "edit-text-user" },
-              message: { mid: "mid-edit-command", text: "make it darker and more gold" },
+              message: {
+                mid: "mid-edit-command",
+                text: "make it darker and more gold",
+              },
             },
           ],
         },
@@ -1558,14 +1886,18 @@ describe("bot conversational editing feature", () => {
 
     expect(sendTextMock).toHaveBeenCalledWith(
       "edit-text-user",
-      "Ik maak nu je Gold-stijl.",
+      "Ik maak nu je Gold-stijl."
     );
     expect(sendImageMock).toHaveBeenCalledWith(
       "edit-text-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
     );
     expect(
-      combinedFetch.mock.calls.some(([url]) => toUrlString(url as string | URL).includes("/v1/responses")),
+      combinedFetch.mock.calls.some(([url]) =>
+        toUrlString(url as string | URL).includes("/v1/responses")
+      )
     ).toBe(true);
   });
 
@@ -1579,7 +1911,12 @@ describe("bot conversational editing feature", () => {
               sender: { id: "style-command-user" },
               message: {
                 mid: "mid-style-command-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -1597,7 +1934,10 @@ describe("bot conversational editing feature", () => {
           messaging: [
             {
               sender: { id: "style-command-user" },
-              message: { mid: "mid-style-command-text", text: "/style cyberpunk" },
+              message: {
+                mid: "mid-style-command-text",
+                text: "/style cyberpunk",
+              },
             },
           ],
         },
@@ -1606,14 +1946,20 @@ describe("bot conversational editing feature", () => {
 
     expect(sendTextMock).toHaveBeenCalledWith(
       "style-command-user",
-      "Ik maak nu je Cyberpunk-stijl.",
+      "Ik maak nu je Cyberpunk-stijl."
     );
     expect(sendImageMock).toHaveBeenCalledWith(
       "style-command-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
     );
-    expect(getState(anonymizePsid("style-command-user"))?.selectedStyle).toBe("cyberpunk");
-    expect(getState(anonymizePsid("style-command-user"))?.lastStyle).toBe("cyberpunk");
+    expect(getState(anonymizePsid("style-command-user"))?.selectedStyle).toBe(
+      "cyberpunk"
+    );
+    expect(getState(anonymizePsid("style-command-user"))?.lastStyle).toBe(
+      "cyberpunk"
+    );
   });
 
   it("persists /style cyberpunk for the next photo upload", async () => {
@@ -1623,7 +1969,10 @@ describe("bot conversational editing feature", () => {
           messaging: [
             {
               sender: { id: "style-preselect-user" },
-              message: { mid: "mid-style-preselect-text", text: "/style cyberpunk" },
+              message: {
+                mid: "mid-style-preselect-text",
+                text: "/style cyberpunk",
+              },
             },
           ],
         },
@@ -1632,7 +1981,7 @@ describe("bot conversational editing feature", () => {
 
     expect(sendTextMock).toHaveBeenCalledWith(
       "style-preselect-user",
-      "✅ Stijl ingesteld op cyberpunk.",
+      "✅ Stijl ingesteld op cyberpunk."
     );
     expect(sendImageMock).not.toHaveBeenCalled();
 
@@ -1649,7 +1998,12 @@ describe("bot conversational editing feature", () => {
               sender: { id: "style-preselect-user" },
               message: {
                 mid: "mid-style-preselect-photo",
-                attachments: [{ type: "image", payload: { url: "https://img.example/source.jpg" } }],
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
               },
             },
           ],
@@ -1659,13 +2013,19 @@ describe("bot conversational editing feature", () => {
 
     expect(sendTextMock).toHaveBeenCalledWith(
       "style-preselect-user",
-      "Ik maak nu je Cyberpunk-stijl.",
+      "Ik maak nu je Cyberpunk-stijl."
     );
     expect(sendImageMock).toHaveBeenCalledWith(
       "style-preselect-user",
-      expect.stringMatching(/^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/),
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
     );
-    expect(getState(anonymizePsid("style-preselect-user"))?.preselectedStyle).toBeNull();
-    expect(getState(anonymizePsid("style-preselect-user"))?.selectedStyle).toBe("cyberpunk");
+    expect(
+      getState(anonymizePsid("style-preselect-user"))?.preselectedStyle
+    ).toBeNull();
+    expect(getState(anonymizePsid("style-preselect-user"))?.selectedStyle).toBe(
+      "cyberpunk"
+    );
   });
 });

--- a/server/webhookHelpers.styleNormalization.test.ts
+++ b/server/webhookHelpers.styleNormalization.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { normalizeStyle, parseReferralStyle, parseStyle, stylePayloadToStyle } from "./_core/webhookHelpers";
+import {
+  normalizeStyle,
+  parseReferralStyle,
+  parseStyle,
+  stylePayloadToStyle,
+} from "./_core/webhookHelpers";
 
 describe("style normalization", () => {
   it("normalizes oil paint aliases to the canonical oil-paint key", () => {
@@ -14,4 +19,14 @@ describe("style normalization", () => {
     expect(stylePayloadToStyle("STYLE_OIL_PAINT")).toBe("oil-paint");
     expect(parseReferralStyle("style_oil-paint")).toBe("oil-paint");
   });
+});
+
+it("normalizes Norman Blackwell aliases to the canonical key", () => {
+  expect(normalizeStyle("Norman Blackwell")).toBe("norman-blackwell");
+  expect(normalizeStyle("blackwell")).toBe("norman-blackwell");
+  expect(parseStyle("norman blackwell")).toBe("norman-blackwell");
+  expect(stylePayloadToStyle("STYLE_NORMAN_BLACKWELL")).toBe(
+    "norman-blackwell"
+  );
+  expect(parseReferralStyle("style_norman-blackwell")).toBe("norman-blackwell");
 });


### PR DESCRIPTION
### Motivation

- Introduce a new canonical style variant inspired by Norman Blackwell and make it available everywhere the app recognizes or generates styles. 
- Ensure the new style is selectable via quick replies, CLI-like commands, payloads and conversational edit hints and that the OpenAI image-edit prompt uses a tuned preset for it. 

### Description

- Added `norman-blackwell` to the `Style` union, `StyleId`, `STYLE_CONFIGS`, `STYLE_OPTIONS`, `STYLE_LABELS`, and alias maps, and exposed it via `STYLE_IDS`/payload helpers. 
- Implemented a new preset prompt in `buildStylePrompt` for `norman-blackwell` and extended the conversational edit interpreter schema and parser to accept the new style. 
- Wired normalization, payload parsing and quick-reply flows so `norman-blackwell` is routable through the messenger webhook and image generation path, and updated several small formatting/logging and typing cleanups across core files. 
- Updated and added unit tests to cover normalization, CLI/command handling, conversational edit detection, and OpenAI prompt behavior for the new style. 

### Testing

- Ran unit tests including `messengerStyles.test.ts`, `webhookHelpers.styleNormalization.test.ts`, `imageService.proof.test.ts`, `messengerWebhook.test.ts`, `conversationalEditInterpreter.test.ts`, and `botFeatures.unit.test.ts`. 
- All updated and new tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac2ed08d48325bcc42ce3ab6f7742)