### PR TITLE
feat: add EntryIntent normalization for Messenger referrals and align routing with identity-games architecture

### DIFF
--- a/server/_core/activeExperience.ts
+++ b/server/_core/activeExperience.ts
@@ -1,0 +1,36 @@
+export type ActiveExperienceStatus =
+  | "started"
+  | "in_progress"
+  | "resolving"
+  | "completed"
+  | "abandoned"
+  | "failed";
+
+export type ActiveExperience = {
+  type: "identity_game";
+  id: string;
+  sessionId: string;
+  status: ActiveExperienceStatus;
+  startedAt: number;
+  updatedAt: number;
+};
+
+export type IdentityGameSession = {
+  sessionId: string;
+  userId: string;
+  gameId: string;
+  gameVersion: string;
+  entryIntent: import("./entryIntent").EntryIntent;
+  status: ActiveExperienceStatus;
+  currentQuestionId?: string;
+  answers: Array<{
+    questionId: string;
+    answerId: string;
+    recordedAt: number;
+  }>;
+  derivedTraits: Record<string, number>;
+  resultRef?: string;
+  startedAt: number;
+  updatedAt: number;
+  expiresAt: number;
+};

--- a/server/_core/botContext.ts
+++ b/server/_core/botContext.ts
@@ -1,5 +1,8 @@
 import type { Lang } from "./i18n";
-import type { BotChannel } from "./normalizedInboundMessage";
+import type {
+  BotChannel,
+  BotChannelCapabilities,
+} from "./normalizedInboundMessage";
 import type {
   ConversationState,
   MessengerUserState,
@@ -14,11 +17,6 @@ export type BotLogger = {
   info(event: string, details?: Record<string, unknown>): void;
   warn(event: string, details?: Record<string, unknown>): void;
   error(event: string, details?: Record<string, unknown>): void;
-};
-
-export type BotChannelCapabilities = {
-  quickReplies: boolean;
-  richTemplates: boolean;
 };
 
 type BotContextBase = {

--- a/server/_core/botResponse.ts
+++ b/server/_core/botResponse.ts
@@ -1,4 +1,42 @@
-export type BotResponse = {
-  kind: "text" | "ack" | "typing";
-  text?: string;
-};
+export type BotResponse =
+  | {
+      kind: "text";
+      text: string;
+    }
+  | {
+      kind: "options_prompt";
+      prompt: string;
+      options: Array<{
+        id: string;
+        title: string;
+      }>;
+      selectionMode: "single";
+      fallbackText?: string;
+    }
+  | {
+      kind: "result_card";
+      title: string;
+      body: string;
+      subtitle?: string;
+      imageUrl?: string;
+      shareText?: string;
+      ctaOptions?: Array<{
+        id: string;
+        title: string;
+      }>;
+    }
+  | {
+      kind: "image";
+      imageUrl: string;
+      caption?: string;
+    }
+  | {
+      kind: "error";
+      text: string;
+    }
+  | {
+      kind: "ack";
+    }
+  | {
+      kind: "typing";
+    };

--- a/server/_core/botResponseAdapters.ts
+++ b/server/_core/botResponseAdapters.ts
@@ -67,6 +67,8 @@ export async function sendMessengerBotResponse(
 
       if (response.caption) {
         await options.sendText(response.caption);
+      } else {
+        await options.sendText("[Image not available]");
       }
       return;
     case "error":
@@ -144,6 +146,8 @@ export async function sendWhatsAppBotResponse(
 
       if (response.caption) {
         await options.sendText(response.caption);
+      } else {
+        await options.sendText("[Image not available]");
       }
       return;
     case "error":

--- a/server/_core/botResponseAdapters.ts
+++ b/server/_core/botResponseAdapters.ts
@@ -9,6 +9,13 @@ export async function sendMessengerBotResponse(
     replyState?: ConversationState;
     sendText: (text: string) => Promise<void>;
     sendStateText: (state: ConversationState, text: string) => Promise<void>;
+    sendOptionsPrompt?: (
+      prompt: string,
+      options: Array<{ id: string; title: string }>,
+      fallbackText?: string
+    ) => Promise<void>;
+    sendImage?: (imageUrl: string, caption?: string) => Promise<void>;
+    sendResultCard?: (card: Extract<BotResponse, { kind: "result_card" }>) => Promise<void>;
   }
 ): Promise<void> {
   if (!response) {
@@ -17,10 +24,6 @@ export async function sendMessengerBotResponse(
 
   switch (response.kind) {
     case "text":
-      if (!response.text) {
-        return;
-      }
-
       if (options.replyState) {
         await options.sendStateText(options.replyState, response.text);
         return;
@@ -28,11 +31,52 @@ export async function sendMessengerBotResponse(
 
       await options.sendText(response.text);
       return;
+    case "options_prompt":
+      if (options.sendOptionsPrompt) {
+        await options.sendOptionsPrompt(
+          response.prompt,
+          response.options,
+          response.fallbackText
+        );
+        return;
+      }
+
+      await options.sendText(
+        response.fallbackText ??
+          [response.prompt, ...response.options.map(option => option.title)].join(
+            "\n"
+          )
+      );
+      return;
+    case "result_card":
+      if (options.sendResultCard) {
+        await options.sendResultCard(response);
+        return;
+      }
+
+      if (response.imageUrl && options.sendImage) {
+        await options.sendImage(response.imageUrl, response.title);
+      }
+      await options.sendText([response.title, response.body].join("\n\n"));
+      return;
+    case "image":
+      if (options.sendImage) {
+        await options.sendImage(response.imageUrl, response.caption);
+        return;
+      }
+
+      if (response.caption) {
+        await options.sendText(response.caption);
+      }
+      return;
+    case "error":
+      await options.sendText(response.text);
+      return;
     case "ack":
     case "typing":
       return;
     default:
-      assertNever(response.kind);
+      assertNever(response);
   }
 }
 
@@ -42,6 +86,13 @@ export async function sendWhatsAppBotResponse(
     sendText: (text: string) => Promise<void>;
     replyState?: ConversationState;
     sendStateText?: (state: ConversationState, text: string) => Promise<void>;
+    sendOptionsPrompt?: (
+      prompt: string,
+      options: Array<{ id: string; title: string }>,
+      fallbackText?: string
+    ) => Promise<void>;
+    sendImage?: (imageUrl: string, caption?: string) => Promise<void>;
+    sendResultCard?: (card: Extract<BotResponse, { kind: "result_card" }>) => Promise<void>;
   }
 ): Promise<void> {
   if (!response) {
@@ -50,10 +101,6 @@ export async function sendWhatsAppBotResponse(
 
   switch (response.kind) {
     case "text":
-      if (!response.text) {
-        return;
-      }
-
       if (options.replyState && options.sendStateText) {
         await options.sendStateText(options.replyState, response.text);
         return;
@@ -61,10 +108,51 @@ export async function sendWhatsAppBotResponse(
 
       await options.sendText(response.text);
       return;
+    case "options_prompt":
+      if (options.sendOptionsPrompt) {
+        await options.sendOptionsPrompt(
+          response.prompt,
+          response.options,
+          response.fallbackText
+        );
+        return;
+      }
+
+      await options.sendText(
+        response.fallbackText ??
+          [response.prompt, ...response.options.map(option => option.title)].join(
+            "\n"
+          )
+      );
+      return;
+    case "result_card":
+      if (options.sendResultCard) {
+        await options.sendResultCard(response);
+        return;
+      }
+
+      if (response.imageUrl && options.sendImage) {
+        await options.sendImage(response.imageUrl, response.title);
+      }
+      await options.sendText([response.title, response.body].join("\n\n"));
+      return;
+    case "image":
+      if (options.sendImage) {
+        await options.sendImage(response.imageUrl, response.caption);
+        return;
+      }
+
+      if (response.caption) {
+        await options.sendText(response.caption);
+      }
+      return;
+    case "error":
+      await options.sendText(response.text);
+      return;
     case "ack":
     case "typing":
       return;
     default:
-      assertNever(response.kind);
+      assertNever(response);
   }
 }

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -27,7 +27,12 @@ export type EntryIntent = {
 };
 
 function normalizeExperienceId(value: string): string {
-  return value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
 }
 
 function resolveSourceType(value: string | null): EntrySourceType {

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -27,12 +27,33 @@ export type EntryIntent = {
 };
 
 function normalizeExperienceId(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9_-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  const normalized = value.trim().toLowerCase();
+  let result = "";
+  let lastWasSeparator = false;
+
+  for (const character of normalized) {
+    const isAlphaNumeric =
+      (character >= "a" && character <= "z") ||
+      (character >= "0" && character <= "9");
+    const isPreservedSeparator = character === "_" || character === "-";
+
+    if (isAlphaNumeric) {
+      result += character;
+      lastWasSeparator = false;
+      continue;
+    }
+
+    if (isPreservedSeparator || !lastWasSeparator) {
+      result += "-";
+      lastWasSeparator = true;
+    }
+  }
+
+  if (result.endsWith("-")) {
+    result = result.slice(0, -1);
+  }
+
+  return result.startsWith("-") ? result.slice(1) : result;
 }
 
 function resolveSourceType(value: string | null): EntrySourceType {

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -1,0 +1,109 @@
+import type { BotChannel } from "./normalizedInboundMessage";
+
+export type EntryMode = "auto_start" | "confirm_first";
+
+export type EntrySourceType =
+  | "deep_link"
+  | "postback"
+  | "organic_message"
+  | "referral"
+  | "ad"
+  | "unknown";
+
+export type ExperienceType = "identity_game";
+
+export type EntryIntent = {
+  sourceChannel: BotChannel;
+  sourceType: EntrySourceType;
+  targetExperienceType: ExperienceType;
+  targetExperienceId: string;
+  entryMode?: EntryMode;
+  campaignId?: string;
+  creativeId?: string;
+  entryVariant?: string;
+  localeHint?: string;
+  rawRef?: string;
+  receivedAt: number;
+};
+
+function normalizeExperienceId(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+}
+
+function resolveSourceType(value: string | null): EntrySourceType {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "deep_link":
+    case "deeplink":
+      return "deep_link";
+    case "postback":
+      return "postback";
+    case "organic_message":
+      return "organic_message";
+    case "referral":
+      return "referral";
+    case "ad":
+      return "ad";
+    default:
+      return "unknown";
+  }
+}
+
+function resolveEntryMode(value: string | null): EntryMode | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value === "auto_start" || value === "confirm_first") {
+    return value;
+  }
+
+  return undefined;
+}
+
+export function parseGameEntryIntent(input: {
+  channel: BotChannel;
+  ref?: string | null;
+  sourceType?: EntrySourceType;
+  localeHint?: string;
+  receivedAt?: number;
+}): EntryIntent | null {
+  const rawRef = input.ref?.trim();
+  if (!rawRef) {
+    return null;
+  }
+
+  const [head, query = ""] = rawRef.split("?", 2);
+  const normalizedHead = head.trim();
+  let gameId = "";
+
+  if (/^game:/i.test(normalizedHead)) {
+    gameId = normalizedHead.slice("game:".length);
+  } else if (/^identity[_-]?game:/i.test(normalizedHead)) {
+    gameId = normalizedHead.slice(normalizedHead.indexOf(":") + 1);
+  } else {
+    return null;
+  }
+
+  const targetExperienceId = normalizeExperienceId(gameId);
+  if (!targetExperienceId) {
+    return null;
+  }
+
+  const params = new URLSearchParams(query);
+
+  return {
+    sourceChannel: input.channel,
+    sourceType:
+      input.sourceType ??
+      resolveSourceType(params.get("sourceType") ?? params.get("source")),
+    targetExperienceType: "identity_game",
+    targetExperienceId,
+    entryMode: resolveEntryMode(params.get("entryMode")),
+    campaignId: params.get("campaignId") ?? undefined,
+    creativeId: params.get("creativeId") ?? undefined,
+    entryVariant: params.get("entryVariant") ?? undefined,
+    localeHint: input.localeHint ?? params.get("locale") ?? undefined,
+    rawRef,
+    receivedAt: input.receivedAt ?? Date.now(),
+  };
+}

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -16,9 +16,15 @@ type ExperienceRouteResult = {
 type ExperienceRouterInput = {
   state: MessengerUserState;
   entryIntent?: EntryIntent | null;
+  action?: string | null;
   setLastEntryIntent: (entryIntent: EntryIntent | null) => Promise<void>;
   setActiveExperience: (activeExperience: ActiveExperience | null) => Promise<void>;
 };
+
+function normalizeAction(action: string | null | undefined): string | null {
+  const normalized = action?.trim().toUpperCase();
+  return normalized ? normalized : null;
+}
 
 function buildPlaceholderSession(
   state: MessengerUserState,
@@ -118,6 +124,46 @@ export async function routeActiveExperience(
   if (!activeSession) {
     await input.setActiveExperience(null);
     return { handled: false };
+  }
+
+  const action = normalizeAction(input.action);
+
+  if (action === "LATER") {
+    const abandonedSession: IdentityGameSession = {
+      ...activeSession,
+      status: "abandoned",
+      updatedAt: Date.now(),
+    };
+    await Promise.resolve(upsertIdentityGameSession(abandonedSession));
+    await input.setActiveExperience(null);
+    return {
+      handled: true,
+      response: {
+        kind: "text",
+        text: "Geen probleem. Deze game-link blijft herkenbaar voor later.",
+      },
+    };
+  }
+
+  if (action === "START_GAME") {
+    const inProgressSession: IdentityGameSession = {
+      ...activeSession,
+      status: "in_progress",
+      updatedAt: Date.now(),
+    };
+    await Promise.resolve(upsertIdentityGameSession(inProgressSession));
+    await input.setActiveExperience({
+      ...activeExperience,
+      status: "in_progress",
+      updatedAt: inProgressSession.updatedAt,
+    });
+    return {
+      handled: true,
+      response: {
+        kind: "text",
+        text: "De game-start is bevestigd. De echte vraagflow volgt in de volgende fase.",
+      },
+    };
   }
 
   return {

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import type { ActiveExperience, IdentityGameSession } from "./activeExperience";
+import type { BotResponse } from "./botResponse";
+import type { EntryIntent } from "./entryIntent";
+import {
+  getIdentityGameSessionByActiveExperience,
+  upsertIdentityGameSession,
+} from "./identityGameSessionState";
+import type { MessengerUserState } from "./messengerState";
+
+type ExperienceRouteResult = {
+  handled: boolean;
+  response?: BotResponse | null;
+};
+
+type ExperienceRouterInput = {
+  state: MessengerUserState;
+  entryIntent?: EntryIntent | null;
+  setLastEntryIntent: (entryIntent: EntryIntent | null) => Promise<void>;
+  setActiveExperience: (activeExperience: ActiveExperience | null) => Promise<void>;
+};
+
+function buildPlaceholderSession(
+  state: MessengerUserState,
+  entryIntent: EntryIntent,
+  activeExperience?: ActiveExperience | null
+): IdentityGameSession {
+  const startedAt = entryIntent.receivedAt;
+  const sessionId = activeExperience?.sessionId ?? randomUUID();
+
+  return {
+    sessionId,
+    userId: state.userKey,
+    gameId: entryIntent.targetExperienceId,
+    gameVersion: "v1",
+    entryIntent,
+    status: "started",
+    answers: [],
+    derivedTraits: {},
+    startedAt,
+    updatedAt: startedAt,
+    expiresAt: startedAt + 24 * 60 * 60 * 1000,
+  };
+}
+
+export async function routeEntryIntent(
+  input: ExperienceRouterInput
+): Promise<ExperienceRouteResult> {
+  if (!input.entryIntent || input.entryIntent.targetExperienceType !== "identity_game") {
+    return { handled: false };
+  }
+
+  await input.setLastEntryIntent(input.entryIntent);
+
+  const existingSession = await Promise.resolve(
+    getIdentityGameSessionByActiveExperience(input.state.activeExperience)
+  );
+  const session =
+    existingSession?.gameId === input.entryIntent.targetExperienceId
+      ? {
+          ...existingSession,
+          entryIntent: input.entryIntent,
+          updatedAt: input.entryIntent.receivedAt,
+        }
+      : buildPlaceholderSession(
+          input.state,
+          input.entryIntent,
+          input.state.activeExperience
+        );
+
+  await Promise.resolve(upsertIdentityGameSession(session));
+  await input.setActiveExperience({
+    type: "identity_game",
+    id: session.gameId,
+    sessionId: session.sessionId,
+    status: session.status,
+    startedAt: session.startedAt,
+    updatedAt: session.updatedAt,
+  });
+
+  if (input.entryIntent.entryMode === "confirm_first") {
+    return {
+      handled: true,
+      response: {
+        kind: "options_prompt",
+        prompt: "Deze game-entry is herkend. Klaar om later te starten?",
+        options: [
+          { id: "START_GAME", title: "Start game" },
+          { id: "LATER", title: "Later" },
+        ],
+        selectionMode: "single",
+        fallbackText: "Antwoord met START_GAME of LATER.",
+      },
+    };
+  }
+
+  return {
+    handled: true,
+    response: {
+      kind: "text",
+      text: "Deze identity game-entry is herkend. De game flow zelf volgt in de volgende fase.",
+    },
+  };
+}
+
+export async function routeActiveExperience(
+  input: Omit<ExperienceRouterInput, "entryIntent">
+): Promise<ExperienceRouteResult> {
+  const activeExperience = input.state.activeExperience;
+  if (!activeExperience || activeExperience.type !== "identity_game") {
+    return { handled: false };
+  }
+
+  const activeSession = await Promise.resolve(
+    getIdentityGameSessionByActiveExperience(activeExperience)
+  );
+
+  if (!activeSession) {
+    await input.setActiveExperience(null);
+    return { handled: false };
+  }
+
+  return {
+    handled: true,
+    response: {
+      kind: "error",
+      text: "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
+    },
+  };
+}

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -28,11 +28,10 @@ function normalizeAction(action: string | null | undefined): string | null {
 
 function buildPlaceholderSession(
   state: MessengerUserState,
-  entryIntent: EntryIntent,
-  activeExperience?: ActiveExperience | null
+  entryIntent: EntryIntent
 ): IdentityGameSession {
   const startedAt = entryIntent.receivedAt;
-  const sessionId = activeExperience?.sessionId ?? randomUUID();
+  const sessionId = randomUUID();
 
   return {
     sessionId,
@@ -68,11 +67,7 @@ export async function routeEntryIntent(
           entryIntent: input.entryIntent,
           updatedAt: input.entryIntent.receivedAt,
         }
-      : buildPlaceholderSession(
-          input.state,
-          input.entryIntent,
-          input.state.activeExperience
-        );
+      : buildPlaceholderSession(input.state, input.entryIntent);
 
   await Promise.resolve(upsertIdentityGameSession(session));
   await input.setActiveExperience({

--- a/server/_core/identityGameSessionState.ts
+++ b/server/_core/identityGameSessionState.ts
@@ -25,6 +25,39 @@ function writeSessionRef(
   );
 }
 
+function logSessionRefWriteFailure(
+  session: IdentityGameSession,
+  error: unknown
+): void {
+  console.error("identity_game_session_ref_write_failed", {
+    sessionId: session.sessionId,
+    userId: session.userId,
+    error: error instanceof Error ? error.message : String(error),
+  });
+}
+
+function rollbackSessionWrite(
+  session: IdentityGameSession
+): MaybePromise<void> {
+  return deleteScopedState(IDENTITY_GAME_SESSION_SCOPE, session.sessionId);
+}
+
+function handleSessionRefWriteFailure<T>(
+  session: IdentityGameSession,
+  error: unknown
+): MaybePromise<T> {
+  logSessionRefWriteFailure(session, error);
+  const rollback = rollbackSessionWrite(session);
+
+  if (isPromiseLike(rollback)) {
+    return rollback.then(() => {
+      throw error;
+    });
+  }
+
+  throw error;
+}
+
 export function getIdentityGameSessionBySessionId(
   sessionId: string
 ): MaybePromise<IdentityGameSession | null> {
@@ -82,15 +115,17 @@ export function upsertIdentityGameSession(
 
   if (isPromiseLike(writeSession)) {
     return writeSession.then(() =>
-      Promise.resolve(writeSessionRef(session.userId, session.sessionId)).then(
-        () => session
-      )
+      Promise.resolve(writeSessionRef(session.userId, session.sessionId))
+        .then(() => session)
+        .catch(error => handleSessionRefWriteFailure(session, error))
     );
   }
 
   const writeRef = writeSessionRef(session.userId, session.sessionId);
   if (isPromiseLike(writeRef)) {
-    return writeRef.then(() => session);
+    return writeRef
+      .then(() => session)
+      .catch(error => handleSessionRefWriteFailure(session, error));
   }
 
   return session;

--- a/server/_core/identityGameSessionState.ts
+++ b/server/_core/identityGameSessionState.ts
@@ -1,0 +1,121 @@
+import type { ActiveExperience, IdentityGameSession } from "./activeExperience";
+import {
+  deleteScopedState,
+  isPromiseLike,
+  readScopedState,
+  type MaybePromise,
+  writeScopedState,
+} from "./stateStore";
+
+const IDENTITY_GAME_SESSION_SCOPE = "identity-game-session";
+const IDENTITY_GAME_USER_SCOPE = "identity-game-session-user";
+
+type IdentityGameSessionRef = {
+  sessionId: string;
+};
+
+function writeSessionRef(
+  userId: string,
+  sessionId: string
+): MaybePromise<void> {
+  return writeScopedState<IdentityGameSessionRef>(
+    IDENTITY_GAME_USER_SCOPE,
+    userId,
+    { sessionId }
+  );
+}
+
+export function getIdentityGameSessionBySessionId(
+  sessionId: string
+): MaybePromise<IdentityGameSession | null> {
+  return readScopedState<IdentityGameSession>(
+    IDENTITY_GAME_SESSION_SCOPE,
+    sessionId
+  );
+}
+
+export function getIdentityGameSessionByUserId(
+  userId: string
+): MaybePromise<IdentityGameSession | null> {
+  const ref = readScopedState<IdentityGameSessionRef>(
+    IDENTITY_GAME_USER_SCOPE,
+    userId
+  );
+
+  if (isPromiseLike(ref)) {
+    return ref.then(current => {
+      if (!current?.sessionId) {
+        return null;
+      }
+
+      return Promise.resolve(
+        getIdentityGameSessionBySessionId(current.sessionId)
+      );
+    });
+  }
+
+  if (!ref?.sessionId) {
+    return null;
+  }
+
+  return getIdentityGameSessionBySessionId(ref.sessionId);
+}
+
+export function getIdentityGameSessionByActiveExperience(
+  activeExperience: ActiveExperience | null | undefined
+): MaybePromise<IdentityGameSession | null> {
+  if (!activeExperience?.sessionId || activeExperience.type !== "identity_game") {
+    return null;
+  }
+
+  return getIdentityGameSessionBySessionId(activeExperience.sessionId);
+}
+
+export function upsertIdentityGameSession(
+  session: IdentityGameSession
+): MaybePromise<IdentityGameSession> {
+  const writeSession = writeScopedState(
+    IDENTITY_GAME_SESSION_SCOPE,
+    session.sessionId,
+    session
+  );
+
+  if (isPromiseLike(writeSession)) {
+    return writeSession.then(() =>
+      Promise.resolve(writeSessionRef(session.userId, session.sessionId)).then(
+        () => session
+      )
+    );
+  }
+
+  const writeRef = writeSessionRef(session.userId, session.sessionId);
+  if (isPromiseLike(writeRef)) {
+    return writeRef.then(() => session);
+  }
+
+  return session;
+}
+
+export function clearIdentityGameSession(
+  sessionId: string,
+  userId?: string
+): MaybePromise<void> {
+  const deleteSession = deleteScopedState(IDENTITY_GAME_SESSION_SCOPE, sessionId);
+
+  const finish = () => {
+    if (!userId) {
+      return undefined;
+    }
+
+    return deleteScopedState(IDENTITY_GAME_USER_SCOPE, userId);
+  };
+
+  if (isPromiseLike(deleteSession)) {
+    return deleteSession.then(() => finish()).then(() => undefined);
+  }
+
+  const deleteRef = finish();
+  if (isPromiseLike(deleteRef)) {
+    return deleteRef.then(() => undefined);
+  }
+}

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -3,6 +3,8 @@ import {
   STYLE_CATEGORY_CONFIGS,
   getStylesForCategory,
 } from "./messengerStyles";
+import type { ActiveExperience } from "./activeExperience";
+import type { EntryIntent } from "./entryIntent";
 import type { Lang } from "./i18n";
 import { toUserKey } from "./privacy";
 import {
@@ -43,6 +45,8 @@ export type MessengerUserState = {
   userKey: string;
   stage: MessengerFlowState;
   state: MessengerFlowState;
+  lastEntryIntent?: EntryIntent | null;
+  activeExperience?: ActiveExperience | null;
   lastUserMessageAt?: number;
   lastPhotoUrl: string | null;
   lastPhoto: string | null;
@@ -102,6 +106,8 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
     userKey: getUserKey(psid),
     stage: "IDLE",
     state: "IDLE",
+    lastEntryIntent: null,
+    activeExperience: null,
     lastUserMessageAt: undefined,
     lastPhotoUrl: null,
     lastPhoto: null,
@@ -144,6 +150,8 @@ function normalizeState(psid: string, value: PartialState | null | undefined): M
     hasSeenIntro: value?.hasSeenIntro ?? fallback.hasSeenIntro,
     stage,
     state: stage,
+    lastEntryIntent: value?.lastEntryIntent ?? fallback.lastEntryIntent,
+    activeExperience: value?.activeExperience ?? fallback.activeExperience,
     lastUserMessageAt: value?.lastUserMessageAt ?? fallback.lastUserMessageAt,
     lastPhotoUrl: lastPhoto,
     lastPhoto,
@@ -307,6 +315,49 @@ export function setFlowState(psid: string, nextState: MessengerFlowState): Maybe
   if (isPromiseLike(result)) {
     return result.then(() => undefined);
   }
+}
+
+export function setLastEntryIntent(
+  psid: string,
+  entryIntent: EntryIntent | null,
+  now = Date.now()
+): MaybePromise<void> {
+  const result = patchState(
+    psid,
+    {
+      lastEntryIntent: entryIntent,
+    },
+    now
+  );
+
+  if (isPromiseLike(result)) {
+    return result.then(() => undefined);
+  }
+}
+
+export function setActiveExperience(
+  psid: string,
+  activeExperience: ActiveExperience | null,
+  now = Date.now()
+): MaybePromise<void> {
+  const result = patchState(
+    psid,
+    {
+      activeExperience,
+    },
+    now
+  );
+
+  if (isPromiseLike(result)) {
+    return result.then(() => undefined);
+  }
+}
+
+export function clearActiveExperience(
+  psid: string,
+  now = Date.now()
+): MaybePromise<void> {
+  return setActiveExperience(psid, null, now);
 }
 
 export function setPendingImage(

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -926,6 +926,7 @@ export async function processWhatsAppWebhookPayload(
 
         const activeExperienceRoute = await routeActiveExperience({
           state: currentState,
+          action: event.textBody ?? null,
           setLastEntryIntent: nextEntryIntent =>
             Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
           setActiveExperience: nextActiveExperience =>
@@ -967,6 +968,7 @@ export async function processWhatsAppWebhookPayload(
 
         const activeExperienceRoute = await routeActiveExperience({
           state: currentState,
+          action: event.textBody ?? null,
           setLastEntryIntent: nextEntryIntent =>
             Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
           setActiveExperience: nextActiveExperience =>

--- a/server/_core/messengerWebhook.ts
+++ b/server/_core/messengerWebhook.ts
@@ -4,6 +4,7 @@ import { createHash } from "node:crypto";
 import { z, ZodError } from "zod";
 import { normalizeLang, t, type Lang } from "./i18n";
 import { createWebhookHandlers } from "./webhookHandlers";
+import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
 import { resetWebhookReplayProtection } from "./webhookReplayProtection";
 import {
   detectAck,
@@ -33,10 +34,12 @@ import {
   setChosenStyle,
   setLastGenerated,
   setLastGenerationContext,
+  setLastEntryIntent,
   setLastUserMessageAt,
   setPendingImage,
   setPreselectedStyle,
   setSelectedStyleCategory,
+  setActiveExperience,
   setFlowState,
   type ConversationState,
 } from "./messengerState";
@@ -237,6 +240,10 @@ function extractWhatsAppEvents(payload: unknown): NormalizedInboundMessage[] {
             channel: "whatsapp",
             senderId: from,
             userId: toUserKey(from),
+            channelCapabilities: {
+              quickReplies: false,
+              richTemplates: false,
+            },
             rawMessageType: messageType,
             messageType:
               messageType === "text" || messageType === "interactive"
@@ -251,6 +258,10 @@ function extractWhatsAppEvents(payload: unknown): NormalizedInboundMessage[] {
               undefined,
             imageId: imageId ?? undefined,
             timestamp: Number.isFinite(timestampRaw) ? timestampRaw! * 1000 : undefined,
+            rawEventMeta: {
+              interactiveReplyId: interactiveReplyId ?? undefined,
+              interactiveReplyTitle: interactiveReplyTitle ?? undefined,
+            },
           },
         ];
       });
@@ -891,11 +902,83 @@ export async function processWhatsAppWebhookPayload(
 
     try {
       if (event.messageType === "image") {
+        const currentState = await Promise.resolve(getOrCreateState(event.senderId));
+        const entryIntentRoute = await routeEntryIntent({
+          state: currentState,
+          entryIntent: event.entryIntent ?? null,
+          setLastEntryIntent: nextEntryIntent =>
+            Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
+          setActiveExperience: nextActiveExperience =>
+            Promise.resolve(setActiveExperience(event.senderId, nextActiveExperience)),
+        });
+        if (entryIntentRoute.handled) {
+          await sendWhatsAppBotResponse(entryIntentRoute.response ?? null, {
+            sendText: text => sendWhatsAppText(event.senderId, text),
+            sendOptionsPrompt: (prompt, options, fallbackText) =>
+              sendWhatsAppText(
+                event.senderId,
+                fallbackText ??
+                  [prompt, ...options.map(option => option.title)].join("\n")
+              ),
+          });
+          continue;
+        }
+
+        const activeExperienceRoute = await routeActiveExperience({
+          state: currentState,
+          setLastEntryIntent: nextEntryIntent =>
+            Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
+          setActiveExperience: nextActiveExperience =>
+            Promise.resolve(setActiveExperience(event.senderId, nextActiveExperience)),
+        });
+        if (activeExperienceRoute.handled) {
+          await sendWhatsAppBotResponse(activeExperienceRoute.response ?? null, {
+            sendText: text => sendWhatsAppText(event.senderId, text),
+          });
+          continue;
+        }
+
         await handleWhatsAppImageEvent(event, reqId, lang);
         continue;
       }
 
       if (event.messageType === "text") {
+        const currentState = await Promise.resolve(getOrCreateState(event.senderId));
+        const entryIntentRoute = await routeEntryIntent({
+          state: currentState,
+          entryIntent: event.entryIntent ?? null,
+          setLastEntryIntent: nextEntryIntent =>
+            Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
+          setActiveExperience: nextActiveExperience =>
+            Promise.resolve(setActiveExperience(event.senderId, nextActiveExperience)),
+        });
+        if (entryIntentRoute.handled) {
+          await sendWhatsAppBotResponse(entryIntentRoute.response ?? null, {
+            sendText: text => sendWhatsAppText(event.senderId, text),
+            sendOptionsPrompt: (prompt, options, fallbackText) =>
+              sendWhatsAppText(
+                event.senderId,
+                fallbackText ??
+                  [prompt, ...options.map(option => option.title)].join("\n")
+              ),
+          });
+          continue;
+        }
+
+        const activeExperienceRoute = await routeActiveExperience({
+          state: currentState,
+          setLastEntryIntent: nextEntryIntent =>
+            Promise.resolve(setLastEntryIntent(event.senderId, nextEntryIntent)),
+          setActiveExperience: nextActiveExperience =>
+            Promise.resolve(setActiveExperience(event.senderId, nextActiveExperience)),
+        });
+        if (activeExperienceRoute.handled) {
+          await sendWhatsAppBotResponse(activeExperienceRoute.response ?? null, {
+            sendText: text => sendWhatsAppText(event.senderId, text),
+          });
+          continue;
+        }
+
         await handleWhatsAppTextEvent(event, reqId, lang);
         continue;
       }

--- a/server/_core/normalizedInboundMessage.ts
+++ b/server/_core/normalizedInboundMessage.ts
@@ -1,13 +1,21 @@
 export type BotChannel = "messenger" | "whatsapp";
 
+export type BotChannelCapabilities = {
+  quickReplies: boolean;
+  richTemplates: boolean;
+};
+
 export type NormalizedInboundMessage = {
   channel: BotChannel;
   senderId: string;
   userId: string;
+  channelCapabilities?: BotChannelCapabilities;
   messageType: "text" | "image" | "unknown";
   rawMessageType?: string;
   textBody?: string;
   imageUrl?: string;
   imageId?: string;
   timestamp?: number;
+  rawEventMeta?: Record<string, unknown>;
+  entryIntent?: import("./entryIntent").EntryIntent | null;
 };

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -23,16 +23,20 @@ import {
   setFlowState,
   setLastGenerated,
   setLastGenerationContext,
+  setLastEntryIntent,
   setLastUserMessageAt,
   setPendingImage,
   setPreselectedStyle,
   setPreferredLang,
   setSelectedStyleCategory,
+  setActiveExperience,
   markIntroSeen,
   anonymizePsid,
   type ConversationState,
 } from "./messengerState";
 import { normalizeLang, t, type Lang } from "./i18n";
+import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
+import { parseGameEntryIntent } from "./entryIntent";
 import { toLogUser, toUserKey } from "./privacy";
 import {
   getStylesForCategory,
@@ -1089,9 +1093,67 @@ export function createWebhookHandlers({
       }
     }
 
-    const referralStyle = parseReferralStyle(
-      event.postback?.referral?.ref ?? event.referral?.ref
-    );
+    const referralRef = event.postback?.referral?.ref ?? event.referral?.ref;
+    const entryIntent = parseGameEntryIntent({
+      channel: "messenger",
+      ref: referralRef,
+      sourceType: event.postback?.payload ? "postback" : "referral",
+      localeHint: localeLang ?? undefined,
+      receivedAt: event.timestamp ?? Date.now(),
+    });
+    const entryIntentRoute = await routeEntryIntent({
+      state,
+      entryIntent,
+      setLastEntryIntent: nextEntryIntent =>
+        Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
+      setActiveExperience: nextActiveExperience =>
+        Promise.resolve(setActiveExperience(psid, nextActiveExperience)),
+    });
+    if (entryIntentRoute.handled) {
+      await sendMessengerBotResponse(entryIntentRoute.response ?? null, {
+        sendText: text => sendLoggedText(psid, text, reqId),
+        sendStateText: (stateName, text) =>
+          sendStateQuickReplies(psid, stateName, text, reqId),
+        sendOptionsPrompt: async (prompt, options, fallbackText) => {
+          await sendLoggedQuickReplies(
+            psid,
+            prompt,
+            options.map(option => ({
+              content_type: "text",
+              title: option.title,
+              payload: option.id,
+            })),
+            reqId
+          );
+
+          if (fallbackText) {
+            safeLog("entry_intent_options_fallback_available", {
+              user: toLogUser(userId),
+              fallbackText,
+            });
+          }
+        },
+      });
+      return;
+    }
+
+    const activeExperienceRoute = await routeActiveExperience({
+      state,
+      setLastEntryIntent: nextEntryIntent =>
+        Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
+      setActiveExperience: nextActiveExperience =>
+        Promise.resolve(setActiveExperience(psid, nextActiveExperience)),
+    });
+    if (activeExperienceRoute.handled) {
+      await sendMessengerBotResponse(activeExperienceRoute.response ?? null, {
+        sendText: text => sendLoggedText(psid, text, reqId),
+        sendStateText: (stateName, text) =>
+          sendStateQuickReplies(psid, stateName, text, reqId),
+      });
+      return;
+    }
+
+    const referralStyle = parseReferralStyle(referralRef);
     if (referralStyle) {
       await clearPendingImageState(psid);
       await setPreselectedStyle(psid, referralStyle);

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -1137,8 +1137,14 @@ export function createWebhookHandlers({
       return;
     }
 
+    const activeExperienceAction =
+      event.postback?.payload ??
+      event.message?.quick_reply?.payload ??
+      event.message?.text?.trim() ??
+      null;
     const activeExperienceRoute = await routeActiveExperience({
       state,
+      action: activeExperienceAction,
       setLastEntryIntent: nextEntryIntent =>
         Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
       setActiveExperience: nextActiveExperience =>

--- a/server/botResponseAdapters.test.ts
+++ b/server/botResponseAdapters.test.ts
@@ -81,4 +81,54 @@ describe("botResponseAdapters", () => {
 
     expect(sendText).not.toHaveBeenCalled();
   });
+
+  it("maps Messenger options prompts to the dedicated sender when available", async () => {
+    const sendText = vi.fn(async () => {});
+    const sendStateText = vi.fn(async () => {});
+    const sendOptionsPrompt = vi.fn(async () => {});
+
+    await sendMessengerBotResponse(
+      {
+        kind: "options_prompt",
+        prompt: "Choose",
+        options: [
+          { id: "ONE", title: "One" },
+          { id: "TWO", title: "Two" },
+        ],
+        selectionMode: "single",
+        fallbackText: "Choose: One or Two",
+      },
+      {
+        sendText,
+        sendStateText,
+        sendOptionsPrompt,
+      }
+    );
+
+    expect(sendOptionsPrompt).toHaveBeenCalledWith(
+      "Choose",
+      [
+        { id: "ONE", title: "One" },
+        { id: "TWO", title: "Two" },
+      ],
+      "Choose: One or Two"
+    );
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("maps WhatsApp error responses to plain text", async () => {
+    const sendText = vi.fn(async () => {});
+
+    await sendWhatsAppBotResponse(
+      {
+        kind: "error",
+        text: "Something broke",
+      },
+      {
+        sendText,
+      }
+    );
+
+    expect(sendText).toHaveBeenCalledWith("Something broke");
+  });
 });

--- a/server/botResponseAdapters.test.ts
+++ b/server/botResponseAdapters.test.ts
@@ -131,4 +131,22 @@ describe("botResponseAdapters", () => {
 
     expect(sendText).toHaveBeenCalledWith("Something broke");
   });
+
+  it("falls back to a placeholder when an image intent has no channel image sender", async () => {
+    const sendText = vi.fn(async () => {});
+    const sendStateText = vi.fn(async () => {});
+
+    await sendMessengerBotResponse(
+      {
+        kind: "image",
+        imageUrl: "https://cdn.example/result.jpg",
+      },
+      {
+        sendText,
+        sendStateText,
+      }
+    );
+
+    expect(sendText).toHaveBeenCalledWith("[Image not available]");
+  });
 });

--- a/server/entryIntent.test.ts
+++ b/server/entryIntent.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseGameEntryIntent } from "./_core/entryIntent";
+
+describe("entryIntent parsing", () => {
+  it("normalizes a Messenger deep link into an identity game entry intent", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "game:party-alter-ego?entryMode=confirm_first&campaignId=camp-1&creativeId=creative-9&entryVariant=feed-a",
+      sourceType: "referral",
+      localeHint: "nl",
+      receivedAt: 1710000000000,
+    });
+
+    expect(result).toEqual({
+      sourceChannel: "messenger",
+      sourceType: "referral",
+      targetExperienceType: "identity_game",
+      targetExperienceId: "party-alter-ego",
+      entryMode: "confirm_first",
+      campaignId: "camp-1",
+      creativeId: "creative-9",
+      entryVariant: "feed-a",
+      localeHint: "nl",
+      rawRef:
+        "game:party-alter-ego?entryMode=confirm_first&campaignId=camp-1&creativeId=creative-9&entryVariant=feed-a",
+      receivedAt: 1710000000000,
+    });
+  });
+
+  it("ignores non-game refs so style deep links can keep their own flow", () => {
+    expect(
+      parseGameEntryIntent({
+        channel: "messenger",
+        ref: "style_disco",
+      })
+    ).toBeNull();
+  });
+});

--- a/server/entryIntent.test.ts
+++ b/server/entryIntent.test.ts
@@ -35,4 +35,13 @@ describe("entryIntent parsing", () => {
       })
     ).toBeNull();
   });
+
+  it("collapses repeated separators when normalizing game ids", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "game: My Game!! ",
+    });
+
+    expect(result?.targetExperienceId).toBe("my-game");
+  });
 });

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -27,6 +27,8 @@ import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState
 import {
   getIdentityGameSessionByActiveExperience,
 } from "./_core/identityGameSessionState";
+import { parseGameEntryIntent } from "./_core/entryIntent";
+import { routeEntryIntent } from "./_core/experienceRouter";
 
 describe("experience routing", () => {
   beforeEach(() => {
@@ -221,6 +223,44 @@ describe("experience routing", () => {
     expect(sendTextMock).toHaveBeenCalledWith(
       psid,
       "Geen probleem. Deze game-link blijft herkenbaar voor later."
+    );
+  });
+
+  it("creates a fresh session id when a different game entry replaces the current active experience", async () => {
+    const state = {
+      ...getState(anonymizePsid("replace-game-user"))!,
+      psid: anonymizePsid("replace-game-user"),
+      userKey: anonymizePsid("replace-game-user"),
+      activeExperience: {
+        type: "identity_game" as const,
+        id: "party-alter-ego",
+        sessionId: "existing-session-id",
+        status: "started" as const,
+        startedAt: 1710000000000,
+        updatedAt: 1710000000000,
+      },
+    };
+
+    const setLastEntryIntent = vi.fn(async () => {});
+    const setActiveExperience = vi.fn(async () => {});
+
+    const result = await routeEntryIntent({
+      state,
+      entryIntent: parseGameEntryIntent({
+        channel: "messenger",
+        ref: "game:which-vibe-are-you",
+        receivedAt: 1710000100000,
+      }),
+      setLastEntryIntent,
+      setActiveExperience,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(setActiveExperience).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "which-vibe-are-you",
+        sessionId: expect.not.stringMatching(/^existing-session-id$/),
+      })
     );
   });
 });

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -127,4 +127,100 @@ describe("experience routing", () => {
     );
     expect(sendQuickRepliesMock).not.toHaveBeenCalled();
   });
+
+  it("handles START_GAME within the active experience instead of dropping the quick reply", async () => {
+    const psid = "confirm-game-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: {
+                payload: "GET_STARTED",
+                referral: {
+                  ref: "game:party-alter-ego?entryMode=confirm_first",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    sendTextMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-start-game",
+                quick_reply: { payload: "START_GAME" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const state = getState(anonymizePsid(psid));
+    expect(state?.activeExperience?.status).toBe("in_progress");
+    expect(sendTextMock).toHaveBeenCalledWith(
+      psid,
+      "De game-start is bevestigd. De echte vraagflow volgt in de volgende fase."
+    );
+  });
+
+  it("handles LATER within the active experience and releases thread ownership", async () => {
+    const psid = "later-game-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: {
+                payload: "GET_STARTED",
+                referral: {
+                  ref: "game:party-alter-ego?entryMode=confirm_first",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    sendTextMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-later-game",
+                quick_reply: { payload: "LATER" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const state = getState(anonymizePsid(psid));
+    expect(state?.activeExperience).toBeNull();
+    expect(sendTextMock).toHaveBeenCalledWith(
+      psid,
+      "Geen probleem. Deze game-link blijft herkenbaar voor later."
+    );
+  });
 });

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  sendImageMock,
+  sendQuickRepliesMock,
+  sendTextMock,
+  safeLogMock,
+} = vi.hoisted(() => ({
+  sendImageMock: vi.fn(async () => undefined),
+  sendQuickRepliesMock: vi.fn(async () => undefined),
+  sendTextMock: vi.fn(async () => undefined),
+  safeLogMock: vi.fn(),
+}));
+
+vi.mock("./_core/messengerApi", () => ({
+  sendImage: sendImageMock,
+  sendQuickReplies: sendQuickRepliesMock,
+  sendText: sendTextMock,
+  safeLog: safeLogMock,
+}));
+
+import {
+  processFacebookWebhookPayload,
+  resetMessengerEventDedupe,
+} from "./_core/messengerWebhook";
+import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
+import {
+  getIdentityGameSessionByActiveExperience,
+} from "./_core/identityGameSessionState";
+
+describe("experience routing", () => {
+  beforeEach(() => {
+    process.env.PRIVACY_PEPPER = "ci-test-pepper";
+    resetStateStore();
+    resetMessengerEventDedupe();
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+    safeLogMock.mockClear();
+  });
+
+  it("prioritizes EntryIntent over generic onboarding for direct game links", async () => {
+    const psid = "deep-link-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid, locale: "nl_BE" },
+              postback: {
+                payload: "GET_STARTED",
+                referral: {
+                  ref: "game:party-alter-ego?entryMode=confirm_first&campaignId=camp-1",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const state = getState(anonymizePsid(psid));
+    expect(state?.lastEntryIntent?.targetExperienceId).toBe("party-alter-ego");
+    expect(state?.activeExperience?.type).toBe("identity_game");
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      "Deze game-entry is herkend. Klaar om later te starten?",
+      [
+        { content_type: "text", title: "Start game", payload: "START_GAME" },
+        { content_type: "text", title: "Later", payload: "LATER" },
+      ]
+    );
+    expect(sendTextMock).not.toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Stuur een foto")
+    );
+  });
+
+  it("prioritizes ActiveExperience over greeting fallback once a game entry exists", async () => {
+    const psid = "resume-game-user";
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: {
+                payload: "GET_STARTED",
+                referral: {
+                  ref: "game:party-alter-ego?campaignId=camp-2",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    sendTextMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-follow-up",
+                text: "hi",
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const state = getState(anonymizePsid(psid));
+    expect(
+      getIdentityGameSessionByActiveExperience(state?.activeExperience)
+    ).not.toBeNull();
+    expect(sendTextMock).toHaveBeenCalledWith(
+      psid,
+      "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase."
+    );
+    expect(sendQuickRepliesMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/identityGameSessionState.rollback.test.ts
+++ b/server/identityGameSessionState.rollback.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const deleteScopedStateMock = vi.fn();
+const readScopedStateMock = vi.fn();
+const writeScopedStateMock = vi.fn();
+
+vi.mock("./_core/stateStore", () => ({
+  deleteScopedState: deleteScopedStateMock,
+  isPromiseLike: (value: unknown) =>
+    Boolean(value) && typeof (value as Promise<unknown>).then === "function",
+  readScopedState: readScopedStateMock,
+  writeScopedState: writeScopedStateMock,
+}));
+
+describe("identityGameSessionState rollback", () => {
+  beforeEach(() => {
+    deleteScopedStateMock.mockReset();
+    readScopedStateMock.mockReset();
+    writeScopedStateMock.mockReset();
+  });
+
+  it("rolls back the session write when the user reference write fails", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    writeScopedStateMock
+      .mockImplementationOnce(async () => undefined)
+      .mockImplementationOnce(async () => {
+        throw new Error("ref write failed");
+      });
+    deleteScopedStateMock.mockReturnValue(Promise.resolve());
+
+    try {
+      const { upsertIdentityGameSession } = await import(
+        "./_core/identityGameSessionState"
+      );
+
+      await expect(
+        upsertIdentityGameSession({
+          sessionId: "session-rollback",
+          userId: "user-rollback",
+          gameId: "party-alter-ego",
+          gameVersion: "v1",
+          entryIntent: {
+            sourceChannel: "messenger",
+            sourceType: "referral",
+            targetExperienceType: "identity_game",
+            targetExperienceId: "party-alter-ego",
+            receivedAt: 1710000000000,
+          },
+          status: "started",
+          answers: [],
+          derivedTraits: {},
+          startedAt: 1710000000000,
+          updatedAt: 1710000000000,
+          expiresAt: 1710086400000,
+        })
+      ).rejects.toThrow("ref write failed");
+
+      expect(deleteScopedStateMock).toHaveBeenCalledWith(
+        "identity-game-session",
+        "session-rollback"
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "identity_game_session_ref_write_failed",
+        expect.objectContaining({
+          sessionId: "session-rollback",
+          userId: "user-rollback",
+          error: "ref write failed",
+        })
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/server/identityGameSessionState.test.ts
+++ b/server/identityGameSessionState.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { ActiveExperience } from "./_core/activeExperience";
+import {
+  clearIdentityGameSession,
+  getIdentityGameSessionByActiveExperience,
+  getIdentityGameSessionBySessionId,
+  getIdentityGameSessionByUserId,
+  upsertIdentityGameSession,
+} from "./_core/identityGameSessionState";
+import { resetStateStore } from "./_core/messengerState";
+
+describe("identityGameSessionState", () => {
+  it("retrieves sessions by userId, sessionId, and activeExperience reference", () => {
+    resetStateStore();
+
+    const session = {
+      sessionId: "session-1",
+      userId: "user-1",
+      gameId: "party-alter-ego",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger" as const,
+        sourceType: "referral" as const,
+        targetExperienceType: "identity_game" as const,
+        targetExperienceId: "party-alter-ego",
+        receivedAt: 1710000000000,
+      },
+      status: "started" as const,
+      answers: [],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000000000,
+      expiresAt: 1710086400000,
+    };
+
+    upsertIdentityGameSession(session);
+
+    expect(getIdentityGameSessionBySessionId("session-1")).toEqual(session);
+    expect(getIdentityGameSessionByUserId("user-1")).toEqual(session);
+
+    const activeExperience: ActiveExperience = {
+      type: "identity_game",
+      id: "party-alter-ego",
+      sessionId: "session-1",
+      status: "started",
+      startedAt: 1710000000000,
+      updatedAt: 1710000000000,
+    };
+
+    expect(getIdentityGameSessionByActiveExperience(activeExperience)).toEqual(
+      session
+    );
+
+    clearIdentityGameSession("session-1", "user-1");
+    expect(getIdentityGameSessionBySessionId("session-1")).toBeNull();
+    expect(getIdentityGameSessionByUserId("user-1")).toBeNull();
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity game sessions with lifecycle/status tracking and session persistence
  * Deep-link entry parsing and intent routing for game entry
  * New bot response types: options prompts, result cards, images (with captions)
  * Experience routing to manage active game flows across messages
  * Messaging adapters can send options prompts, result cards, and images when available
  * Inbound messages now include channel capability and entry-intent metadata

* **Tests**
  * Added end-to-end and unit tests for entry intent parsing, routing, session state, and bot response adapters
<!-- end of auto-generated comment: release notes by coderabbit.ai -->