### PR TITLE
Share_bot_features_across_Messenger_and_WhatsApp

### DIFF
--- a/server/_core/botContext.ts
+++ b/server/_core/botContext.ts
@@ -1,4 +1,5 @@
 import type { Lang } from "./i18n";
+import type { BotChannel } from "./normalizedInboundMessage";
 import type {
   ConversationState,
   MessengerUserState,
@@ -15,7 +16,14 @@ export type BotLogger = {
   error(event: string, details?: Record<string, unknown>): void;
 };
 
+export type BotChannelCapabilities = {
+  quickReplies: boolean;
+  richTemplates: boolean;
+};
+
 type BotContextBase = {
+  channel: BotChannel;
+  capabilities: BotChannelCapabilities;
   senderId: string;
   userId: string;
   reqId: string;

--- a/server/_core/botResponseAdapters.ts
+++ b/server/_core/botResponseAdapters.ts
@@ -40,6 +40,8 @@ export async function sendWhatsAppBotResponse(
   response: BotResponse | null,
   options: {
     sendText: (text: string) => Promise<void>;
+    replyState?: ConversationState;
+    sendStateText?: (state: ConversationState, text: string) => Promise<void>;
   }
 ): Promise<void> {
   if (!response) {
@@ -49,6 +51,11 @@ export async function sendWhatsAppBotResponse(
   switch (response.kind) {
     case "text":
       if (!response.text) {
+        return;
+      }
+
+      if (options.replyState && options.sendStateText) {
+        await options.sendStateText(options.replyState, response.text);
         return;
       }
 

--- a/server/_core/i18n.ts
+++ b/server/_core/i18n.ts
@@ -10,6 +10,9 @@ type TranslationKey =
   | "stylePicker"
   | "styleCategoryPicker"
   | "styleCategoryCarouselIntro"
+  | "whatIsThis"
+  | "newStyle"
+  | "retry"
   | "success"
   | "processingBlocked"
   | "styleWithoutPhoto"
@@ -38,6 +41,9 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
     styleCategoryPicker: "Kies eerst een stijlgroep 👇",
     styleCategoryCarouselIntro: ({ styleLabel }) =>
       `Hier zijn je ${styleLabel ?? ""}-stijlen. Kies er eentje hieronder.`,
+    whatIsThis: "Wat doe ik?",
+    newStyle: "Nieuwe stijl",
+    retry: "Probeer opnieuw",
     success: "Klaar ✅",
     processingBlocked: "Even geduld — je vorige afbeelding is bijna klaar.",
     styleWithoutPhoto: "Stuur eerst een foto, dan maak ik die stijl voor je.",
@@ -68,6 +74,9 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
     styleCategoryPicker: "Pick a style group first 👇",
     styleCategoryCarouselIntro: ({ styleLabel }) =>
       `Here are your ${styleLabel ?? ""} styles. Pick one below.`,
+    whatIsThis: "What is this?",
+    newStyle: "New style",
+    retry: "Retry",
     success: "Done ✅",
     processingBlocked: "One sec — your previous image is almost done.",
     styleWithoutPhoto: "Send a photo first, then I can make that style for you.",

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -54,7 +54,10 @@ import {
 } from "./messengerStyles";
 import { canGenerate, increment } from "./messengerQuota";
 import { storeInboundSourceImage } from "./sourceImageStore";
-import { buildStateResponseText } from "./stateResponseText";
+import {
+  buildStateResponseText,
+  resolveStateReplyPayload,
+} from "./stateResponseText";
 import { getBotFeatures } from "./bot/features";
 import type { BotLogger, BotTextContext } from "./botContext";
 import { getTodayRuntimeStats } from "./botRuntimeStats";
@@ -309,6 +312,74 @@ async function sendWhatsAppStateText(
   await sendWhatsAppText(senderId, buildStateResponseText(state, text, lang));
 }
 
+function resolveWhatsAppPrivacyPolicyUrl(): string | undefined {
+  const configured = process.env.PRIVACY_POLICY_URL?.trim();
+  if (configured && /^https?:\/\//i.test(configured)) {
+    return configured;
+  }
+
+  const appBaseUrl =
+    process.env.APP_BASE_URL?.trim() ?? process.env.BASE_URL?.trim();
+  if (appBaseUrl && /^https?:\/\//i.test(appBaseUrl)) {
+    return `${appBaseUrl.replace(/\/$/, "")}/privacy`;
+  }
+
+  return undefined;
+}
+
+async function handleWhatsAppPayloadSelection(
+  payload: string,
+  event: NormalizedInboundMessage,
+  reqId: string,
+  lang: Lang
+): Promise<boolean> {
+  if (payload === "WHAT_IS_THIS") {
+    await sendWhatsAppText(event.senderId, t(lang, "flowExplanation"));
+    return true;
+  }
+
+  if (payload === "PRIVACY_INFO") {
+    const privacyUrl = resolveWhatsAppPrivacyPolicyUrl();
+    await sendWhatsAppText(
+      event.senderId,
+      t(lang, "privacy", { link: privacyUrl })
+    );
+    return true;
+  }
+
+  if (payload === "CHOOSE_STYLE") {
+    await setPreselectedStyle(event.senderId, null);
+    await setSelectedStyleCategory(event.senderId, null);
+    await setFlowState(event.senderId, "AWAITING_STYLE");
+    await sendWhatsAppStyleCategoryPrompt(event.senderId, lang);
+    return true;
+  }
+
+  if (payload === "RETRY_STYLE") {
+    const currentState = await Promise.resolve(getOrCreateState(event.senderId));
+    const retryStyle = currentState.selectedStyle
+      ? parseStyle(currentState.selectedStyle)
+      : undefined;
+
+    if (retryStyle) {
+      await runWhatsAppStyleGeneration(
+        event.senderId,
+        event.userId,
+        retryStyle,
+        reqId,
+        lang
+      );
+      return true;
+    }
+
+    await setFlowState(event.senderId, "AWAITING_STYLE");
+    await sendWhatsAppStyleCategoryPrompt(event.senderId, lang);
+    return true;
+  }
+
+  return false;
+}
+
 function createWhatsAppFeatureLogger(userId: string): BotLogger {
   return {
     info(event, details = {}) {
@@ -503,6 +574,23 @@ async function handleWhatsAppTextEvent(
   }
 
   if (textBody) {
+    const selectedPayload = resolveStateReplyPayload(
+      state.stage,
+      textBody,
+      lang
+    );
+    if (
+      selectedPayload &&
+      (await handleWhatsAppPayloadSelection(
+        selectedPayload,
+        event,
+        reqId,
+        lang
+      ))
+    ) {
+      return;
+    }
+
     const selectedStyle = parseWhatsAppStyleSelection(textBody, selectedCategory);
     if (selectedStyle && state.lastPhotoUrl) {
       await runWhatsAppStyleGeneration(

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -30,6 +30,7 @@ import {
   setLastGenerationContext,
   setLastUserMessageAt,
   setPendingImage,
+  setPreselectedStyle,
   setSelectedStyleCategory,
   setFlowState,
   type ConversationState,
@@ -53,6 +54,11 @@ import {
 } from "./messengerStyles";
 import { canGenerate, increment } from "./messengerQuota";
 import { storeInboundSourceImage } from "./sourceImageStore";
+import { buildStateResponseText } from "./stateResponseText";
+import { getBotFeatures } from "./bot/features";
+import type { BotLogger, BotTextContext } from "./botContext";
+import { getTodayRuntimeStats } from "./botRuntimeStats";
+import type { QuickReply } from "./messengerApi";
 
 const PRIVACY_POLICY_URL = process.env.PRIVACY_POLICY_URL?.trim() || "<link>";
 const DEFAULT_LANG = normalizeLang(process.env.DEFAULT_MESSENGER_LANG);
@@ -282,12 +288,110 @@ async function sendWhatsAppStyleOptions(
   await sendWhatsAppText(senderId, getWhatsAppStylePrompt(category, lang));
 }
 
+function buildWhatsAppReplyListText(text: string, replies: QuickReply[]): string {
+  if (replies.length === 0) {
+    return text;
+  }
+
+  return [
+    text,
+    "",
+    ...replies.map((reply, index) => `${index + 1}. ${reply.title}`),
+  ].join("\n");
+}
+
+async function sendWhatsAppStateText(
+  senderId: string,
+  state: ConversationState,
+  text: string,
+  lang: Lang
+): Promise<void> {
+  await sendWhatsAppText(senderId, buildStateResponseText(state, text, lang));
+}
+
+function createWhatsAppFeatureLogger(userId: string): BotLogger {
+  return {
+    info(event, details = {}) {
+      console.info("[whatsapp feature]", event, {
+        user: toLogUser(userId),
+        ...details,
+      });
+    },
+    warn(event, details = {}) {
+      console.warn("[whatsapp feature]", event, {
+        user: toLogUser(userId),
+        ...details,
+      });
+    },
+    error(event, details = {}) {
+      console.error("[whatsapp feature]", event, {
+        user: toLogUser(userId),
+        ...details,
+      });
+    },
+  };
+}
+
+function createWhatsAppTextContext(
+  event: NormalizedInboundMessage,
+  reqId: string,
+  lang: Lang,
+  state: Awaited<ReturnType<typeof getOrCreateState>>,
+  messageText: string,
+  normalizedText: string,
+  hasPhoto: boolean
+): BotTextContext {
+  return {
+    channel: "whatsapp",
+    capabilities: {
+      quickReplies: false,
+      richTemplates: false,
+    },
+    senderId: event.senderId,
+    userId: event.userId,
+    reqId,
+    lang,
+    state,
+    messageText,
+    normalizedText,
+    hasPhoto,
+    sendText: text => sendWhatsAppText(event.senderId, text),
+    sendImage: imageUrl => sendWhatsAppImage(event.senderId, imageUrl),
+    sendQuickReplies: (text, replies) =>
+      sendWhatsAppText(event.senderId, buildWhatsAppReplyListText(text, replies)),
+    sendStateQuickReplies: (nextState, text) =>
+      sendWhatsAppStateText(event.senderId, nextState, text, lang),
+    setFlowState: nextState =>
+      Promise.resolve(setFlowState(event.senderId, nextState)),
+    preselectStyle: style =>
+      Promise.resolve(setPreselectedStyle(event.senderId, style)).then(
+        () => undefined
+      ),
+    chooseStyle: style =>
+      runWhatsAppStyleGeneration(event.senderId, event.userId, style, reqId, lang),
+    runStyleGeneration: (style, sourceImageUrl, promptHint) =>
+      runWhatsAppStyleGeneration(
+        event.senderId,
+        event.userId,
+        style,
+        reqId,
+        lang,
+        sourceImageUrl,
+        promptHint
+      ),
+    getRuntimeStats: () => getTodayRuntimeStats(),
+    logger: createWhatsAppFeatureLogger(event.userId),
+  };
+}
+
 async function runWhatsAppStyleGeneration(
   senderId: string,
   userId: string,
   style: Style,
   reqId: string,
-  lang: Lang
+  lang: Lang,
+  sourceImageUrl?: string,
+  promptHint?: string
 ): Promise<void> {
   const allowed = await canGenerate(senderId);
   if (!allowed) {
@@ -302,7 +406,8 @@ async function runWhatsAppStyleGeneration(
   }
 
   const state = await Promise.resolve(getOrCreateState(senderId));
-  if (!state.lastPhotoUrl) {
+  const resolvedSourceImageUrl = sourceImageUrl ?? state.lastPhotoUrl ?? undefined;
+  if (!resolvedSourceImageUrl) {
     await setFlowState(senderId, "AWAITING_PHOTO");
     await sendWhatsAppText(senderId, t(lang, "styleWithoutPhoto"));
     return;
@@ -320,7 +425,8 @@ async function runWhatsAppStyleGeneration(
   try {
     const { imageUrl, metrics } = await generator.generate({
       style,
-      sourceImageUrl: state.lastPhotoUrl,
+      sourceImageUrl: resolvedSourceImageUrl,
+      promptHint,
       userKey: userId,
       reqId,
     });
@@ -328,7 +434,7 @@ async function runWhatsAppStyleGeneration(
     await sendWhatsAppImage(senderId, imageUrl);
     await increment(senderId);
     await setLastGenerated(senderId, imageUrl);
-    await setLastGenerationContext(senderId, { style });
+    await setLastGenerationContext(senderId, { style, prompt: promptHint });
     await setFlowState(senderId, "RESULT_READY");
     await sendWhatsAppText(
       senderId,
@@ -423,6 +529,31 @@ async function handleWhatsAppTextEvent(
     getState: () => Promise.resolve(getOrCreateState(event.senderId)),
     setFlowState: (nextState: ConversationState) =>
       Promise.resolve(setFlowState(event.senderId, nextState)),
+    runTextFeatures: async ({
+      state: currentState,
+      messageText,
+      normalizedText: currentNormalizedText,
+      hasPhoto,
+    }) => {
+      for (const feature of getBotFeatures()) {
+        const result = await feature.onText?.(
+          createWhatsAppTextContext(
+            event,
+            reqId,
+            lang,
+            currentState,
+            messageText,
+            currentNormalizedText,
+            hasPhoto
+          )
+        );
+        if (result?.handled) {
+          return true;
+        }
+      }
+
+      return false;
+    },
     logState: (currentState, context) => {
       console.log("[whatsapp webhook] shared state", {
         context,
@@ -435,6 +566,9 @@ async function handleWhatsAppTextEvent(
 
   await sendWhatsAppBotResponse(result.response, {
     sendText: text => sendWhatsAppText(event.senderId, text),
+    replyState: result.replyState,
+    sendStateText: (stateName, text) =>
+      sendWhatsAppStateText(event.senderId, stateName, text, lang),
   });
   if (result.afterSend === "markIntroSeen") {
     await Promise.resolve(markIntroSeen(event.senderId));
@@ -460,7 +594,23 @@ async function handleWhatsAppImageEvent(
     reqId
   );
 
+  const state = await Promise.resolve(getOrCreateState(event.senderId));
+  const preselectedStyle = normalizeStyle(state.preselectedStyle ?? "");
   await setPendingImage(event.senderId, persistedImageUrl);
+
+  if (preselectedStyle) {
+    await setPreselectedStyle(event.senderId, null);
+    await runWhatsAppStyleGeneration(
+      event.senderId,
+      event.userId,
+      preselectedStyle,
+      reqId,
+      lang,
+      persistedImageUrl
+    );
+    return;
+  }
+
   await sendWhatsAppStyleCategoryPrompt(event.senderId, lang);
 }
 

--- a/server/_core/stateResponseText.ts
+++ b/server/_core/stateResponseText.ts
@@ -1,0 +1,40 @@
+import { type Lang, t } from "./i18n";
+import {
+  getQuickRepliesForState,
+  type ConversationState,
+  type StateQuickReply,
+} from "./messengerState";
+
+function localizeReplyTitle(reply: StateQuickReply, lang: Lang): string {
+  switch (reply.payload) {
+    case "WHAT_IS_THIS":
+      return lang === "en" ? "What is this?" : "Wat doe ik?";
+    case "PRIVACY_INFO":
+      return t(lang, "privacyButtonLabel");
+    case "CHOOSE_STYLE":
+      return lang === "en" ? "New style" : "Nieuwe stijl";
+    case "RETRY_STYLE":
+      return lang === "en" ? "Retry" : "Probeer opnieuw";
+    default:
+      return reply.title;
+  }
+}
+
+export function buildStateResponseText(
+  state: ConversationState,
+  leadText: string,
+  lang: Lang
+): string {
+  const replies = getQuickRepliesForState(state);
+  if (replies.length === 0) {
+    return leadText;
+  }
+
+  return [
+    leadText,
+    "",
+    ...replies.map(
+      (reply, index) => `${index + 1}. ${localizeReplyTitle(reply, lang)}`
+    ),
+  ].join("\n");
+}

--- a/server/_core/stateResponseText.ts
+++ b/server/_core/stateResponseText.ts
@@ -8,13 +8,13 @@ import {
 function localizeReplyTitle(reply: StateQuickReply, lang: Lang): string {
   switch (reply.payload) {
     case "WHAT_IS_THIS":
-      return lang === "en" ? "What is this?" : "Wat doe ik?";
+      return t(lang, "whatIsThis");
     case "PRIVACY_INFO":
       return t(lang, "privacyButtonLabel");
     case "CHOOSE_STYLE":
-      return lang === "en" ? "New style" : "Nieuwe stijl";
+      return t(lang, "newStyle");
     case "RETRY_STYLE":
-      return lang === "en" ? "Retry" : "Probeer opnieuw";
+      return t(lang, "retry");
     default:
       return reply.title;
   }

--- a/server/_core/stateResponseText.ts
+++ b/server/_core/stateResponseText.ts
@@ -20,6 +20,38 @@ function localizeReplyTitle(reply: StateQuickReply, lang: Lang): string {
   }
 }
 
+function normalizeSelectionText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function resolveStateReplyPayload(
+  state: ConversationState,
+  rawSelection: string,
+  lang: Lang
+): string | undefined {
+  const replies = getQuickRepliesForState(state);
+  if (replies.length === 0) {
+    return undefined;
+  }
+
+  const normalizedSelection = normalizeSelectionText(rawSelection);
+  const selectedIndex = Number.parseInt(normalizedSelection, 10);
+  if (Number.isFinite(selectedIndex) && selectedIndex > 0) {
+    return replies[selectedIndex - 1]?.payload;
+  }
+
+  const matchedReply = replies.find(reply => {
+    const localizedTitle = normalizeSelectionText(localizeReplyTitle(reply, lang));
+    const rawTitle = normalizeSelectionText(reply.title);
+    return (
+      normalizedSelection === localizedTitle ||
+      normalizedSelection === rawTitle
+    );
+  });
+
+  return matchedReply?.payload;
+}
+
 export function buildStateResponseText(
   state: ConversationState,
   leadText: string,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -359,6 +359,11 @@ export function createWebhookHandlers({
     payload: string
   ): BotPayloadContext {
     return {
+      channel: "messenger",
+      capabilities: {
+        quickReplies: true,
+        richTemplates: true,
+      },
       senderId: psid,
       userId,
       reqId,
@@ -403,6 +408,11 @@ export function createWebhookHandlers({
     imageUrl: string
   ): BotImageContext {
     return {
+      channel: "messenger",
+      capabilities: {
+        quickReplies: true,
+        richTemplates: true,
+      },
       senderId: psid,
       userId,
       reqId,
@@ -449,6 +459,11 @@ export function createWebhookHandlers({
     hasPhoto: boolean
   ): BotTextContext {
     return {
+      channel: "messenger",
+      capabilities: {
+        quickReplies: true,
+        richTemplates: true,
+      },
       senderId: psid,
       userId,
       reqId,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -87,6 +87,10 @@ type HandlerDeps = {
 const IN_FLIGHT_MESSAGE =
   "\u23F3 even geduld, ik ben nog bezig met jouw restyle";
 const inFlightNoticeSent = new Set();
+const MESSENGER_CAPABILITIES = Object.freeze({
+  quickReplies: true,
+  richTemplates: true,
+});
 
 export function createWebhookHandlers({
   defaultLang,
@@ -360,10 +364,7 @@ export function createWebhookHandlers({
   ): BotPayloadContext {
     return {
       channel: "messenger",
-      capabilities: {
-        quickReplies: true,
-        richTemplates: true,
-      },
+      capabilities: MESSENGER_CAPABILITIES,
       senderId: psid,
       userId,
       reqId,
@@ -409,10 +410,7 @@ export function createWebhookHandlers({
   ): BotImageContext {
     return {
       channel: "messenger",
-      capabilities: {
-        quickReplies: true,
-        richTemplates: true,
-      },
+      capabilities: MESSENGER_CAPABILITIES,
       senderId: psid,
       userId,
       reqId,
@@ -460,10 +458,7 @@ export function createWebhookHandlers({
   ): BotTextContext {
     return {
       channel: "messenger",
-      capabilities: {
-        quickReplies: true,
-        richTemplates: true,
-      },
+      capabilities: MESSENGER_CAPABILITIES,
       senderId: psid,
       userId,
       reqId,

--- a/server/botResponseAdapters.test.ts
+++ b/server/botResponseAdapters.test.ts
@@ -52,6 +52,23 @@ describe("botResponseAdapters", () => {
     expect(sendText).toHaveBeenCalledWith("hello");
   });
 
+  it("maps a WhatsApp text response with replyState to state text sending", async () => {
+    const sendText = vi.fn(async () => {});
+    const sendStateText = vi.fn(async () => {});
+
+    await sendWhatsAppBotResponse(
+      { kind: "text", text: "hello" },
+      {
+        replyState: "AWAITING_STYLE",
+        sendText,
+        sendStateText,
+      }
+    );
+
+    expect(sendStateText).toHaveBeenCalledWith("AWAITING_STYLE", "hello");
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
   it("ignores non-text WhatsApp intents until channel support is added", async () => {
     const sendText = vi.fn(async () => {});
 

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -269,4 +269,118 @@ describe("whatsapp webhook flow", () => {
     );
     expect(getState(anonymizePsid("wa-user-4"))?.stage).toBe("AWAITING_STYLE");
   });
+
+  it("supports /style commands on WhatsApp before the user uploads a photo", async () => {
+    downloadWhatsAppMediaMock.mockResolvedValue({
+      buffer: Buffer.alloc(6000, 7),
+      contentType: "image/jpeg",
+    });
+
+    const sourceImage = Buffer.alloc(6000, 9);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const resolved = typeof url === "string" ? url : url.toString();
+
+        if (resolved.startsWith("https://leaderbot-fb-image-gen.fly.dev/generated/")) {
+          return {
+            ok: true,
+            headers: new Headers({ "content-type": "image/jpeg" }),
+            arrayBuffer: async () => sourceImage,
+          } as Response;
+        }
+
+        if (resolved === "https://api.openai.com/v1/images/edits") {
+          return {
+            ok: true,
+            json: async () => ({
+              data: [{ b64_json: Buffer.from("generated-image-2").toString("base64") }],
+            }),
+          } as Response;
+        }
+
+        throw new Error(`Unexpected fetch url: ${resolved}`);
+      })
+    );
+
+    await processWhatsAppWebhookPayload(
+      createWhatsAppPayload({
+        from: "wa-user-5",
+        timestamp: "1710000008",
+        type: "text",
+        text: { body: "/style cyberpunk" },
+      })
+    );
+
+    expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
+      "wa-user-5",
+      "✅ Stijl ingesteld op cyberpunk."
+    );
+    expect(getState(anonymizePsid("wa-user-5"))?.preselectedStyle).toBe(
+      "cyberpunk"
+    );
+
+    sendWhatsAppTextMock.mockClear();
+    sendWhatsAppImageMock.mockClear();
+
+    await processWhatsAppWebhookPayload(
+      createWhatsAppPayload({
+        from: "wa-user-5",
+        timestamp: "1710000009",
+        type: "image",
+        image: { id: "wamid-image-5" },
+      })
+    );
+
+    expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
+      "wa-user-5",
+      "Ik maak nu je Cyberpunk-stijl."
+    );
+    expect(sendWhatsAppImageMock).toHaveBeenCalledWith(
+      "wa-user-5",
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.jpg$/
+      )
+    );
+    expect(getState(anonymizePsid("wa-user-5"))?.preselectedStyle).toBeNull();
+    expect(getState(anonymizePsid("wa-user-5"))?.selectedStyle).toBe(
+      "cyberpunk"
+    );
+  });
+
+  it("runs shared help commands on WhatsApp with state-aware fallback options", async () => {
+    downloadWhatsAppMediaMock.mockResolvedValue({
+      buffer: Buffer.alloc(6000, 7),
+      contentType: "image/jpeg",
+    });
+
+    await processWhatsAppWebhookPayload(
+      createWhatsAppPayload({
+        from: "wa-user-6",
+        timestamp: "1710000010",
+        type: "image",
+        image: { id: "wamid-image-6" },
+      })
+    );
+
+    sendWhatsAppTextMock.mockClear();
+
+    await processWhatsAppWebhookPayload(
+      createWhatsAppPayload({
+        from: "wa-user-6",
+        timestamp: "1710000011",
+        type: "text",
+        text: { body: "help" },
+      })
+    );
+
+    expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
+      "wa-user-6",
+      expect.stringContaining("Quick actions")
+    );
+    expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
+      "wa-user-6",
+      expect.stringContaining("1. ")
+    );
+  });
 });

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -21,7 +21,12 @@ import {
   processWhatsAppWebhookPayload,
   resetMessengerEventDedupe,
 } from "./_core/messengerWebhook";
-import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
+import {
+  anonymizePsid,
+  getState,
+  resetStateStore,
+  setFlowState,
+} from "./_core/messengerState";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
@@ -381,6 +386,26 @@ describe("whatsapp webhook flow", () => {
     expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
       "wa-user-6",
       expect.stringContaining("1. ")
+    );
+  });
+
+  it("maps WhatsApp fallback menu selections back to their advertised actions", async () => {
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    const userKey = anonymizePsid("wa-user-7");
+    setFlowState(userKey, "RESULT_READY");
+
+    await processWhatsAppWebhookPayload(
+      createWhatsAppPayload({
+        from: "wa-user-7",
+        timestamp: "1710000013",
+        type: "text",
+        text: { body: "2" },
+      })
+    );
+
+    expect(sendWhatsAppTextMock).toHaveBeenCalledWith(
+      "wa-user-7",
+      expect.stringContaining("Privacybeleid: https://leaderbot-fb-image-gen.fly.dev/privacy")
     );
   });
 });

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -391,8 +391,7 @@ describe("whatsapp webhook flow", () => {
 
   it("maps WhatsApp fallback menu selections back to their advertised actions", async () => {
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    const userKey = anonymizePsid("wa-user-7");
-    setFlowState(userKey, "RESULT_READY");
+    setFlowState("wa-user-7", "RESULT_READY");
 
     await processWhatsAppWebhookPayload(
       createWhatsAppPayload({


### PR DESCRIPTION
## Summary
- run shared bot text features on WhatsApp instead of keeping them Messenger-only
- add state-aware WhatsApp text fallbacks so shared replies can render consistently across channels
- support preselected WhatsApp styles when a user sends a photo after a `/style ...` command

## Verification
- `pnpm check`
- `pnpm vitest run server/messengerWebhook.test.ts server/messengerWebhook.photoFirst.test.ts server/whatsappWebhook.test.ts`
- `pnpm vitest run server/whatsappWebhook.test.ts server/sharedTextHandler.test.ts server/botResponseAdapters.test.ts server/messengerWebhook.photoFirst.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bots advertise channel capabilities (quick replies, rich templates) and can emit state-aware text replies.
  * WhatsApp: preselect a style before image upload and auto-apply it on upload; retry-style flow supported.
  * Image generation accepts a source image and prompt hint.
  * Numbered, localized quick-action lists and new localized strings (whatIsThis, newStyle, retry).

* **Tests**
  * Added tests for WhatsApp stateful replies, style preselection/flow, and menu selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->