### PR TITLE
Add WhatsApp interactive message support with trusted source image handling

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -18,6 +18,7 @@ export interface ImageGenerator {
     style: Style;
     sourceImageUrl?: string;
     trustedSourceImageUrl?: boolean;
+    sourceImageProvenance?: "storeInbound";
     sourceImageData?: {
       buffer: Buffer;
       contentType: string;
@@ -429,7 +430,10 @@ function isBlockedHostname(hostname: string): boolean {
 export function validateSourceImageUrlOrThrow(
   sourceImageUrl: string,
   reqId?: string,
-  options?: { trustedSourceImageUrl?: boolean }
+  options?: {
+    trustedSourceImageUrl?: boolean;
+    sourceImageProvenance?: "storeInbound";
+  }
 ): URL {
   let parsedUrl: URL;
 
@@ -476,7 +480,11 @@ export function validateSourceImageUrlOrThrow(
     throw new InvalidSourceImageUrlError("sourceImageUrl is not allowed");
   }
 
-  if (!options?.trustedSourceImageUrl) {
+  const allowTrustedSourceBypass =
+    options?.trustedSourceImageUrl === true &&
+    options.sourceImageProvenance === "storeInbound";
+
+  if (!allowTrustedSourceBypass) {
     const allowedHosts = parseAllowedHostsFromEnv();
     if (allowedHosts.length === 0) {
       console.warn("SOURCE_IMAGE_URL_BLOCKED", {
@@ -527,7 +535,10 @@ async function fetchWithTimeout(
 async function downloadSourceImageOrThrow(
   sourceImageUrl: string,
   reqId: string,
-  options?: { trustedSourceImageUrl?: boolean }
+  options?: {
+    trustedSourceImageUrl?: boolean;
+    sourceImageProvenance?: "storeInbound";
+  }
 ): Promise<DownloadedSourceImage> {
   const validatedSourceImageUrl = validateSourceImageUrlOrThrow(
     sourceImageUrl,
@@ -680,6 +691,7 @@ export class OpenAiImageGenerator implements ImageGenerator {
     style: Style;
     sourceImageUrl?: string;
     trustedSourceImageUrl?: boolean;
+    sourceImageProvenance?: "storeInbound";
     sourceImageData?: {
       buffer: Buffer;
       contentType: string;
@@ -720,6 +732,7 @@ export class OpenAiImageGenerator implements ImageGenerator {
         console.info("SOURCE_IMAGE_FETCH_START", {
           reqId: input.reqId,
           trustedSourceImageUrl: Boolean(input.trustedSourceImageUrl),
+          sourceImageProvenance: input.sourceImageProvenance,
           ...getSourceUrlDiagnostics(input.sourceImageUrl),
         });
       }
@@ -727,6 +740,7 @@ export class OpenAiImageGenerator implements ImageGenerator {
         ? normalizeProvidedSourceImage(input.sourceImageData)
         : await downloadSourceImageOrThrow(input.sourceImageUrl!, input.reqId, {
             trustedSourceImageUrl: input.trustedSourceImageUrl,
+            sourceImageProvenance: input.sourceImageProvenance,
           });
       const imageBuffer = sourceImage.buffer;
       const contentType = sourceImage.contentType;

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -36,6 +36,8 @@ export type QuotaState = {
   count: number;
 };
 
+export type SourceImageOrigin = "external" | "stored";
+
 export type MessengerUserState = {
   psid: string;
   userKey: string;
@@ -44,6 +46,7 @@ export type MessengerUserState = {
   lastUserMessageAt?: number;
   lastPhotoUrl: string | null;
   lastPhoto: string | null;
+  lastPhotoSource?: SourceImageOrigin | null;
   selectedStyle: string | null;
   chosenStyle: string | null;
   selectedStyleCategory?: StyleCategory | null;
@@ -102,6 +105,7 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
     lastUserMessageAt: undefined,
     lastPhotoUrl: null,
     lastPhoto: null,
+    lastPhotoSource: null,
     selectedStyle: null,
     chosenStyle: null,
     selectedStyleCategory: null,
@@ -143,6 +147,7 @@ function normalizeState(psid: string, value: PartialState | null | undefined): M
     lastUserMessageAt: value?.lastUserMessageAt ?? fallback.lastUserMessageAt,
     lastPhotoUrl: lastPhoto,
     lastPhoto,
+    lastPhotoSource: value?.lastPhotoSource ?? fallback.lastPhotoSource,
     selectedStyle,
     chosenStyle: selectedStyle,
     selectedStyleCategory:
@@ -304,12 +309,18 @@ export function setFlowState(psid: string, nextState: MessengerFlowState): Maybe
   }
 }
 
-export function setPendingImage(psid: string, imageUrl: string, now = Date.now()): MaybePromise<void> {
+export function setPendingImage(
+  psid: string,
+  imageUrl: string,
+  now = Date.now(),
+  source: SourceImageOrigin = "external"
+): MaybePromise<void> {
   const result = patchState(
     psid,
     {
       lastPhotoUrl: imageUrl,
       lastPhoto: imageUrl,
+      lastPhotoSource: source,
       pendingImageUrl: imageUrl,
       pendingImageAt: now,
       stage: "AWAITING_STYLE",
@@ -329,6 +340,7 @@ export function clearPendingImageState(psid: string, now = Date.now()): MaybePro
     {
       lastPhotoUrl: null,
       lastPhoto: null,
+      lastPhotoSource: null,
       pendingImageUrl: undefined,
       pendingImageAt: undefined,
       selectedStyle: null,

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -26,6 +26,7 @@ import {
 import { toUserKey, toLogUser } from "./privacy";
 import { handleSharedTextMessage } from "./sharedTextHandler";
 import {
+  clearPendingImageState,
   getOrCreateState,
   markIntroSeen,
   setChosenStyle,
@@ -631,6 +632,9 @@ async function runWhatsAppStyleGeneration(
     let failureText = t(lang, "generationGenericFailure");
     if (error instanceof InvalidSourceImageUrlError) {
       failureText = t(lang, "missingInputImage");
+      if (!sourceImageUrl || resolvedSourceImageUrl === state.lastPhotoUrl) {
+        await clearPendingImageState(senderId);
+      }
       await setFlowState(senderId, "AWAITING_PHOTO");
       console.error("[whatsapp webhook] source image rejected", {
         user: toLogUser(userId),

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
+import { createHash } from "node:crypto";
 import { z, ZodError } from "zod";
 import { normalizeLang, t, type Lang } from "./i18n";
 import { createWebhookHandlers } from "./webhookHandlers";
@@ -93,6 +94,25 @@ export { detectAck, getGreetingResponse, summarizeWebhook };
 
 export function resetMessengerEventDedupe(): void {
   resetWebhookReplayProtection();
+}
+
+function summarizeSensitiveUrl(url: string): {
+  host: string;
+  shortHash: string;
+} {
+  const shortHash = createHash("sha256").update(url).digest("hex").slice(0, 12);
+
+  try {
+    return {
+      host: new URL(url).host || "invalid-url",
+      shortHash,
+    };
+  } catch {
+    return {
+      host: "invalid-url",
+      shortHash,
+    };
+  }
 }
 
 function getMetaVerifyToken(): string {
@@ -639,7 +659,7 @@ async function runWhatsAppStyleGeneration(
       console.error("[whatsapp webhook] source image rejected", {
         user: toLogUser(userId),
         style,
-        sourceImageUrl: resolvedSourceImageUrl,
+        sourceImageUrl: summarizeSensitiveUrl(resolvedSourceImageUrl),
       });
     } else if (error instanceof MissingInputImageError) {
       failureText = t(lang, "missingInputImage");

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -557,7 +557,10 @@ async function runWhatsAppStyleGeneration(
 
   const state = await Promise.resolve(getOrCreateState(senderId));
   const resolvedSourceImageUrl = sourceImageUrl ?? state.lastPhotoUrl ?? undefined;
-  const trustedSourceImageUrl = resolvedSourceImageUrl === state.lastPhotoUrl;
+  const trustedSourceImageUrl =
+    resolvedSourceImageUrl !== undefined &&
+    resolvedSourceImageUrl === state.lastPhotoUrl &&
+    state.lastPhotoSource === "stored";
   if (!resolvedSourceImageUrl) {
     await setFlowState(senderId, "AWAITING_PHOTO");
     await sendWhatsAppText(senderId, t(lang, "styleWithoutPhoto"));
@@ -592,6 +595,7 @@ async function runWhatsAppStyleGeneration(
       style,
       sourceImageUrl: resolvedSourceImageUrl,
       trustedSourceImageUrl,
+      sourceImageProvenance: trustedSourceImageUrl ? "storeInbound" : undefined,
       promptHint,
       userKey: userId,
       reqId,
@@ -812,7 +816,12 @@ async function handleWhatsAppImageEvent(
 
   const state = await Promise.resolve(getOrCreateState(event.senderId));
   const preselectedStyle = normalizeStyle(state.preselectedStyle ?? "");
-  await setPendingImage(event.senderId, persistedImageUrl);
+  await setPendingImage(
+    event.senderId,
+    persistedImageUrl,
+    Date.now(),
+    "stored"
+  );
 
   if (preselectedStyle) {
     await setPreselectedStyle(event.senderId, null);

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -641,11 +641,17 @@ export function createWebhookHandlers({
 
       const state = await getOrCreateState(psid);
       const lastImageUrl = sourceImageUrl ?? state.lastPhotoUrl;
+      const trustedSourceImageUrl =
+        lastImageUrl !== undefined &&
+        lastImageUrl === state.lastPhotoUrl &&
+        state.lastPhotoSource === "stored";
 
       try {
         const { imageUrl, proof, metrics } = await generator.generate({
           style,
           sourceImageUrl: lastImageUrl ?? undefined,
+          trustedSourceImageUrl,
+          sourceImageProvenance: trustedSourceImageUrl ? "storeInbound" : undefined,
           promptHint,
           userKey: userId,
           reqId,

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -551,6 +551,7 @@ describe("OpenAi image-to-image proof", () => {
       style: "disco",
       sourceImageUrl: "https://pub-storage.example/inbound-source/test.jpg",
       trustedSourceImageUrl: true,
+      sourceImageProvenance: "storeInbound",
       userKey: "user-1",
       reqId: "req-trusted-stored-source",
     });
@@ -559,6 +560,28 @@ describe("OpenAi image-to-image proof", () => {
     expect(result.imageUrl).toMatch(
       /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
     );
+  });
+
+  it("does not bypass SOURCE_IMAGE_ALLOWED_HOSTS without stored-source provenance", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://pub-storage.example/inbound-source/test.jpg",
+        trustedSourceImageUrl: true,
+        userKey: "user-1",
+        reqId: "req-missing-provenance",
+      })
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("rejects source image URLs with embedded credentials before fetch", async () => {

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -126,6 +126,9 @@ describe("whatsapp webhook flow", () => {
     expect(getState(anonymizePsid("wa-user-1"))?.lastPhotoUrl).toMatch(
       /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.jpg$/
     );
+    expect(getState(anonymizePsid("wa-user-1"))?.lastPhotoSource).toBe(
+      "stored"
+    );
     expect(sendWhatsAppButtonsMock).toHaveBeenCalledWith(
       "wa-user-1",
       expect.stringContaining("stijlgroep"),
@@ -324,6 +327,7 @@ describe("whatsapp webhook flow", () => {
             /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/.+\.jpg$/
           ),
           trustedSourceImageUrl: true,
+          sourceImageProvenance: "storeInbound",
         })
       );
     } finally {

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -23,7 +23,10 @@ vi.mock("./_core/whatsappApi", () => ({
 }));
 
 import { clearGeneratedImageStore } from "./_core/generatedImageStore";
-import { OpenAiImageGenerator } from "./_core/imageService";
+import {
+  InvalidSourceImageUrlError,
+  OpenAiImageGenerator,
+} from "./_core/imageService";
 import {
   processWhatsAppWebhookPayload,
   resetMessengerEventDedupe,
@@ -330,6 +333,61 @@ describe("whatsapp webhook flow", () => {
           sourceImageProvenance: "storeInbound",
         })
       );
+    } finally {
+      generateSpy.mockRestore();
+    }
+  });
+
+  it("clears a rejected stored WhatsApp photo when the trusted source URL is invalid", async () => {
+    downloadWhatsAppMediaMock.mockResolvedValue({
+      buffer: Buffer.alloc(6000, 7),
+      contentType: "image/jpeg",
+    });
+
+    const generateSpy = vi
+      .spyOn(OpenAiImageGenerator.prototype, "generate")
+      .mockRejectedValue(
+        new InvalidSourceImageUrlError("sourceImageUrl is not allowed")
+      );
+
+    try {
+      await processWhatsAppWebhookPayload(
+        createWhatsAppPayload({
+          from: "wa-user-invalid-source",
+          timestamp: "1710000020",
+          type: "image",
+          image: { id: "wamid-image-invalid-source" },
+        })
+      );
+
+      await processWhatsAppWebhookPayload(
+        createWhatsAppPayload({
+          from: "wa-user-invalid-source",
+          timestamp: "1710000021",
+          type: "interactive",
+          interactive: {
+            type: "button_reply",
+            button_reply: { id: "WA_BOLD", title: "Bold" },
+          },
+        })
+      );
+
+      await processWhatsAppWebhookPayload(
+        createWhatsAppPayload({
+          from: "wa-user-invalid-source",
+          timestamp: "1710000022",
+          type: "interactive",
+          interactive: {
+            type: "list_reply",
+            list_reply: { id: "STYLE_DISCO", title: "Disco" },
+          },
+        })
+      );
+
+      const nextState = getState(anonymizePsid("wa-user-invalid-source"));
+      expect(nextState?.lastPhotoUrl).toBeNull();
+      expect(nextState?.lastPhotoSource).toBeNull();
+      expect(nextState?.stage).toBe("AWAITING_PHOTO");
     } finally {
       generateSpy.mockRestore();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Previously uploaded photos can be reused as trusted sources for image generation, but only when the photo was originally stored by the system.

* **Bug Fixes**
  * When a stored source image is rejected, pending image state is cleared and users are prompted to resend.
  * Trusted-image gating tightened to prevent inadvertent bypasses.

* **Chores**
  * Improved diagnostics and safer logging around image source handling.

* **Tests**
  * Added and strengthened tests for trusted-source behavior and negative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->