### PR TITLE
Handle leaderbot_start referral as identity-ai-v1 game entry

### DIFF
--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -107,7 +107,9 @@ export function parseGameEntryIntent(input: {
   const normalizedHead = head.trim();
   let gameId = "";
 
-  if (/^game:/i.test(normalizedHead)) {
+  if (rawRef === "leaderbot_start") {
+    gameId = "identity-ai-v1";
+  } else if (/^game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice("game:".length);
   } else if (/^identity[_-]?game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice(normalizedHead.indexOf(":") + 1);

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -107,7 +107,7 @@ export function parseGameEntryIntent(input: {
   const normalizedHead = head.trim();
   let gameId = "";
 
-  if (rawRef === "leaderbot_start") {
+  if (normalizedHead.toLowerCase() === "leaderbot_start") {
     gameId = "identity-ai-v1";
   } else if (/^game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice("game:".length);

--- a/server/entryIntent.test.ts
+++ b/server/entryIntent.test.ts
@@ -116,6 +116,40 @@ describe("entryIntent parsing", () => {
     expect(result?.localeHint).toBe("en");
   });
 
+  it("maps leaderbot_start refs with query params to identity-ai-v1", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "leaderbot_start?locale=en&campaignId=launch-1",
+      sourceType: "referral",
+      receivedAt: 1710000000002,
+    });
+
+    expect(result).toEqual({
+      sourceChannel: "messenger",
+      sourceType: "referral",
+      targetExperienceType: "identity_game",
+      targetExperienceId: "identity-ai-v1",
+      entryMode: undefined,
+      campaignId: "launch-1",
+      creativeId: undefined,
+      entryVariant: undefined,
+      localeHint: "en",
+      rawRef: "leaderbot_start?locale=en&campaignId=launch-1",
+      receivedAt: 1710000000002,
+    });
+  });
+
+  it("matches leaderbot_start case-insensitively", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "LEADERBOT_START",
+      sourceType: "referral",
+      receivedAt: 1710000000003,
+    });
+
+    expect(result?.targetExperienceId).toBe("identity-ai-v1");
+  });
+
   it("ignores an empty locale query value and falls back to the input locale hint", () => {
     const result = parseGameEntryIntent({
       channel: "messenger",


### PR DESCRIPTION
# Summary
This PR fixes Messenger deep-link onboarding for the leaderbot_start referral.

When users arrive via ref=leaderbot_start, parseGameEntryIntent now maps it to identity-ai-v1 so the flow is treated as a valid game entry intent instead of returning null.

# What Changed
Updated server/_core/entryIntent.ts
Added a special-case branch in parseGameEntryIntent:
leaderbot_start -> identity-ai-v1
# Why
Previously, leaderbot_start did not match supported patterns (game:..., identity_game:..., identity-...) and was ignored as a game entry.
This prevented routeEntryIntent from receiving a valid intent and starting the expected game flow.

# Validation
Ran: pnpm -s vitest run server/entryIntent.test.ts
Result: passing
# Scope
No behavioral changes to existing game:* refs.
This is a targeted compatibility fix for the legacy/referral key leaderbot_start.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a special "leaderbot_start" entry that launches the identity AI experience and preserves query parameters (locale, campaign, entry variant), matching case-insensitively.
* **Tests**
  * Added test coverage verifying behavior and case-insensitive matching for the new entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->