### PR TITLE
Seal Remaining Identity-Games Session Safety Gaps

### DIFF
--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -43,7 +43,7 @@ function normalizeExperienceId(value: string): string {
       continue;
     }
 
-    if ((isPreservedSeparator || !isAlphaNumeric) && !lastWasSeparator) {
+    if (!lastWasSeparator) {
       result += "-";
       lastWasSeparator = true;
     }

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -116,6 +116,7 @@ export function parseGameEntryIntent(input: {
   }
 
   const params = new URLSearchParams(query);
+  const localeFromQuery = params.get("locale")?.trim();
 
   return {
     sourceChannel: input.channel,
@@ -128,7 +129,7 @@ export function parseGameEntryIntent(input: {
     campaignId: params.get("campaignId") ?? undefined,
     creativeId: params.get("creativeId") ?? undefined,
     entryVariant: params.get("entryVariant") ?? undefined,
-    localeHint: params.get("locale") ?? input.localeHint ?? undefined,
+    localeHint: localeFromQuery || input.localeHint || undefined,
     rawRef,
     receivedAt: input.receivedAt ?? Date.now(),
   };

--- a/server/_core/identityGameSessionState.ts
+++ b/server/_core/identityGameSessionState.ts
@@ -76,10 +76,26 @@ function handleSessionRefWriteFailure<T>(
 export function getIdentityGameSessionBySessionId(
   sessionId: string
 ): MaybePromise<IdentityGameSession | null> {
-  return readScopedState<IdentityGameSession>(
+  const session = readScopedState<IdentityGameSession>(
     IDENTITY_GAME_SESSION_SCOPE,
     sessionId
   );
+
+  if (isPromiseLike(session)) {
+    return session.then(current => {
+      if (!current || isExpired(current)) {
+        return null;
+      }
+
+      return current;
+    });
+  }
+
+  if (!session || isExpired(session)) {
+    return null;
+  }
+
+  return session;
 }
 
 export function getIdentityGameSessionByUserId(

--- a/server/_core/identityGameSessionState.ts
+++ b/server/_core/identityGameSessionState.ts
@@ -99,7 +99,7 @@ export function getIdentityGameSessionByUserId(
       return Promise.resolve(
         getIdentityGameSessionBySessionId(current.sessionId)
       ).then(session => {
-        if (!session || isExpired(session)) {
+        if (!session) {
           return null;
         }
 

--- a/server/_core/identityGameSessionState.ts
+++ b/server/_core/identityGameSessionState.ts
@@ -116,7 +116,7 @@ export function getIdentityGameSessionByUserId(
 
   if (isPromiseLike(session)) {
     return session.then(current => {
-      if (!current || isExpired(current)) {
+      if (!current) {
         return null;
       }
 
@@ -124,7 +124,7 @@ export function getIdentityGameSessionByUserId(
     });
   }
 
-  if (!session || isExpired(session)) {
+  if (!session) {
     return null;
   }
 
@@ -142,7 +142,7 @@ export function getIdentityGameSessionByActiveExperience(
 
   if (isPromiseLike(session)) {
     return session.then(current => {
-      if (!current || isExpired(current)) {
+      if (!current) {
         return null;
       }
 
@@ -150,7 +150,7 @@ export function getIdentityGameSessionByActiveExperience(
     });
   }
 
-  if (!session || isExpired(session)) {
+  if (!session) {
     return null;
   }
 

--- a/server/entryIntent.test.ts
+++ b/server/entryIntent.test.ts
@@ -68,4 +68,14 @@ describe("entryIntent parsing", () => {
 
     expect(result?.localeHint).toBe("en");
   });
+
+  it("ignores an empty locale query value and falls back to the input locale hint", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "game:party-alter-ego?locale=%20%20",
+      localeHint: "nl_BE",
+    });
+
+    expect(result?.localeHint).toBe("nl_BE");
+  });
 });

--- a/server/identityGameSessionState.test.ts
+++ b/server/identityGameSessionState.test.ts
@@ -82,4 +82,31 @@ describe("identityGameSessionState", () => {
 
     expect(getIdentityGameSessionByUserId("expired-user-1")).toBeNull();
   });
+
+  it("returns null for an expired session when loaded by sessionId", () => {
+    resetStateStore();
+
+    const now = Date.now();
+    upsertIdentityGameSession({
+      sessionId: "expired-session-2",
+      userId: "expired-user-2",
+      gameId: "party-alter-ego",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "party-alter-ego",
+        receivedAt: now - 10_000,
+      },
+      status: "started",
+      answers: [],
+      derivedTraits: {},
+      startedAt: now - 10_000,
+      updatedAt: now - 10_000,
+      expiresAt: now - 1_000,
+    });
+
+    expect(getIdentityGameSessionBySessionId("expired-session-2")).toBeNull();
+  });
 });


### PR DESCRIPTION
Direct sessionId lookup now applies the same expiration guard as the userId and activeExperience paths, so expired identity-game sessions are treated as missing across all supported retrieval paths. Added a regression test covering getIdentityGameSessionBySessionId(expired) => null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale parameter handling from URLs—now properly trims and handles whitespace in locale query parameters.
  * Enhanced session expiration detection for more reliable session state management.

* **Tests**
  * Added test coverage for locale parameter edge cases.
  * Added test coverage for session expiration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->