### PR TITLE
Harden image service debug path handling

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -638,9 +638,10 @@ async function maybeWriteDebugImageProof(
 
   const ext = contentType.includes("png") ? "png" : "jpg";
   const debugDir = path.join(os.tmpdir(), "leaderbot-debug");
+  const safeReqId = reqId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 80) || "req";
   const savedPath = path.join(
     debugDir,
-    `leaderbot_incoming_${reqId}_${Date.now()}_${randomUUID()}.${ext}`
+    `leaderbot_incoming_${safeReqId}_${Date.now()}_${randomUUID()}.${ext}`
   );
   try {
     await fs.mkdir(debugDir, { recursive: true });
@@ -746,7 +747,8 @@ async function readResponseBufferWithinLimit(
 async function buildDownloadedSourceImage(
   reqId: string,
   contentType: string,
-  response: Response
+  response: Response,
+  totalFetchMs: number
 ): Promise<DownloadedSourceImage> {
   const imageBuffer = await readResponseBufferWithinLimit(reqId, response);
   const incomingByteLen = safeLen(imageBuffer);
@@ -760,7 +762,7 @@ async function buildDownloadedSourceImage(
     contentType,
     incomingLen: incomingByteLen,
     incomingSha256: incomingHash,
-    fbImageFetchMs: 0,
+    fbImageFetchMs: totalFetchMs,
   };
 }
 
@@ -834,16 +836,13 @@ async function downloadSourceImageOrThrow(
         throwMissingInputDownloadFailed(reqId, response.status);
       }
 
-      const downloadedImage = await buildDownloadedSourceImage(
+      totalFetchMs += Date.now() - attemptStartedAt;
+      return buildDownloadedSourceImage(
         reqId,
         contentType,
-        response
+        response,
+        totalFetchMs
       );
-      totalFetchMs += Date.now() - attemptStartedAt;
-      return {
-        ...downloadedImage,
-        fbImageFetchMs: totalFetchMs,
-      };
     } catch (error) {
       totalFetchMs += Date.now() - attemptStartedAt;
       if (shouldRetrySourceImageError(attempt, error, reqId)) {


### PR DESCRIPTION
## Samenvatting

Deze PR hardent een kleine maar echte paper cut in `imageService.ts`.

Ze doet twee dingen:
- sanitizet `reqId` voordat het in debug proof bestandsnamen terechtkomt
- geeft `fbImageFetchMs` direct door als de echte totale fetchduur

## Waarom

Deze snede komt voort uit de salvage-review van een oudere diverged branch. Daar zat één nuttig idee in rond fetch-metrics, maar ook regressierisico rond inbound image limits en debug-proof error handling.

Deze PR neemt alleen de veilige hardening over en laat de bestaande safeguards intact.

## Wat verandert

- debug proof bestandsnamen gebruiken nu een gesanitized `reqId`-component
- fetchduur wordt rechtstreeks meegegeven aan `buildDownloadedSourceImage(...)`
- geen wijziging aan:
  - inbound image size limiting
  - streamed response limiting
  - non-fatal debug proof write handling

## Gedragsimpact

Geen bedoelde gedragswijziging in de generation flow.

De enige functionele impact is:
- debug proof writes kunnen niet meer ontsporen via rare `reqId`-tekens
- metrics voor `fbImageFetchMs` zijn iets consistenter

## Validatie

- `pnpm -s tsc --noEmit`

`vitest run server/imageService.proof.test.ts` kon lokaal in deze omgeving niet opstarten door dezelfde Vite/Vitest `spawn EPERM` config-startupbeperking die we eerder ook zagen. Dat blokkeerde de runner vóór testuitvoering; er is dus geen geobserveerde assertion failure uit deze wijziging gekomen.

## Buiten scope

- geen rewrite van `imageService.ts`
- geen wijziging aan inbound image guardrails
- geen salvage van de oude branch als geheel
