### PR TITLE
Avoid duplicate Messenger style pills

### DIFF
--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -472,6 +472,7 @@ export function createWebhookHandlers({ defaultLang, privacyPolicyUrl }: Handler
         })),
         reqId
       );
+      return;
     } catch (error) {
       safeLog("style_category_carousel_failed", {
         user: toLogUser(psid),

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -1790,36 +1790,15 @@ describe("messenger greeting behavior", () => {
         title: "Norman Blackwell",
       }),
     ]);
-    expect(sendQuickRepliesMock).toHaveBeenLastCalledWith(
+    expect(sendQuickRepliesMock).toHaveBeenCalledTimes(1);
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
       "category-user",
-      "Hier zijn je illustrated-stijlen. Kies er eentje hieronder.",
-      [
-        {
-          content_type: "text",
-          title: "🎨 Caricature",
-          payload: "STYLE_CARICATURE",
-        },
-        {
-          content_type: "text",
-          title: "🌿 Storybook Anime",
-          payload: "STYLE_STORYBOOK_ANIME",
-        },
-        {
-          content_type: "text",
-          title: "🖼️ Oil Paint",
-          payload: "STYLE_OIL_PAINT",
-        },
-        {
-          content_type: "text",
-          title: "📰 Norman Blackwell",
-          payload: "STYLE_NORMAN_BLACKWELL",
-        },
-        {
-          content_type: "text",
-          title: "Categorieen",
-          payload: "CHOOSE_STYLE",
-        },
-      ]
+      "Kies eerst een stijlgroep 👇",
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "STYLE_CATEGORY_ILLUSTRATED" }),
+        expect.objectContaining({ payload: "STYLE_CATEGORY_ATMOSPHERE" }),
+        expect.objectContaining({ payload: "STYLE_CATEGORY_BOLD" }),
+      ])
     );
   });
 


### PR DESCRIPTION
### Motivation
- Users saw duplicate UI because the bot sent both a carousel and a quick-reply pill row for the same style category.
- The intent is to show the carousel when available and only fall back to quick-reply style pills when the carousel fails.

### Description
- Return immediately after a successful `sendLoggedGenericTemplate` in `sendStyleOptionsForCategory` to avoid sending the extra quick-reply pill set (change in `server/_core/webhookHandlers.ts`).
- Keep the existing quick-reply fallback path so pills are still sent when the carousel request fails.
- Update `server/messengerWebhook.test.ts` to reflect the new behavior by expecting the category-picker quick replies only at the prior step and verifying fallback behavior when the carousel send fails.

### Testing
- Ran `pnpm vitest run server/messengerWebhook.test.ts server/messengerWebhook.photoFirst.test.ts server/messengerStyles.test.ts server/messengerState.test.ts` and all tests passed (`59 passed`).
- The modified tests specifically exercising the carousel + quick-reply flow were updated and pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbc05c8e54832589d526ddaca0c40d)