### PR TITLE
Update privacy policy contact email to privacy@leaderbot.live

### DIFF
--- a/server/_core/index.ts
+++ b/server/_core/index.ts
@@ -343,11 +343,11 @@ async function startServer() {
       <p>You can stop using the service at any time by not messaging the Page.</p>
 
       <h2>Data deletion requests</h2>
-      <p>If you want us to delete data associated with your interactions, contact us at: shortcutcomputerguy@gmail.com</p>
+      <p>If you want us to delete data associated with your interactions, contact us at: privacy@leaderbot.live</p>
       <p>Include your Facebook profile name and the approximate time you messaged the Page so we can locate your conversation context.</p>
 
       <h2>Contact</h2>
-      <p>Email: shortcutcomputerguy@gmail.com</p>
+      <p>Email: privacy@leaderbot.live</p>
     </body>
     </html>
   `);
@@ -378,7 +378,7 @@ async function startServer() {
       </ul>
 
       <h2>How to request deletion</h2>
-      <p>Email your request to: <strong>shortcutcomputerguy@gmail.com</strong></p>
+      <p>Email your request to: <strong>privacy@leaderbot.live</strong></p>
       <p>To help us identify your records accurately, include:</p>
       <ul>
         <li>Your Facebook profile name</li>


### PR DESCRIPTION
### Motivation
- Centralize and update the contact address used in the privacy policy and data-deletion instructions to `privacy@leaderbot.live`.

### Description
- Replaced `shortcutcomputerguy@gmail.com` with `privacy@leaderbot.live` in the HTML responses for `/privacy` and `/data-deletion` by editing `server/_core/index.ts` (one file modified).

### Testing
- Ran `rg -n "shortcutcomputerguy@gmail.com|privacy@leaderbot.live" server/_core/index.ts` to verify all references were updated and only the new address remains.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c68a3e67a4832584f34044c53d93df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contact information for data deletion requests on the privacy and data-deletion pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->