### PR TITLE
Refactor identity game routing to registry-based handlers

### DIFF
--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -152,6 +152,7 @@ export async function routeEntryIntent(
   const lang = resolveRouterLang(input);
   const gameHandler = getIdentityGameHandler(input.entryIntent.targetExperienceId);
   if (!gameHandler) {
+    await input.setActiveExperience(null);
     return {
       handled: true,
       response: {
@@ -201,23 +202,6 @@ export async function routeActiveExperience(
     ...input,
     entryIntent: input.state.lastEntryIntent,
   });
-
-  if (controlAction === "LATER" && activeSession.status === "started") {
-    const abandonedSession: IdentityGameSession = {
-      ...activeSession,
-      status: "abandoned",
-      updatedAt: Date.now(),
-    };
-    await Promise.resolve(upsertIdentityGameSession(abandonedSession));
-    await input.setActiveExperience(null);
-    return {
-      handled: true,
-      response: {
-        kind: "text",
-        text: t(lang, "identityGameDeferred"),
-      },
-    };
-  }
   const gameHandler = getIdentityGameHandler(activeSession.gameId);
   if (!gameHandler) {
     await input.setActiveExperience(null);
@@ -238,15 +222,19 @@ export async function routeActiveExperience(
   });
 
   if (handlerResult.session) {
-    await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
-    const shouldUpdateActiveExperience =
+    const sessionChanged =
       handlerResult.session.sessionId !== activeSession.sessionId ||
       handlerResult.session.status !== activeSession.status ||
       handlerResult.session.updatedAt !== activeSession.updatedAt;
-    if (shouldUpdateActiveExperience) {
-      await input.setActiveExperience(toActiveExperience(handlerResult.session));
+    if (sessionChanged) {
+      await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
+      if (!handlerResult.clearActiveExperience) {
+        await input.setActiveExperience(toActiveExperience(handlerResult.session));
+      }
     }
-  } else if (handlerResult.clearActiveExperience) {
+  }
+
+  if (handlerResult.clearActiveExperience) {
     await input.setActiveExperience(null);
   }
 

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -1,16 +1,8 @@
-import { randomUUID } from "node:crypto";
 import type { ActiveExperience, IdentityGameSession } from "./activeExperience";
 import type { BotResponse } from "./botResponse";
 import type { EntryIntent } from "./entryIntent";
 import { normalizeLang, t } from "./i18n";
-import {
-  applyIdentityAiV1Answer,
-  buildIdentityAiV1QuestionResponse,
-  createIdentityAiV1Session,
-  generateIdentityAiV1ImageResponse,
-  isIdentityAiV1GameId,
-  isIdentityAiV1SessionResumable,
-} from "./identityAiV1";
+import { getIdentityGameHandler, type GameControlAction } from "./gameRegistry";
 import {
   getIdentityGameSessionByActiveExperience,
   getIdentityGameSessionByUserId,
@@ -44,15 +36,6 @@ function normalizeAction(action: string | null | undefined): string | null {
   return normalized ? normalized : null;
 }
 
-/**
- * Canonical control commands used by the confirm-first identity game flow.
- */
-type ControlAction = "START_GAME" | "LATER";
-
-/**
- * Free-text variants that should start the game.
- * Values are stored uppercase because matching happens on normalized uppercase input.
- */
 const START_GAME_TEXT_VARIANTS = new Set([
   "START GAME",
   "START",
@@ -75,7 +58,7 @@ const LATER_TEXT_VARIANTS = new Set(["LATER", "LATER AAN", "NU NIET"]);
  */
 function normalizeControlAction(
   action: string | null | undefined
-): ControlAction | null {
+): GameControlAction | null {
   const normalized = normalizeAction(action);
   if (!normalized) {
     return null;
@@ -106,28 +89,6 @@ function resolveRouterLang(input: ExperienceRouterInput): "nl" | "en" {
       input.state.preferredLang ??
       input.state.lastEntryIntent?.localeHint
   );
-}
-
-function buildPlaceholderSession(
-  state: MessengerUserState,
-  entryIntent: EntryIntent
-): IdentityGameSession {
-  const startedAt = entryIntent.receivedAt;
-  const sessionId = randomUUID();
-
-  return {
-    sessionId,
-    userId: state.userKey,
-    gameId: entryIntent.targetExperienceId,
-    gameVersion: "v1",
-    entryIntent,
-    status: "started",
-    answers: [],
-    derivedTraits: {},
-    startedAt,
-    updatedAt: startedAt,
-    expiresAt: startedAt + 24 * 60 * 60 * 1000,
-  };
 }
 
 function isIdentityGameSessionActive(session: IdentityGameSession): boolean {
@@ -189,95 +150,32 @@ export async function routeEntryIntent(
 
   await input.setLastEntryIntent(input.entryIntent);
   const lang = resolveRouterLang(input);
-
-  const resumableSession = await findResumableSession(input.state, input.entryIntent);
-  const isAutoStart = input.entryIntent.entryMode !== "confirm_first";
-
-  if (isIdentityAiV1GameId(input.entryIntent.targetExperienceId)) {
-    const baseSession =
-      resumableSession && isIdentityAiV1SessionResumable(resumableSession)
-        ? {
-            ...resumableSession,
-            entryIntent: input.entryIntent,
-            updatedAt: input.entryIntent.receivedAt,
-          }
-        : createIdentityAiV1Session(input.state, input.entryIntent);
-
-    const session =
-      isAutoStart && baseSession.status === "started"
-        ? {
-            ...baseSession,
-            status: "in_progress" as const,
-            updatedAt: input.entryIntent.receivedAt,
-          }
-        : baseSession;
-
-    await Promise.resolve(upsertIdentityGameSession(session));
-    await input.setActiveExperience(toActiveExperience(session));
-
-    if (!isAutoStart) {
-      return {
-        handled: true,
-        response: {
-          kind: "options_prompt",
-          prompt: t(lang, "identityGameConfirmFirstPrompt"),
-          options: [
-            { id: "START_GAME", title: t(lang, "identityGameConfirmStart") },
-            { id: "LATER", title: t(lang, "identityGameConfirmLater") },
-          ],
-          selectionMode: "single",
-          fallbackText:
-            lang === "en"
-              ? "Reply with START_GAME or LATER."
-              : "Antwoord met START_GAME of LATER.",
-        },
-      };
-    }
-
-    return {
-      handled: true,
-      response: buildIdentityAiV1QuestionResponse(session, lang),
-    };
-  }
-
-  const session =
-    resumableSession?.gameId === input.entryIntent.targetExperienceId
-      ? {
-          ...resumableSession,
-          entryIntent: input.entryIntent,
-          updatedAt: input.entryIntent.receivedAt,
-        }
-      : buildPlaceholderSession(input.state, input.entryIntent);
-
-  await Promise.resolve(upsertIdentityGameSession(session));
-  await input.setActiveExperience(toActiveExperience(session));
-
-  if (input.entryIntent.entryMode === "confirm_first") {
+  const gameHandler = getIdentityGameHandler(input.entryIntent.targetExperienceId);
+  if (!gameHandler) {
     return {
       handled: true,
       response: {
-        kind: "options_prompt",
-        prompt: t(lang, "identityGameConfirmFirstPrompt"),
-        options: [
-          { id: "START_GAME", title: t(lang, "identityGameConfirmStart") },
-          { id: "LATER", title: t(lang, "identityGameConfirmLater") },
-        ],
-        selectionMode: "single",
-        fallbackText:
-          lang === "en"
-            ? "Reply with START_GAME or LATER."
-            : "Antwoord met START_GAME of LATER.",
+        kind: "error",
+        text: t(lang, "identityGameUnavailable"),
       },
     };
   }
 
-  return {
-    handled: true,
-    response: {
-      kind: "text",
-      text: t(lang, "identityGameEntryRecognized"),
-    },
-  };
+  const resumableSession = await findResumableSession(input.state, input.entryIntent);
+  const isAutoStart = input.entryIntent.entryMode !== "confirm_first";
+  const { session, response } = await gameHandler.startSession({
+    state: input.state,
+    entryIntent: input.entryIntent,
+    resumableSession:
+      resumableSession && gameHandler.isResumable(resumableSession)
+        ? resumableSession
+        : null,
+    lang,
+    isAutoStart,
+  });
+  await Promise.resolve(upsertIdentityGameSession(session));
+  await input.setActiveExperience(toActiveExperience(session));
+  return { handled: true, response };
 }
 
 export async function routeActiveExperience(
@@ -320,119 +218,56 @@ export async function routeActiveExperience(
       },
     };
   }
-
-  if (isIdentityAiV1GameId(activeSession.gameId)) {
-    if (activeSession.status === "resolving" || activeSession.status === "completed") {
-      return {
-        handled: true,
-        response: {
-          kind: "error",
-          text: t(lang, "identityGameSessionPending"),
-        },
-      };
-    }
-
-    if (controlAction === "START_GAME" && activeSession.status === "started") {
-      const inProgressSession: IdentityGameSession = {
-        ...activeSession,
-        status: "in_progress",
-        updatedAt: Date.now(),
-      };
-      await Promise.resolve(upsertIdentityGameSession(inProgressSession));
-      await input.setActiveExperience(toActiveExperience(inProgressSession));
-      return {
-        handled: true,
-        response: buildIdentityAiV1QuestionResponse(inProgressSession, lang),
-      };
-    }
-
-    if (activeSession.status === "started") {
-      return {
-        handled: true,
-        response: {
-          kind: "error",
-          text: t(lang, "identityGameSessionPending"),
-        },
-      };
-    }
-
-    if (!action) {
-      return {
-        handled: true,
-        response: buildIdentityAiV1QuestionResponse(activeSession, lang, true),
-      };
-    }
-
-    const answerResult = applyIdentityAiV1Answer(activeSession, action, Date.now(), lang);
-
-    if (answerResult.kind === "invalid") {
-      return {
-        handled: true,
-        response: answerResult.response,
-      };
-    }
-
-    if (answerResult.kind === "question") {
-      await Promise.resolve(upsertIdentityGameSession(answerResult.session));
-      await input.setActiveExperience(toActiveExperience(answerResult.session));
-      return {
-        handled: true,
-        response: answerResult.response,
-      };
-    }
-
-    const resolvingSession = answerResult.session;
-    await Promise.resolve(upsertIdentityGameSession(resolvingSession));
-    await input.setActiveExperience(toActiveExperience(resolvingSession));
-
+  const gameHandler = getIdentityGameHandler(activeSession.gameId);
+  if (!gameHandler) {
+    await input.setActiveExperience(null);
     return {
       handled: true,
-      response: answerResult.response,
-      afterSend: async () => {
-        const imageResponse = await generateIdentityAiV1ImageResponse({
-          session: resolvingSession,
-          result: answerResult.result,
-        });
-        const completedAt = Date.now();
-        const completedSession: IdentityGameSession = {
-          ...resolvingSession,
-          status: "completed",
-          updatedAt: completedAt,
-          resultRef: answerResult.result.archetype.id,
-        };
-        await Promise.resolve(upsertIdentityGameSession(completedSession));
-        await input.setActiveExperience(null);
-        return imageResponse;
+      response: {
+        kind: "error",
+        text: t(lang, "identityGameUnavailable"),
       },
     };
   }
 
-  if (controlAction === "START_GAME") {
-    const inProgressSession: IdentityGameSession = {
-      ...activeSession,
-      status: "in_progress",
-      updatedAt: Date.now(),
-    };
-    await Promise.resolve(upsertIdentityGameSession(inProgressSession));
-    await input.setActiveExperience({
-      ...activeExperience,
-      status: "in_progress",
-      updatedAt: inProgressSession.updatedAt,
-    });
-    return {
-      handled: true,
-      response: {
-        kind: "text",
-        text: t(lang, "identityGameStartConfirmed"),
-      },
-    };
+  const handlerResult = await gameHandler.handleAction({
+    session: activeSession,
+    action,
+    controlAction,
+    lang,
+  });
+
+  if (handlerResult.session) {
+    await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
+    const shouldUpdateActiveExperience =
+      handlerResult.session.sessionId !== activeSession.sessionId ||
+      handlerResult.session.status !== activeSession.status ||
+      handlerResult.session.updatedAt !== activeSession.updatedAt;
+    if (shouldUpdateActiveExperience) {
+      await input.setActiveExperience(toActiveExperience(handlerResult.session));
+    }
+  } else if (handlerResult.clearActiveExperience) {
+    await input.setActiveExperience(null);
   }
 
   return {
     handled: true,
-    response: {
-      kind: "error",
-      text: t(lang, "identityGameSessionPending"),
-    },
+    response: handlerResult.response,
+    afterSend: handlerResult.afterSend
+      ? async () => {
+          const followUp = await handlerResult.afterSend!();
+          if (handlerResult.session?.status === "resolving") {
+            const completedAt = Date.now();
+            const completedSession: IdentityGameSession = {
+              ...handlerResult.session,
+              status: "completed",
+              updatedAt: completedAt,
+            };
+            await Promise.resolve(upsertIdentityGameSession(completedSession));
+            await input.setActiveExperience(null);
+          }
+          return followUp;
+        }
+      : undefined,
   };
 }

--- a/server/_core/gameRegistry.ts
+++ b/server/_core/gameRegistry.ts
@@ -1,0 +1,203 @@
+import type { IdentityGameSession } from "./activeExperience";
+import type { BotResponse } from "./botResponse";
+import type { EntryIntent } from "./entryIntent";
+import type { Lang } from "./i18n";
+import type { MessengerUserState } from "./messengerState";
+import {
+  applyIdentityAiV1Answer,
+  buildIdentityAiV1QuestionResponse,
+  createIdentityAiV1Session,
+  generateIdentityAiV1ImageResponse,
+  IDENTITY_AI_V1_GAME_ID,
+  isIdentityAiV1SessionResumable,
+} from "./identityAiV1";
+
+export type GameControlAction = "START_GAME" | "LATER";
+
+export type StartGameInput = {
+  state: MessengerUserState;
+  entryIntent: EntryIntent;
+  resumableSession: IdentityGameSession | null;
+  lang: Lang;
+  isAutoStart: boolean;
+};
+
+export type StartGameResult = {
+  session: IdentityGameSession;
+  response: BotResponse;
+};
+
+export type HandleGameActionInput = {
+  session: IdentityGameSession;
+  action: string | null;
+  controlAction: GameControlAction | null;
+  lang: Lang;
+};
+
+export type HandleGameActionResult = {
+  session: IdentityGameSession | null;
+  clearActiveExperience?: boolean;
+  response: BotResponse;
+  afterSend?: (() => Promise<BotResponse | null>) | undefined;
+};
+
+export type IdentityGameHandler = {
+  gameId: string;
+  isResumable: (session: IdentityGameSession | null) => session is IdentityGameSession;
+  startSession: (input: StartGameInput) => Promise<StartGameResult>;
+  handleAction: (input: HandleGameActionInput) => Promise<HandleGameActionResult>;
+};
+
+function buildConfirmFirstResponse(lang: Lang): BotResponse {
+  return {
+    kind: "options_prompt",
+    prompt:
+      lang === "en"
+        ? "This game entry was recognized. Ready to start later?"
+        : "Deze game-entry is herkend. Klaar om later te starten?",
+    options: [
+      { id: "START_GAME", title: lang === "en" ? "Start game" : "Start game" },
+      { id: "LATER", title: lang === "en" ? "Later" : "Later" },
+    ],
+    selectionMode: "single",
+    fallbackText:
+      lang === "en"
+        ? "Reply with START_GAME or LATER."
+        : "Antwoord met START_GAME of LATER.",
+  };
+}
+
+const identityAiV1Handler: IdentityGameHandler = {
+  gameId: IDENTITY_AI_V1_GAME_ID,
+  isResumable: isIdentityAiV1SessionResumable,
+  async startSession(input) {
+    const baseSession =
+      input.resumableSession && isIdentityAiV1SessionResumable(input.resumableSession)
+        ? {
+            ...input.resumableSession,
+            entryIntent: input.entryIntent,
+            updatedAt: input.entryIntent.receivedAt,
+          }
+        : createIdentityAiV1Session(input.state, input.entryIntent);
+
+    const session =
+      input.isAutoStart && baseSession.status === "started"
+        ? {
+            ...baseSession,
+            status: "in_progress" as const,
+            updatedAt: input.entryIntent.receivedAt,
+          }
+        : baseSession;
+
+    if (!input.isAutoStart) {
+      return {
+        session,
+        response: buildConfirmFirstResponse(input.lang),
+      };
+    }
+
+    return {
+      session,
+      response: buildIdentityAiV1QuestionResponse(session, input.lang),
+    };
+  },
+  async handleAction(input) {
+    if (input.session.status === "resolving" || input.session.status === "completed") {
+      return {
+        session: input.session,
+        response: {
+          kind: "error",
+          text:
+            input.lang === "en"
+              ? "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet."
+              : "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
+        },
+      };
+    }
+
+    if (input.controlAction === "START_GAME" && input.session.status === "started") {
+      const inProgressSession: IdentityGameSession = {
+        ...input.session,
+        status: "in_progress",
+        updatedAt: Date.now(),
+      };
+      return {
+        session: inProgressSession,
+        response: buildIdentityAiV1QuestionResponse(inProgressSession, input.lang),
+      };
+    }
+
+    if (input.session.status === "started") {
+      return {
+        session: input.session,
+        response: {
+          kind: "error",
+          text:
+            input.lang === "en"
+              ? "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet."
+              : "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
+        },
+      };
+    }
+
+    if (!input.action) {
+      return {
+        session: input.session,
+        response: buildIdentityAiV1QuestionResponse(input.session, input.lang, true),
+      };
+    }
+
+    const answerResult = applyIdentityAiV1Answer(
+      input.session,
+      input.action,
+      Date.now(),
+      input.lang
+    );
+
+    if (answerResult.kind === "invalid") {
+      return {
+        session: input.session,
+        response: answerResult.response,
+      };
+    }
+
+    if (answerResult.kind === "question") {
+      return {
+        session: answerResult.session,
+        response: answerResult.response,
+      };
+    }
+
+    const resolvingSession = answerResult.session;
+    return {
+      session: resolvingSession,
+      response: answerResult.response,
+      clearActiveExperience: false,
+      afterSend: async () => {
+        const imageResponse = await generateIdentityAiV1ImageResponse({
+          session: resolvingSession,
+          result: answerResult.result,
+        });
+        return imageResponse;
+      },
+    };
+  },
+};
+
+const handlers = new Map<string, IdentityGameHandler>([
+  [identityAiV1Handler.gameId, identityAiV1Handler],
+]);
+
+export function getIdentityGameHandler(
+  gameId: string | null | undefined
+): IdentityGameHandler | null {
+  if (!gameId) {
+    return null;
+  }
+
+  return handlers.get(gameId) ?? null;
+}
+
+export function listIdentityGameHandlers(): readonly IdentityGameHandler[] {
+  return Array.from(handlers.values());
+}

--- a/server/_core/gameRegistry.ts
+++ b/server/_core/gameRegistry.ts
@@ -99,7 +99,7 @@ const identityAiV1Handler: IdentityGameHandler = {
     };
   },
   async handleAction(input) {
-    if (input.controlAction === "LATER") {
+    if (input.controlAction === "LATER" && input.session.status === "started") {
       const abandonedSession: IdentityGameSession = {
         ...input.session,
         status: "abandoned",

--- a/server/_core/gameRegistry.ts
+++ b/server/_core/gameRegistry.ts
@@ -1,7 +1,7 @@
 import type { IdentityGameSession } from "./activeExperience";
 import type { BotResponse } from "./botResponse";
 import type { EntryIntent } from "./entryIntent";
-import type { Lang } from "./i18n";
+import { t, type Lang } from "./i18n";
 import type { MessengerUserState } from "./messengerState";
 import {
   applyIdentityAiV1Answer,
@@ -49,21 +49,18 @@ export type IdentityGameHandler = {
 };
 
 function buildConfirmFirstResponse(lang: Lang): BotResponse {
+  const prompt = t(lang, "identityGameConfirmFirstPrompt");
+  const startTitle = t(lang, "identityGameConfirmStart");
+  const laterTitle = t(lang, "identityGameConfirmLater");
   return {
     kind: "options_prompt",
-    prompt:
-      lang === "en"
-        ? "This game entry was recognized. Ready to start later?"
-        : "Deze game-entry is herkend. Klaar om later te starten?",
+    prompt,
     options: [
-      { id: "START_GAME", title: lang === "en" ? "Start game" : "Start game" },
-      { id: "LATER", title: lang === "en" ? "Later" : "Later" },
+      { id: "START_GAME", title: startTitle },
+      { id: "LATER", title: laterTitle },
     ],
     selectionMode: "single",
-    fallbackText:
-      lang === "en"
-        ? "Reply with START_GAME or LATER."
-        : "Antwoord met START_GAME of LATER.",
+    fallbackText: [prompt, `${startTitle} / ${laterTitle}`].join("\n"),
   };
 }
 
@@ -72,7 +69,7 @@ const identityAiV1Handler: IdentityGameHandler = {
   isResumable: isIdentityAiV1SessionResumable,
   async startSession(input) {
     const baseSession =
-      input.resumableSession && isIdentityAiV1SessionResumable(input.resumableSession)
+      input.resumableSession
         ? {
             ...input.resumableSession,
             entryIntent: input.entryIntent,
@@ -89,7 +86,7 @@ const identityAiV1Handler: IdentityGameHandler = {
           }
         : baseSession;
 
-    if (!input.isAutoStart) {
+    if (!input.isAutoStart && session.status === "started") {
       return {
         session,
         response: buildConfirmFirstResponse(input.lang),
@@ -102,15 +99,28 @@ const identityAiV1Handler: IdentityGameHandler = {
     };
   },
   async handleAction(input) {
+    if (input.controlAction === "LATER") {
+      const abandonedSession: IdentityGameSession = {
+        ...input.session,
+        status: "abandoned",
+        updatedAt: Date.now(),
+      };
+      return {
+        session: abandonedSession,
+        clearActiveExperience: true,
+        response: {
+          kind: "text",
+          text: t(input.lang, "identityGameDeferred"),
+        },
+      };
+    }
+
     if (input.session.status === "resolving" || input.session.status === "completed") {
       return {
         session: input.session,
         response: {
           kind: "error",
-          text:
-            input.lang === "en"
-              ? "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet."
-              : "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
+          text: t(input.lang, "identityGameSessionPending"),
         },
       };
     }
@@ -127,15 +137,19 @@ const identityAiV1Handler: IdentityGameHandler = {
       };
     }
 
+    if (input.controlAction === "START_GAME" && input.session.status === "in_progress") {
+      return {
+        session: input.session,
+        response: buildIdentityAiV1QuestionResponse(input.session, input.lang),
+      };
+    }
+
     if (input.session.status === "started") {
       return {
         session: input.session,
         response: {
           kind: "error",
-          text:
-            input.lang === "en"
-              ? "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet."
-              : "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
+          text: t(input.lang, "identityGameSessionPending"),
         },
       };
     }

--- a/server/_core/i18n.ts
+++ b/server/_core/i18n.ts
@@ -11,6 +11,7 @@ type TranslationKey =
   | "identityGameConfirmStart"
   | "identityGameConfirmLater"
   | "identityGameEntryRecognized"
+  | "identityGameUnavailable"
   | "identityGameSessionPending"
   | "identityGameStartConfirmed"
   | "identityGameDeferred"
@@ -55,6 +56,8 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
     identityGameConfirmLater: "Later",
     identityGameEntryRecognized:
       "Deze identity game-entry is herkend. De game flow zelf volgt in de volgende fase.",
+    identityGameUnavailable:
+      "Deze game-link is herkend, maar deze game is momenteel niet beschikbaar.",
     identityGameSessionPending:
       "Je identity game-sessie is herkend, maar de game flow zelf is nog niet geactiveerd in deze fase.",
     identityGameStartConfirmed:
@@ -110,6 +113,8 @@ const translations: Record<Lang, Record<TranslationKey, TranslationValue>> = {
     identityGameConfirmLater: "Later",
     identityGameEntryRecognized:
       "This identity game entry was recognized. The actual game flow will follow in the next phase.",
+    identityGameUnavailable:
+      "This game link was recognized, but this game is not available right now.",
     identityGameSessionPending:
       "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet.",
     identityGameStartConfirmed:

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -213,6 +213,78 @@ describe("identity-ai-v1 routing", () => {
     });
   });
 
+  it("confirm-first deep links still resume in-progress sessions immediately", async () => {
+    const userKey = anonymizePsid("identity-ai-v1-confirm-first-resume-user");
+    await upsertIdentityGameSession({
+      sessionId: "confirm-first-resume-session",
+      userId: userKey,
+      gameId: "identity-ai-v1",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "identity-ai-v1",
+        entryMode: "confirm_first",
+        receivedAt: 1710000000000,
+      },
+      status: "in_progress",
+      currentQuestionId: "identity-ai-v1-q2",
+      answers: [
+        {
+          questionId: "identity-ai-v1-q1",
+          answerId: "q1_build",
+          recordedAt: 1710000001000,
+        },
+      ],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000001000,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const setLastEntryIntent = vi.fn(async () => undefined);
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    const result = await routeEntryIntent({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+      },
+      entryIntent: parseGameEntryIntent({
+        channel: "messenger",
+        ref: "game:identity-ai-v1?entry=confirm_first&locale=en",
+        receivedAt: 1710000002000,
+      }),
+      setLastEntryIntent,
+      setActiveExperience,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      response: {
+        kind: "options_prompt",
+        prompt: "What kind of result feels most satisfying to you?",
+        options: [
+          { id: "q2_build", title: "A finished thing I can use now" },
+          { id: "q2_vision", title: "A bold idea no one saw coming" },
+          { id: "q2_analyst", title: "A clean answer that makes sense" },
+          { id: "q2_operate", title: "A process that runs smoothly" },
+        ],
+        selectionMode: "single",
+        fallbackText: [
+          "What kind of result feels most satisfying to you?",
+          "1. A finished thing I can use now",
+          "2. A bold idea no one saw coming",
+          "3. A clean answer that makes sense",
+          "4. A process that runs smoothly",
+          "Reply with one of these exact options:",
+        ].join("\n"),
+      },
+    });
+  });
+
   it("does not resume an expired same-game session and starts from question 1 instead", async () => {
     const userKey = anonymizePsid("identity-ai-v1-expired-resume-user");
     await upsertIdentityGameSession({
@@ -325,6 +397,44 @@ describe("identity-ai-v1 routing", () => {
         sessionId: expect.not.stringMatching(/^old-session-id$/),
       })
     );
+  });
+
+  it("clears stale active experience for unavailable game entry intents", async () => {
+    const userKey = anonymizePsid("identity-ai-v1-unavailable-entry-user");
+    const setLastEntryIntent = vi.fn(async () => undefined);
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    const result = await routeEntryIntent({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+        activeExperience: {
+          type: "identity_game",
+          id: "identity-ai-v1",
+          sessionId: "stale-active-session",
+          status: "in_progress",
+          startedAt: 1710000000000,
+          updatedAt: 1710000000000,
+        },
+      },
+      entryIntent: parseGameEntryIntent({
+        channel: "messenger",
+        ref: "game:unknown-game-v1?locale=en",
+        receivedAt: 1710000010000,
+      }),
+      setLastEntryIntent,
+      setActiveExperience,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      response: {
+        kind: "error",
+        text: "This game link was recognized, but this game is not available right now.",
+      },
+    });
+    expect(setActiveExperience).toHaveBeenCalledWith(null);
   });
 
   it("re-prompts the same question on invalid input", async () => {
@@ -858,6 +968,92 @@ describe("identity-ai-v1 routing", () => {
       prompt: "When a new AI tool drops, what do you do first?",
     });
     expect(setActiveExperience).toHaveBeenCalledOnce();
+  });
+
+  it("treats START_GAME as a resume control for in-progress sessions", async () => {
+    const userKey = anonymizePsid("identity-ai-v1-start-game-in-progress-user");
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    await upsertIdentityGameSession({
+      sessionId: "in-progress-start-game-session",
+      userId: userKey,
+      gameId: "identity-ai-v1",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "identity-ai-v1",
+        localeHint: "en",
+        entryMode: "confirm_first",
+        receivedAt: 1710000000000,
+      },
+      status: "in_progress",
+      currentQuestionId: "identity-ai-v1-q2",
+      answers: [
+        {
+          questionId: "identity-ai-v1-q1",
+          answerId: "q1_vision",
+          recordedAt: 1710000001000,
+        },
+      ],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000001000,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const result = await routeActiveExperience({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+        lastEntryIntent: {
+          sourceChannel: "messenger",
+          sourceType: "referral",
+          targetExperienceType: "identity_game",
+          targetExperienceId: "identity-ai-v1",
+          localeHint: "en",
+          entryMode: "confirm_first",
+          receivedAt: 1710000000000,
+        },
+        activeExperience: {
+          type: "identity_game",
+          id: "identity-ai-v1",
+          sessionId: "in-progress-start-game-session",
+          status: "in_progress",
+          startedAt: 1710000000000,
+          updatedAt: 1710000001000,
+        },
+      },
+      action: "START_GAME",
+      setLastEntryIntent: vi.fn(async () => undefined),
+      setActiveExperience,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      response: {
+        kind: "options_prompt",
+        prompt: "What kind of result feels most satisfying to you?",
+        options: [
+          { id: "q2_build", title: "A finished thing I can use now" },
+          { id: "q2_vision", title: "A bold idea no one saw coming" },
+          { id: "q2_analyst", title: "A clean answer that makes sense" },
+          { id: "q2_operate", title: "A process that runs smoothly" },
+        ],
+        selectionMode: "single",
+        fallbackText: [
+          "What kind of result feels most satisfying to you?",
+          "1. A finished thing I can use now",
+          "2. A bold idea no one saw coming",
+          "3. A clean answer that makes sense",
+          "4. A process that runs smoothly",
+          "Reply with one of these exact options:",
+        ].join("\n"),
+      },
+    });
+    expect(setActiveExperience).not.toHaveBeenCalled();
   });
 
   it("accepts Dutch 'nu niet' text as the later action", async () => {


### PR DESCRIPTION
### Summary

This PR refactors identity-game routing to use a registry/handler model so new game variants can be added without expanding router if/else chains.

### What changed

Added a game registry module:
gameRegistry.ts

Refactored router dispatch:
experienceRouter.ts

Added explicit unavailable-game translation keys:
i18n.ts

### Behavior

routeEntryIntent now resolves a handler by targetExperienceId.
routeActiveExperience now resolves a handler by activeSession.gameId.
Unknown game IDs now return an explicit friendly error (identityGameUnavailable) instead of silently falling back.
Current identity-ai-v1 behavior remains intact, but now lives behind the handler contract.

### Why

This creates a scalable foundation for future game variants (game:<id> deep links) with:

Single dispatch point
Standardized handler contract
Lower routing complexity as game count grows
Validation
Ran: pnpm -s vitest run server/experienceRouting.test.ts server/entryIntent.test.ts
Result: all tests passed (22 passed)

### Notes

This PR is intentionally incremental: it establishes the registry and migrates current identity-ai-v1 behavior.
Next game variants can now be added by registering new handlers rather than editing core routing logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resumable identity-game sessions and handler-driven game flows for more flexible game types.
  * Localized message when a recognized game link is not currently available.

* **Bug Fixes**
  * Router clears stale active experiences and returns a clear error when a target game is unavailable.
  * Improved handling of confirm-first/start/defer interactions to avoid incorrect state transitions.

* **Refactor**
  * Game handling restructured into a registry-based dispatch for cleaner, extensible logic.

* **Tests**
  * Added routing tests covering entry intent, unknown-game handling, and start-as-resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->