### PR TITLE
add entry intent diagnostic logging

### DIFF
--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -107,7 +107,9 @@ export function parseGameEntryIntent(input: {
   const normalizedHead = head.trim();
   let gameId = "";
 
-  if (/^game:/i.test(normalizedHead)) {
+  if (rawRef === "leaderbot_start") {
+    gameId = "identity-ai-v1";
+  } else if (/^game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice("game:".length);
   } else if (/^identity[_-]?game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice(normalizedHead.indexOf(":") + 1);

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -107,7 +107,7 @@ export function parseGameEntryIntent(input: {
   const normalizedHead = head.trim();
   let gameId = "";
 
-  if (rawRef === "leaderbot_start") {
+  if (normalizedHead.toLowerCase() === "leaderbot_start") {
     gameId = "identity-ai-v1";
   } else if (/^game:/i.test(normalizedHead)) {
     gameId = normalizedHead.slice("game:".length);

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -1101,6 +1101,19 @@ export function createWebhookHandlers({
       localeHint: localeLang ?? undefined,
       receivedAt: event.timestamp ?? Date.now(),
     });
+    console.info("[messenger webhook] entry intent parse", {
+      reqId,
+      user: toLogUser(userId),
+      referralRef: referralRef ?? null,
+      entryIntent: entryIntent
+        ? {
+            targetExperienceType: entryIntent.targetExperienceType,
+            targetExperienceId: entryIntent.targetExperienceId,
+            sourceType: entryIntent.sourceType,
+            entryMode: entryIntent.entryMode ?? null,
+          }
+        : null,
+    });
     const entryIntentRoute = await routeEntryIntent({
       state,
       entryIntent,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -1101,7 +1101,7 @@ export function createWebhookHandlers({
       localeHint: localeLang ?? undefined,
       receivedAt: event.timestamp ?? Date.now(),
     });
-    console.info("[messenger webhook] entry intent parse", {
+    safeLog("entry_intent_parsed", {
       reqId,
       user: toLogUser(userId),
       referralRef: referralRef ?? null,

--- a/server/entryIntent.test.ts
+++ b/server/entryIntent.test.ts
@@ -116,6 +116,40 @@ describe("entryIntent parsing", () => {
     expect(result?.localeHint).toBe("en");
   });
 
+  it("maps leaderbot_start refs with query params to identity-ai-v1", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "leaderbot_start?locale=en&campaignId=launch-1",
+      sourceType: "referral",
+      receivedAt: 1710000000002,
+    });
+
+    expect(result).toEqual({
+      sourceChannel: "messenger",
+      sourceType: "referral",
+      targetExperienceType: "identity_game",
+      targetExperienceId: "identity-ai-v1",
+      entryMode: undefined,
+      campaignId: "launch-1",
+      creativeId: undefined,
+      entryVariant: undefined,
+      localeHint: "en",
+      rawRef: "leaderbot_start?locale=en&campaignId=launch-1",
+      receivedAt: 1710000000002,
+    });
+  });
+
+  it("matches leaderbot_start case-insensitively", () => {
+    const result = parseGameEntryIntent({
+      channel: "messenger",
+      ref: "LEADERBOT_START",
+      sourceType: "referral",
+      receivedAt: 1710000000003,
+    });
+
+    expect(result?.targetExperienceId).toBe("identity-ai-v1");
+  });
+
   it("ignores an empty locale query value and falls back to the input locale hint", () => {
     const result = parseGameEntryIntent({
       channel: "messenger",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes "leaderbot_start" (case-insensitive) as an entry method and maps it to the identity-ai-v1 experience.

* **Chores**
  * Improved request logging to capture parsed entry intent details (request ID, anonymized user, referral, and normalized intent fields) for better observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->