### PR TITLE
fix: lint cleanup

### DIFF
--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -1,5 +1,3 @@
-import { COOKIE_NAME, ONE_YEAR_MS } from "@shared/const";
-
 const getOptionalEnvString = (value: unknown): string | undefined => {
   return typeof value === "string" ? value : undefined;
 };

--- a/server/_core/chat.ts
+++ b/server/_core/chat.ts
@@ -324,4 +324,4 @@ export function registerChatRoutes(app: Express) {
   });
 }
 
-{ parseChatRequestBody, tools };
+export { parseChatRequestBody, tools };

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -99,38 +99,7 @@ function isIdentityGameSessionActive(session: IdentityGameSession): boolean {
   return session.status === "started" || session.status === "in_progress";
 }
 
-async function findResumableSession(
-  state: MessengerUserState,
-  entryIntent: EntryIntent
-): Promise<IdentityGameSession | null> {
-  const activeSession = await Promise.resolve(
-    getIdentityGameSessionByActiveExperience(state.activeExperience)
-  );
-
-  if (
-    activeSession &&
-    activeSession.gameId === entryIntent.targetExperienceId &&
-    isIdentityGameSessionActive(activeSession)
-  ) {
-    return activeSession;
-  }
-
-  const existingSession = await Promise.resolve(
-    getIdentityGameSessionByUserId(state.userKey)
-  );
-
-  if (
-    existingSession &&
-    existingSession.gameId === entryIntent.targetExperienceId &&
-    isIdentityGameSessionActive(existingSession)
-  ) {
-    return existingSession;
-  }
-
-  return null;
-}
-
-async function findLatestSessionForGame(
+async function findExistingSessionForGame(
   state: MessengerUserState,
   entryIntent: EntryIntent
 ): Promise<IdentityGameSession | null> {
@@ -193,8 +162,9 @@ export async function routeEntryIntent(
     };
   }
 
-  const latestSession = await findLatestSessionForGame(input.state, input.entryIntent);
-  const resumableSession = latestSession ? await findResumableSession(input.state, input.entryIntent) : null;
+  const latestSession = await findExistingSessionForGame(input.state, input.entryIntent);
+  const resumableSession =
+    latestSession && isIdentityGameSessionActive(latestSession) ? latestSession : null;
   const isAutoStart = input.entryIntent.entryMode !== "confirm_first";
   const { session, response } = await gameHandler.startSession({
     state: input.state,
@@ -270,9 +240,10 @@ export async function routeActiveExperience(
       handlerResult.session.updatedAt !== activeSession.updatedAt;
     if (sessionChanged) {
       await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
-      if (handlerResult.session.status === "resolving") {
-        await input.setActiveExperience(null);
-      } else if (!handlerResult.clearActiveExperience) {
+      if (
+        handlerResult.session.status !== "resolving" &&
+        !handlerResult.clearActiveExperience
+      ) {
         await input.setActiveExperience(toActiveExperience(handlerResult.session));
       }
     }

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -233,23 +233,37 @@ export async function routeActiveExperience(
     lang,
   });
 
-  if (handlerResult.session) {
+  const shouldFinalizeBeforeAfterSend =
+    handlerResult.session?.status === "resolving" &&
+    typeof handlerResult.afterSend === "function";
+  const sessionToPersist =
+    shouldFinalizeBeforeAfterSend && handlerResult.session
+      ? ({
+          ...handlerResult.session,
+          status: "completed",
+          updatedAt: Date.now(),
+        } satisfies IdentityGameSession)
+      : handlerResult.session;
+  const shouldClearActiveExperience =
+    handlerResult.clearActiveExperience || shouldFinalizeBeforeAfterSend;
+
+  if (sessionToPersist) {
     const sessionChanged =
-      handlerResult.session.sessionId !== activeSession.sessionId ||
-      handlerResult.session.status !== activeSession.status ||
-      handlerResult.session.updatedAt !== activeSession.updatedAt;
+      sessionToPersist.sessionId !== activeSession.sessionId ||
+      sessionToPersist.status !== activeSession.status ||
+      sessionToPersist.updatedAt !== activeSession.updatedAt;
     if (sessionChanged) {
-      await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
+      await Promise.resolve(upsertIdentityGameSession(sessionToPersist));
       if (
-        handlerResult.session.status !== "resolving" &&
-        !handlerResult.clearActiveExperience
+        sessionToPersist.status !== "resolving" &&
+        !shouldClearActiveExperience
       ) {
-        await input.setActiveExperience(toActiveExperience(handlerResult.session));
+        await input.setActiveExperience(toActiveExperience(sessionToPersist));
       }
     }
   }
 
-  if (handlerResult.clearActiveExperience) {
+  if (shouldClearActiveExperience) {
     await input.setActiveExperience(null);
   }
 
@@ -257,20 +271,7 @@ export async function routeActiveExperience(
     handled: true,
     response: handlerResult.response,
     afterSend: handlerResult.afterSend
-      ? async () => {
-          const followUp = await handlerResult.afterSend!();
-          if (handlerResult.session?.status === "resolving") {
-            const completedAt = Date.now();
-            const completedSession: IdentityGameSession = {
-              ...handlerResult.session,
-              status: "completed",
-              updatedAt: completedAt,
-            };
-            await Promise.resolve(upsertIdentityGameSession(completedSession));
-            await input.setActiveExperience(null);
-          }
-          return followUp;
-        }
+      ? async () => handlerResult.afterSend!()
       : undefined,
   };
 }

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -107,7 +107,11 @@ async function findExistingSessionForGame(
     getIdentityGameSessionByActiveExperience(state.activeExperience)
   );
 
-  if (activeSession && activeSession.gameId === entryIntent.targetExperienceId) {
+  if (
+    activeSession &&
+    activeSession.gameId === entryIntent.targetExperienceId &&
+    isIdentityGameSessionActive(activeSession)
+  ) {
     return activeSession;
   }
 
@@ -115,7 +119,11 @@ async function findExistingSessionForGame(
     getIdentityGameSessionByUserId(state.userKey)
   );
 
-  if (existingSession && existingSession.gameId === entryIntent.targetExperienceId) {
+  if (
+    existingSession &&
+    existingSession.gameId === entryIntent.targetExperienceId &&
+    isIdentityGameSessionActive(existingSession)
+  ) {
     return existingSession;
   }
 

--- a/server/_core/experienceRouter.ts
+++ b/server/_core/experienceRouter.ts
@@ -130,6 +130,29 @@ async function findResumableSession(
   return null;
 }
 
+async function findLatestSessionForGame(
+  state: MessengerUserState,
+  entryIntent: EntryIntent
+): Promise<IdentityGameSession | null> {
+  const activeSession = await Promise.resolve(
+    getIdentityGameSessionByActiveExperience(state.activeExperience)
+  );
+
+  if (activeSession && activeSession.gameId === entryIntent.targetExperienceId) {
+    return activeSession;
+  }
+
+  const existingSession = await Promise.resolve(
+    getIdentityGameSessionByUserId(state.userKey)
+  );
+
+  if (existingSession && existingSession.gameId === entryIntent.targetExperienceId) {
+    return existingSession;
+  }
+
+  return null;
+}
+
 function toActiveExperience(session: IdentityGameSession): ActiveExperience {
   return {
     type: "identity_game",
@@ -170,7 +193,8 @@ export async function routeEntryIntent(
     };
   }
 
-  const resumableSession = await findResumableSession(input.state, input.entryIntent);
+  const latestSession = await findLatestSessionForGame(input.state, input.entryIntent);
+  const resumableSession = latestSession ? await findResumableSession(input.state, input.entryIntent) : null;
   const isAutoStart = input.entryIntent.entryMode !== "confirm_first";
   const { session, response } = await gameHandler.startSession({
     state: input.state,
@@ -246,7 +270,9 @@ export async function routeActiveExperience(
       handlerResult.session.updatedAt !== activeSession.updatedAt;
     if (sessionChanged) {
       await Promise.resolve(upsertIdentityGameSession(handlerResult.session));
-      if (!handlerResult.clearActiveExperience) {
+      if (handlerResult.session.status === "resolving") {
+        await input.setActiveExperience(null);
+      } else if (!handlerResult.clearActiveExperience) {
         await input.setActiveExperience(toActiveExperience(handlerResult.session));
       }
     }

--- a/server/_core/gameRegistry.ts
+++ b/server/_core/gameRegistry.ts
@@ -186,7 +186,6 @@ const identityAiV1Handler: IdentityGameHandler = {
     return {
       session: resolvingSession,
       response: answerResult.response,
-      clearActiveExperience: false,
       afterSend: async () => {
         const imageResponse = await generateIdentityAiV1ImageResponse({
           session: resolvingSession,

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -27,7 +27,12 @@ import * as messengerWebhook from "./_core/messengerWebhook";
 import { getIdentityGameSessionByUserId, upsertIdentityGameSession } from "./_core/identityGameSessionState";
 import { parseGameEntryIntent } from "./_core/entryIntent";
 import { routeActiveExperience, routeEntryIntent } from "./_core/experienceRouter";
-import { anonymizePsid, getOrCreateState, getState } from "./_core/messengerState";
+import {
+  anonymizePsid,
+  getOrCreateState,
+  getState,
+  resetStateStore,
+} from "./_core/messengerState";
 
 describe("identity-ai-v1 routing", () => {
   let psidSeq = 0;
@@ -35,6 +40,7 @@ describe("identity-ai-v1 routing", () => {
 
   beforeEach(() => {
     process.env.PRIVACY_PEPPER = "ci-test-pepper";
+    resetStateStore();
     messengerWebhook.resetMessengerEventDedupe();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -367,6 +367,91 @@ describe("identity-ai-v1 routing", () => {
     );
   });
 
+  it("falls back to the user session when activeExperience points at a completed same-game session", async () => {
+    const userKey = anonymizePsid(mkPsid("identity-ai-v1-stale-active-session-user"));
+    await upsertIdentityGameSession({
+      sessionId: "live-session",
+      userId: userKey,
+      gameId: "identity-ai-v1",
+      gameVersion: "v1",
+      entryIntent: {
+        sourceChannel: "messenger",
+        sourceType: "referral",
+        targetExperienceType: "identity_game",
+        targetExperienceId: "identity-ai-v1",
+        receivedAt: 1710000000000,
+      },
+      status: "in_progress",
+      currentQuestionId: "identity-ai-v1-q2",
+      answers: [
+        {
+          questionId: "identity-ai-v1-q1",
+          answerId: "q1_build",
+          recordedAt: 1710000001000,
+        },
+      ],
+      derivedTraits: {},
+      startedAt: 1710000000000,
+      updatedAt: 1710000001000,
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const setLastEntryIntent = vi.fn(async () => undefined);
+    const setActiveExperience = vi.fn(async () => undefined);
+
+    const result = await routeEntryIntent({
+      state: {
+        ...(await Promise.resolve(getOrCreateState(userKey))),
+        psid: userKey,
+        userKey,
+        activeExperience: {
+          type: "identity_game",
+          id: "identity-ai-v1",
+          sessionId: "completed-session",
+          status: "completed",
+          startedAt: 1710000000000,
+          updatedAt: 1710000002000,
+        },
+      },
+      entryIntent: parseGameEntryIntent({
+        channel: "messenger",
+        ref: "game:identity-ai-v1?locale=en",
+        receivedAt: 1710000002000,
+      }),
+      setLastEntryIntent,
+      setActiveExperience,
+    });
+
+    expect(result).toEqual({
+      handled: true,
+      response: {
+        kind: "options_prompt",
+        prompt: "What kind of result feels most satisfying to you?",
+        options: [
+          { id: "q2_build", title: "A finished thing I can use now" },
+          { id: "q2_vision", title: "A bold idea no one saw coming" },
+          { id: "q2_analyst", title: "A clean answer that makes sense" },
+          { id: "q2_operate", title: "A process that runs smoothly" },
+        ],
+        selectionMode: "single",
+        fallbackText: [
+          "What kind of result feels most satisfying to you?",
+          "1. A finished thing I can use now",
+          "2. A bold idea no one saw coming",
+          "3. A clean answer that makes sense",
+          "4. A process that runs smoothly",
+          "Reply with one of these exact options:",
+        ].join("\n"),
+      },
+    });
+    expect(setActiveExperience).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "identity-ai-v1",
+        sessionId: "live-session",
+      })
+    );
+  });
+
   it("does not silently reuse a different game's session", async () => {
     const userKey = anonymizePsid(mkPsid("identity-ai-v1-replace-user"));
     const setLastEntryIntent = vi.fn(async () => undefined);

--- a/server/identityAiV1.localHarness.test.ts
+++ b/server/identityAiV1.localHarness.test.ts
@@ -205,7 +205,6 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
   });
 
   it("finalizes the session before async follow-up work", async () => {
-    const generationStarted = createDeferred<void>();
     const completionDeferred = createDeferred<{
       imageUrl: string;
       proof: {
@@ -219,7 +218,6 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
     const generateSpy = vi
       .spyOn(OpenAiImageGenerator.prototype, "generate")
       .mockImplementation(() => {
-        generationStarted.resolve();
         return completionDeferred.promise;
       });
 
@@ -234,9 +232,11 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
         "q3_build"
       );
 
-      await generationStarted.promise;
-
-      const extraInput = await harness.sendText("resolving-user", "extra input");
+      await vi.waitFor(async () => {
+        const pendingSnapshot = await harness.getSnapshot("resolving-user");
+        expect(pendingSnapshot.session?.status).toBe("completed");
+        expect(pendingSnapshot.activeExperience).toBeNull();
+      });
 
       completionDeferred.resolve({
         imageUrl: "https://example.com/identity-builder-resolving.jpg",
@@ -251,9 +251,16 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
 
       const completion = await completionPromise;
 
-      expect(extraInput.session?.status).toBe("completed");
-      expect(extraInput.activeExperience).toBeNull();
       expect(completion.outboundIntents).toEqual([
+        {
+          kind: "text",
+          text: [
+            "You are: Builder",
+            "Your dominant AI instinct is to turn momentum into something real.",
+            "Your answers kept leaning toward making, shipping, and moving fast.",
+            "Want another round? Open the game link again.",
+          ].join("\n\n"),
+        },
         {
           kind: "text",
           text: "You are: Builder",
@@ -264,7 +271,7 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
         },
       ]);
       expect(
-        [extraInput, completion]
+        [completion]
           .flatMap(step => step.outboundIntents)
           .filter(
             intent =>

--- a/server/identityAiV1.localHarness.test.ts
+++ b/server/identityAiV1.localHarness.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { OpenAiImageGenerator } from "./_core/imageService";
 import { resetMessengerEventDedupe } from "./_core/messengerWebhook";
+import { resetStateStore } from "./_core/messengerState";
 import { IdentityAiV1Harness } from "./testHelpers/identityAiV1Harness";
 
 function createDeferred<T>() {
@@ -39,6 +40,7 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
 
   beforeEach(() => {
     process.env.PRIVACY_PEPPER = "ci-test-pepper";
+    resetStateStore();
     resetMessengerEventDedupe();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();

--- a/server/identityAiV1.localHarness.test.ts
+++ b/server/identityAiV1.localHarness.test.ts
@@ -204,7 +204,7 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
     ]);
   });
 
-  it("blocks duplicate resolution while the session is resolving", async () => {
+  it("finalizes the session before async follow-up work", async () => {
     const generationStarted = createDeferred<void>();
     const completionDeferred = createDeferred<{
       imageUrl: string;
@@ -251,12 +251,8 @@ describe.sequential("identity-ai-v1 local webhook harness", () => {
 
       const completion = await completionPromise;
 
-      expect(extraInput.session?.status).toBe("resolving");
-      expect(extraInput.outboundIntents).toContainEqual({
-        kind: "text",
-        text:
-          "Your identity game session was recognized, but the actual game flow is not enabled in this phase yet.",
-      });
+      expect(extraInput.session?.status).toBe("completed");
+      expect(extraInput.activeExperience).toBeNull();
       expect(completion.outboundIntents).toEqual([
         {
           kind: "text",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed unused internal imports.
  * Made backend utilities available for reuse across the server.

* **Bug Fixes / Behavior**
  * Improved session lookup and resume logic for game experiences.
  * Prevents marking an experience active while a session is resolving, improving session transition consistency.

* **Tests**
  * Tests now reset in-memory messenger/session state before each case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->