### PR TITLE
Support typed START_GAME / LATER text commands for identity games

### DIFF
--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -32,13 +32,28 @@ type ExperienceRouterInput = {
   setActiveExperience: (activeExperience: ActiveExperience | null) => Promise<void>;
 };
 
+/**
+ * Normalizes inbound user input while preserving semantic content for answer parsing.
+ * Returns `null` for empty/whitespace-only input.
+ */
 function normalizeAction(action: string | null | undefined): string | null {
   const normalized = action?.trim();
   return normalized ? normalized : null;
 }
 
 type ControlAction = "START_GAME" | "LATER";
+const START_GAME_TEXT_VARIANTS = new Set([
+  "START GAME",
+  "START",
+  "START SPEL",
+  "SPEL STARTEN",
+]);
+const LATER_TEXT_VARIANTS = new Set(["LATER", "LATER AAN", "NU NIET"]);
 
+/**
+ * Maps human-entered control text to canonical game commands.
+ * This keeps confirm-first flows resilient across typed labels and quick-reply payloads.
+ */
 function normalizeControlAction(
   action: string | null | undefined
 ): ControlAction | null {
@@ -53,15 +68,10 @@ function normalizeControlAction(
   }
 
   const compact = uppercase.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
-  if (
-    compact === "START GAME" ||
-    compact === "START" ||
-    compact === "START SPEL" ||
-    compact === "SPEL STARTEN"
-  ) {
+  if (START_GAME_TEXT_VARIANTS.has(compact)) {
     return "START_GAME";
   }
-  if (compact === "LATER" || compact === "LATERAAN" || compact === "NU NIET") {
+  if (LATER_TEXT_VARIANTS.has(compact)) {
     return "LATER";
   }
 

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -37,6 +37,37 @@ function normalizeAction(action: string | null | undefined): string | null {
   return normalized ? normalized : null;
 }
 
+type ControlAction = "START_GAME" | "LATER";
+
+function normalizeControlAction(
+  action: string | null | undefined
+): ControlAction | null {
+  const normalized = normalizeAction(action);
+  if (!normalized) {
+    return null;
+  }
+
+  const uppercase = normalized.toUpperCase();
+  if (uppercase === "START_GAME" || uppercase === "LATER") {
+    return uppercase;
+  }
+
+  const compact = uppercase.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
+  if (
+    compact === "START GAME" ||
+    compact === "START" ||
+    compact === "START SPEL" ||
+    compact === "SPEL STARTEN"
+  ) {
+    return "START_GAME";
+  }
+  if (compact === "LATER" || compact === "LATERAAN" || compact === "NU NIET") {
+    return "LATER";
+  }
+
+  return null;
+}
+
 function resolveRouterLang(input: ExperienceRouterInput): "nl" | "en" {
   return normalizeLang(
     input.entryIntent?.localeHint ??
@@ -235,13 +266,13 @@ export async function routeActiveExperience(
   }
 
   const action = normalizeAction(input.action);
-  const normalizedAction = action?.toUpperCase() ?? null;
+  const controlAction = normalizeControlAction(action);
   const lang = resolveRouterLang({
     ...input,
     entryIntent: input.state.lastEntryIntent,
   });
 
-  if (normalizedAction === "LATER") {
+  if (controlAction === "LATER") {
     const abandonedSession: IdentityGameSession = {
       ...activeSession,
       status: "abandoned",
@@ -269,7 +300,7 @@ export async function routeActiveExperience(
       };
     }
 
-    if (normalizedAction === "START_GAME" && activeSession.status === "started") {
+    if (controlAction === "START_GAME" && activeSession.status === "started") {
       const inProgressSession: IdentityGameSession = {
         ...activeSession,
         status: "in_progress",
@@ -344,7 +375,7 @@ export async function routeActiveExperience(
     };
   }
 
-  if (normalizedAction === "START_GAME") {
+  if (controlAction === "START_GAME") {
     const inProgressSession: IdentityGameSession = {
       ...activeSession,
       status: "in_progress",

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -796,6 +796,136 @@ describe("identity-ai-v1 routing", () => {
     expect(setActiveExperience).not.toHaveBeenCalled();
   });
 
+  it("accepts typed 'start game' text when a confirm-first session is waiting", async () => {
+    const userKey = anonymizePsid("identity-ai-v1-start-game-text-user");
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    await upsertIdentityGameSession({
+      sessionId: "started-session",
+      userId: userKey,
+      gameId: "identity-ai-v1",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "identity-ai-v1",
+        localeHint: "en",
+        receivedAt: 1710000000000,
+        entryMode: "confirm_first",
+      },
+      status: "started",
+      answers: [],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000000000,
+      expiresAt: Date.now() + 60_000,
+      currentQuestionId: "identity-ai-v1-q1",
+      questionIndex: 1,
+    });
+
+    const result = await routeActiveExperience({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+        lastEntryIntent: {
+          sourceChannel: "messenger",
+          sourceType: "referral",
+          targetExperienceType: "identity_game",
+          targetExperienceId: "identity-ai-v1",
+          localeHint: "en",
+          receivedAt: 1710000000000,
+          entryMode: "confirm_first",
+        },
+        activeExperience: {
+          type: "identity_game",
+          id: "identity-ai-v1",
+          sessionId: "started-session",
+          status: "started",
+          startedAt: 1710000000000,
+          updatedAt: 1710000000000,
+        },
+      },
+      action: "start game",
+      setLastEntryIntent: vi.fn(async () => undefined),
+      setActiveExperience,
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.response).toMatchObject({
+      kind: "options_prompt",
+      prompt: "When a new AI tool drops, what do you do first?",
+    });
+    expect(setActiveExperience).toHaveBeenCalledOnce();
+  });
+
+  it("accepts Dutch 'nu niet' text as the later action", async () => {
+    const userKey = anonymizePsid("identity-ai-v1-later-text-user");
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    await upsertIdentityGameSession({
+      sessionId: "later-session",
+      userId: userKey,
+      gameId: "identity-ai-v1",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "identity-ai-v1",
+        localeHint: "nl",
+        receivedAt: 1710000000000,
+        entryMode: "confirm_first",
+      },
+      status: "started",
+      answers: [],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000000000,
+      expiresAt: Date.now() + 60_000,
+      currentQuestionId: "identity-ai-v1-q1",
+      questionIndex: 1,
+    });
+
+    const result = await routeActiveExperience({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+        lastEntryIntent: {
+          sourceChannel: "messenger",
+          sourceType: "referral",
+          targetExperienceType: "identity_game",
+          targetExperienceId: "identity-ai-v1",
+          localeHint: "nl",
+          receivedAt: 1710000000000,
+          entryMode: "confirm_first",
+        },
+        activeExperience: {
+          type: "identity_game",
+          id: "identity-ai-v1",
+          sessionId: "later-session",
+          status: "started",
+          startedAt: 1710000000000,
+          updatedAt: 1710000000000,
+        },
+      },
+      action: "nu niet",
+      setLastEntryIntent: vi.fn(async () => undefined),
+      setActiveExperience,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      response: {
+        kind: "text",
+        text: "Geen probleem. Deze game-link blijft herkenbaar voor later.",
+      },
+    });
+    expect(setActiveExperience).toHaveBeenCalledWith(null);
+  });
+
   it("falls back to normal thread handling after game completion", async () => {
     const psid = "identity-ai-v1-post-complete-user";
     const generateSpy = vi


### PR DESCRIPTION
### Motivation
- The confirm-first identity-game flow only recognized payload-style actions (`START_GAME` / `LATER`) and failed when users typed equivalent text, causing the game entry UX to be brittle.
- The change makes the router resilient to common typed variants and Dutch labels so users can start or defer games by typing instead of using quick-replies.

### Description
- Add a `ControlAction` type and `normalizeControlAction` helper that maps freeform text to `"START_GAME"` or `"LATER"`, recognizing variants like `start game`, `start`, `start spel`, `spel starten`, and `nu niet`.
- Use `normalizeControlAction` in `routeActiveExperience` so `START_GAME` and `LATER` handling works for typed text as well as payloads, while leaving existing answer parsing unchanged.
- Add tests in `server/experienceRouting.test.ts` verifying typed English start (`"start game"`) and Dutch defer (`"nu niet"`) both work for `confirm_first` sessions.

### Testing
- Ran the modified routing tests with `pnpm vitest run server/experienceRouting.test.ts` and received `14 passed (14)`.
- Ran the full test suite with `pnpm test` and received `290 passed (290)`.
- The changes were validated by automated tests and no test failures remain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6a8273e7483259103a9ba9362758b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of free-text commands during active sessions to recognize varied phrasing and separators (e.g., multiple ways to say "start game" or "later"), ensuring correct session transitions.

* **Tests**
  * Added tests covering text-based input handling in a confirm-first game flow, including localized responses (e.g., Dutch) and clearing/updating active sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->