### PR TITLE
Expire in-memory state entries when TTL elapses

### DIFF
--- a/server/_core/stateStore.ts
+++ b/server/_core/stateStore.ts
@@ -18,6 +18,7 @@ type RedisModule = {
 export type MaybePromise<T> = T | Promise<T>;
 
 const memoryState = new Map<string, string>();
+const memoryStateExpiresAt = new Map<string, number>();
 const memoryEphemeral = new Map<string, number>();
 
 let redisClientPromise: Promise<RedisLike> | null = null;
@@ -75,6 +76,7 @@ export async function ensureStateStoreReady(): Promise<void> {
 
 function readRawState<T>(storageKey: string): MaybePromise<T | null> {
   if (!isRedisStateStoreEnabled()) {
+    clearExpiredMemoryState();
     const payload = memoryState.get(storageKey);
     return payload ? (JSON.parse(payload) as T) : null;
   }
@@ -93,7 +95,14 @@ function writeRawState<T>(
   const payload = JSON.stringify(value);
 
   if (!isRedisStateStoreEnabled()) {
+    clearExpiredMemoryState();
+    if (ttlSeconds <= 0) {
+      memoryState.delete(storageKey);
+      memoryStateExpiresAt.delete(storageKey);
+      return;
+    }
     memoryState.set(storageKey, payload);
+    memoryStateExpiresAt.set(storageKey, Date.now() + ttlSeconds * 1000);
     return;
   }
 
@@ -107,6 +116,7 @@ function writeRawState<T>(
 function deleteRawState(storageKey: string): MaybePromise<void> {
   if (!isRedisStateStoreEnabled()) {
     memoryState.delete(storageKey);
+    memoryStateExpiresAt.delete(storageKey);
     return;
   }
 
@@ -199,6 +209,8 @@ export function findInMemoryState<T>(
     return null;
   }
 
+  clearExpiredMemoryState();
+
   for (const payload of memoryState.values()) {
     const value = JSON.parse(payload) as T;
     if (predicate(value)) {
@@ -211,7 +223,17 @@ export function findInMemoryState<T>(
 
 export function clearStateStore(): void {
   memoryState.clear();
+  memoryStateExpiresAt.clear();
   memoryEphemeral.clear();
+}
+
+function clearExpiredMemoryState(now = Date.now()): void {
+  for (const [key, expiresAt] of memoryStateExpiresAt.entries()) {
+    if (expiresAt <= now) {
+      memoryStateExpiresAt.delete(key);
+      memoryState.delete(key);
+    }
+  }
 }
 
 function clearExpiredMemoryEphemeral(now = Date.now()): void {

--- a/server/stateStore.test.ts
+++ b/server/stateStore.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearStateStore,
+  findInMemoryState,
+  getOrCreateStoredState,
+  readScopedState,
+  readState,
+  updateStoredState,
+  writeScopedState,
+  writeState,
+} from "./_core/stateStore";
+
+describe("stateStore memory TTL", () => {
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeEach(() => {
+    delete process.env.REDIS_URL;
+    clearStateStore();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearStateStore();
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+      return;
+    }
+
+    process.env.REDIS_URL = originalRedisUrl;
+  });
+
+  it("expires scoped state in memory mode after its TTL", () => {
+    writeScopedState("scope", "key", { value: 1 }, 5);
+
+    expect(readScopedState<{ value: number }>("scope", "key")).toEqual({
+      value: 1,
+    });
+
+    vi.advanceTimersByTime(5_001);
+
+    expect(readScopedState("scope", "key")).toBeNull();
+  });
+
+  it("applies the same TTL semantics to default state writes", () => {
+    writeState("user-1", { stage: "IDLE" });
+
+    expect(readState<{ stage: string }>("user-1")).toEqual({ stage: "IDLE" });
+
+    vi.advanceTimersByTime(172800_001);
+
+    expect(readState("user-1")).toBeNull();
+  });
+
+  it("recreates stored state after expiry", () => {
+    const first = getOrCreateStoredState("user-2", () => ({ version: 1 }));
+    expect(first).toEqual({ version: 1 });
+
+    vi.advanceTimersByTime(172800_001);
+
+    const second = getOrCreateStoredState("user-2", () => ({ version: 2 }));
+    expect(second).toEqual({ version: 2 });
+  });
+
+  it("treats expired state as null during update", () => {
+    writeState("user-3", { count: 1 });
+    vi.advanceTimersByTime(172800_001);
+
+    const result = updateStoredState<{ count: number }>("user-3", current => ({
+      count: current?.count ?? 99,
+    }));
+
+    expect(result).toEqual({ count: 99 });
+    expect(readState("user-3")).toEqual({ count: 99 });
+  });
+
+  it("does not return expired entries from findInMemoryState", () => {
+    writeScopedState("scope", "fresh", { id: "fresh" }, 10);
+    writeScopedState("scope", "stale", { id: "stale" }, 1);
+
+    vi.advanceTimersByTime(1_001);
+
+    expect(findInMemoryState<{ id: string }>(value => value.id === "stale")).toBeNull();
+    expect(findInMemoryState<{ id: string }>(value => value.id === "fresh")).toEqual({
+      id: "fresh",
+    });
+  });
+
+  it("clears both payloads and TTL metadata", () => {
+    writeScopedState("scope", "key", { ok: true }, 10);
+    clearStateStore();
+    vi.advanceTimersByTime(10_001);
+
+    expect(readScopedState("scope", "key")).toBeNull();
+    expect(findInMemoryState<{ ok: boolean }>(value => value.ok)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What broke
In memory mode, normal state entries never expired even though the same writes use TTL in Redis mode. That meant stale user/session state could linger indefinitely whenever Redis was not configured.

## Root cause
`stateStore` tracked TTL only for `memoryEphemeral`, while normal state writes only stored JSON payloads in `memoryState` with no expiry metadata or lazy eviction on reads.

## Why this fix is minimal
This patch only changes the in-memory path inside `stateStore` and adds a focused regression test. It leaves Redis behavior, public state APIs, and higher-level bot flows untouched.

## What I tested
- `pnpm -s tsc --noEmit`
- Added `server/stateStore.test.ts` covering scoped state expiry, default state expiry, recreate-after-expiry, update-after-expiry, `findInMemoryState`, and `clearStateStore`
- Note: local Vitest execution in this environment still hits the known Vite/Vitest `spawn EPERM` startup issue before running assertions

## What I intentionally did not change
I did not change Redis requirements, metrics auth, webhook flow, `imageService`, or any broader state-machine or provider-boundary logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-memory state entries now support automatic expiration via configurable time-to-live (TTL) settings, with stale entries automatically removed during reads and cleanup operations.

* **Tests**
  * Added comprehensive test suite for in-memory state TTL expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->