### PR TITLE
feat: normalize messenger source images at ingress

### DIFF
--- a/server/_core/messengerImageIngress.ts
+++ b/server/_core/messengerImageIngress.ts
@@ -1,0 +1,72 @@
+import type { Style } from "./messengerStyles";
+import { ingestExternalSourceImage } from "./sourceImageStore";
+import { normalizeStyle } from "./webhookHelpers";
+
+type NormalizeMessengerInboundImageInput = {
+  inboundImageUrl: string;
+  psidHash: string;
+  reqId: string;
+};
+
+export async function normalizeMessengerInboundImage(
+  input: NormalizeMessengerInboundImageInput
+): Promise<string | null> {
+  try {
+    const storedSourceImage = await ingestExternalSourceImage(
+      input.inboundImageUrl,
+      input.reqId
+    );
+    return storedSourceImage.url;
+  } catch (error) {
+    console.error("[messenger webhook] failed to normalize inbound image", {
+      psidHash: input.psidHash,
+      reqId: input.reqId,
+      inboundImageUrl: input.inboundImageUrl,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+type StoredMessengerImageDecisionInput = {
+  lastPhotoUrl: string | null;
+  preselectedStyle?: string | null;
+  storedSourceImageUrl: string;
+};
+
+export type StoredMessengerImageDecision =
+  | {
+      action: "show_style_picker";
+      hadPreviousPhoto: boolean;
+      incomingImageUrl: string;
+      preselectedStyle: null;
+    }
+  | {
+      action: "auto_run_preselected_style";
+      hadPreviousPhoto: boolean;
+      incomingImageUrl: string;
+      preselectedStyle: Style;
+    };
+
+export function getStoredMessengerImageDecision(
+  input: StoredMessengerImageDecisionInput
+): StoredMessengerImageDecision {
+  const hadPreviousPhoto = Boolean(input.lastPhotoUrl);
+  const preselectedStyle = normalizeStyle(input.preselectedStyle ?? "") ?? null;
+
+  if (preselectedStyle && !hadPreviousPhoto) {
+    return {
+      action: "auto_run_preselected_style",
+      hadPreviousPhoto,
+      incomingImageUrl: input.storedSourceImageUrl,
+      preselectedStyle,
+    };
+  }
+
+  return {
+    action: "show_style_picker",
+    hadPreviousPhoto,
+    incomingImageUrl: input.storedSourceImageUrl,
+    preselectedStyle: null,
+  };
+}

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -385,6 +385,14 @@ export function setPendingImage(
   }
 }
 
+export function setPendingStoredImage(
+  psid: string,
+  imageUrl: string,
+  now = Date.now()
+): MaybePromise<void> {
+  return setPendingImage(psid, imageUrl, now, "stored");
+}
+
 export function clearPendingImageState(psid: string, now = Date.now()): MaybePromise<MessengerUserState> {
   return patchState(
     psid,

--- a/server/_core/sourceImageStore.ts
+++ b/server/_core/sourceImageStore.ts
@@ -3,7 +3,13 @@ import {
   buildGeneratedImageUrl,
   putGeneratedImage,
 } from "./generatedImageStore";
+import { resolveSourceImage } from "./image-generation/sourceImageFetcher";
 import { storagePut } from "../storage";
+
+export type StoredSourceImage = {
+  url: string;
+  origin: "stored";
+};
 
 function getConfiguredBaseUrl(): string | undefined {
   const configuredBaseUrl =
@@ -62,4 +68,24 @@ export async function storeInboundSourceImage(
 
   const token = putGeneratedImage(buffer, contentType);
   return buildGeneratedImageUrl(publicBaseUrl, token);
+}
+
+export async function ingestExternalSourceImage(
+  sourceImageUrl: string,
+  reqId: string
+): Promise<StoredSourceImage> {
+  const downloadedImage = await resolveSourceImage({
+    sourceImageUrl,
+    reqId,
+  });
+  const storedImageUrl = await storeInboundSourceImage(
+    downloadedImage.buffer,
+    downloadedImage.contentType,
+    reqId
+  );
+
+  return {
+    url: storedImageUrl,
+    origin: "stored",
+  };
 }

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -19,7 +19,7 @@ import {
   setLastGenerationContext,
   setLastEntryIntent,
   setLastUserMessageAt,
-  setPendingImage,
+  setPendingStoredImage,
   setPreselectedStyle,
   setPreferredLang,
   setSelectedStyleCategory,
@@ -32,6 +32,10 @@ import { normalizeLang, t, type Lang } from "./i18n";
 import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
 import { parseGameEntryIntent } from "./entryIntent";
 import { toLogUser, toUserKey } from "./privacy";
+import {
+  getStoredMessengerImageDecision,
+  normalizeMessengerInboundImage,
+} from "./messengerImageIngress";
 import {
   getStylesForCategory,
   type Style,
@@ -949,14 +953,26 @@ export function createWebhookHandlers({
       att => att.type === "image" && att.payload?.url
     );
     if (imageAttachment?.payload?.url) {
+      const inboundImageUrl = imageAttachment.payload.url;
       debugWebhookLog({
         level: "debug",
         msg: "photo_received",
         reqId,
         psidHash: anonymizePsid(psid).slice(0, 12),
         hasAttachments: !!message.attachments,
-        attachmentHostname: getAttachmentHostname(imageAttachment.payload.url),
+        attachmentHostname: getAttachmentHostname(inboundImageUrl),
       });
+
+      const storedSourceImageUrl = await normalizeMessengerInboundImage({
+        inboundImageUrl,
+        psidHash: anonymizePsid(psid).slice(0, 12),
+        reqId,
+      });
+      if (!storedSourceImageUrl) {
+        await setFlowState(psid, "AWAITING_PHOTO");
+        await sendLoggedText(psid, t(lang, "missingInputImage"), reqId);
+        return;
+      }
 
       const state = await getOrCreateState(psid);
       for (const feature of getBotFeatures()) {
@@ -967,7 +983,7 @@ export function createWebhookHandlers({
             reqId,
             lang,
             state,
-            imageAttachment.payload.url
+            storedSourceImageUrl
           )
         );
         if (result?.handled) {
@@ -975,25 +991,34 @@ export function createWebhookHandlers({
         }
       }
       logUserState(psid, userId, state, reqId, "image_received");
-      const hadPreviousPhoto = Boolean(state.lastPhotoUrl);
-      const preselectedStyle = normalizeStyle(state.preselectedStyle ?? "");
-      await setPendingImage(psid, imageAttachment.payload.url);
+      const imageDecision = getStoredMessengerImageDecision({
+        lastPhotoUrl: state.lastPhotoUrl,
+        preselectedStyle: state.preselectedStyle,
+        storedSourceImageUrl,
+      });
+      await setPendingStoredImage(psid, storedSourceImageUrl);
 
-      if (preselectedStyle && !hadPreviousPhoto) {
+      if (imageDecision.action === "auto_run_preselected_style") {
         logImageFlowDecision({
           psid,
           userId,
           reqId,
           stage: state.stage,
-          hadPreviousPhoto,
-          incomingImageUrl: imageAttachment.payload.url,
+          hadPreviousPhoto: imageDecision.hadPreviousPhoto,
+          incomingImageUrl: imageDecision.incomingImageUrl,
           selectedStyle: state.selectedStyle,
-          preselectedStyle: preselectedStyle ?? null,
-          action: "auto_run_preselected_style",
+          preselectedStyle: imageDecision.preselectedStyle,
+          action: imageDecision.action,
         });
         await setPreselectedStyle(psid, null);
-        await setChosenStyle(psid, preselectedStyle);
-        await runStyleGeneration(psid, userId, preselectedStyle, reqId, lang);
+        await setChosenStyle(psid, imageDecision.preselectedStyle);
+        await runStyleGeneration(
+          psid,
+          userId,
+          imageDecision.preselectedStyle,
+          reqId,
+          lang
+        );
         return;
       }
 
@@ -1002,11 +1027,11 @@ export function createWebhookHandlers({
         userId,
         reqId,
         stage: state.stage,
-        hadPreviousPhoto,
-        incomingImageUrl: imageAttachment.payload.url,
+        hadPreviousPhoto: imageDecision.hadPreviousPhoto,
+        incomingImageUrl: imageDecision.incomingImageUrl,
         selectedStyle: state.selectedStyle,
-        preselectedStyle: preselectedStyle ?? null,
-        action: "show_style_picker",
+        preselectedStyle: imageDecision.preselectedStyle,
+        action: imageDecision.action,
       });
       await setFlowState(psid, "AWAITING_STYLE");
       await sendPhotoReceivedPrompt(psid, lang, reqId);

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -37,17 +37,40 @@ describe("photo-first onboarding", () => {
   });
 
   beforeEach(() => {
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS =
+      "img.example,fbsbx.com,leaderbot-fb-image-gen.fly.dev";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     sendImageMock.mockClear();
     sendButtonTemplateMock.mockClear();
     sendGenericTemplateMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();
     safeLogMock.mockClear();
+    const sourceImage = Buffer.alloc(6000, 7);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        const urlString = typeof url === "string" ? url : url.toString();
+        if (
+          urlString.startsWith("https://img.example/") ||
+          urlString.startsWith("https://leaderbot-fb-image-gen.fly.dev/generated/")
+        ) {
+          return {
+            ok: true,
+            headers: new Headers({ "content-type": "image/jpeg" }),
+            arrayBuffer: async () => sourceImage,
+          } as Response;
+        }
+
+        throw new Error(`Unexpected fetch in messengerWebhook.photoFirst.test: ${urlString}`);
+      })
+    );
     resetStateStore();
     resetMessengerEventDedupe();
   });
 
   afterAll(() => {
+    vi.unstubAllGlobals();
     if (originalPrivacyPepper === undefined) {
       delete process.env.PRIVACY_PEPPER;
       return;
@@ -76,7 +99,10 @@ describe("photo-first onboarding", () => {
     });
 
     const userState = getState(anonymizePsid(psid));
-    expect(userState?.lastPhoto).toBe("https://img.example/source.jpg");
+    expect(userState?.lastPhoto).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
+    expect(userState?.lastPhotoSource).toBe("stored");
     expect(userState?.stage).toBe("AWAITING_STYLE");
     expect(sendQuickRepliesMock).toHaveBeenCalledWith(
       psid,

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -114,6 +114,24 @@ function installOpenAiSuccessFetchMock() {
   return fetchMock;
 }
 
+function installImageIngressFetchMock() {
+  const sourceImage = Buffer.alloc(6000, 7);
+  const fetchMock = vi.fn(async (url: string | URL) => {
+    if (isSourceImageFetchUrl(url)) {
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "image/jpeg" }),
+        arrayBuffer: async () => sourceImage,
+      } as Response;
+    }
+
+    throw new Error(`Unexpected fetch in messengerWebhook.test: ${toUrlString(url)}`);
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
 beforeAll(() => {
   process.env.PRIVACY_PEPPER = TEST_PEPPER;
 });
@@ -131,6 +149,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete process.env.OPENAI_API_KEY;
   delete process.env.APP_BASE_URL;
+  delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
 });
 
 beforeEach(() => {
@@ -151,6 +170,7 @@ describe("messenger webhook dedupe", () => {
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    installImageIngressFetchMock();
     sendImageMock.mockClear();
     sendGenericTemplateMock.mockClear();
     sendQuickRepliesMock.mockClear();
@@ -1218,6 +1238,7 @@ describe("messenger text brain rollout", () => {
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    installImageIngressFetchMock();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();
@@ -1454,6 +1475,7 @@ describe("messenger greeting behavior", () => {
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    installImageIngressFetchMock();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();
@@ -1990,6 +2012,8 @@ describe("acknowledgement edgecases", () => {
 describe("bot rate limit feature", () => {
   beforeEach(() => {
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    installImageIngressFetchMock();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();
@@ -2029,6 +2053,7 @@ describe("disabled bot features stay out of the runtime flow", () => {
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    installImageIngressFetchMock();
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -68,11 +68,35 @@ function toUrlString(url: string | URL): string {
 }
 
 const GENERATED_IMAGE_BASE64 = Buffer.from("fake-png").toString("base64");
+const GENERATED_SOURCE_IMAGE_URL_PREFIX =
+  "https://leaderbot-fb-image-gen.fly.dev/generated/";
+const DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS =
+  "img.example,fbsbx.com,leaderbot-fb-image-gen.fly.dev";
+
+function isNormalizedSourceImageUrl(url: string | URL): boolean {
+  return toUrlString(url).startsWith(GENERATED_SOURCE_IMAGE_URL_PREFIX);
+}
+
+function isSourceImageFetchUrl(
+  url: string | URL,
+  exactExternalUrl?: string
+): boolean {
+  const urlString = toUrlString(url);
+  if (isNormalizedSourceImageUrl(urlString)) {
+    return true;
+  }
+
+  if (exactExternalUrl) {
+    return urlString === exactExternalUrl;
+  }
+
+  return urlString.startsWith("https://img.example/");
+}
 
 function installOpenAiSuccessFetchMock() {
   const sourceImage = Buffer.alloc(6000, 7);
   const fetchMock = vi.fn(async (url: string | URL) => {
-    if (toUrlString(url).startsWith("https://img.example/")) {
+    if (isSourceImageFetchUrl(url)) {
       return {
         ok: true,
         headers: new Headers({ "content-type": "image/jpeg" }),
@@ -124,7 +148,7 @@ describe("messenger webhook dedupe", () => {
   beforeEach(() => {
     delete process.env.MOCK_MODE;
     process.env.GENERATOR_MODE = "openai";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     sendImageMock.mockClear();
@@ -524,7 +548,7 @@ describe("messenger webhook dedupe", () => {
         ],
       });
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(sendImageMock).toHaveBeenCalledWith(
         `style-user-${style}`,
         expect.stringMatching(
@@ -579,7 +603,7 @@ describe("messenger webhook dedupe", () => {
 
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      if (toUrlString(url).startsWith("https://img.example/")) {
+      if (isSourceImageFetchUrl(url)) {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -633,7 +657,7 @@ describe("messenger webhook dedupe", () => {
       ],
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(sendImageMock).toHaveBeenCalledWith(
       "norman-payload-user",
       expect.stringMatching(
@@ -760,7 +784,7 @@ describe("messenger webhook dedupe", () => {
     const sourceImage = Buffer.alloc(6000, 7);
     const generatedImageBytes = Buffer.from("fake-png").toString("base64");
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
+      if (isSourceImageFetchUrl(url, "https://img.example/source.jpg")) {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -808,7 +832,7 @@ describe("messenger webhook dedupe", () => {
       vi.unstubAllGlobals();
     }
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(sendImageMock).toHaveBeenCalledWith(
       "openai-success-user",
       expect.stringMatching(
@@ -853,7 +877,10 @@ describe("messenger webhook dedupe", () => {
 
     const failedState = getState(userId);
     expect(failedState?.stage).toBe("FAILURE");
-    expect(failedState?.lastPhoto).toBe("https://img.example/retry.jpg");
+    expect(failedState?.lastPhoto).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
+    expect(failedState?.lastPhotoSource).toBe("stored");
     expect(failedState?.selectedStyle).toBe("gold");
 
     sendTextMock.mockClear();
@@ -874,7 +901,10 @@ describe("messenger webhook dedupe", () => {
 
     const retriedState = getState(userId);
     expect(retriedState?.stage).toBe("FAILURE");
-    expect(retriedState?.lastPhoto).toBe("https://img.example/retry.jpg");
+    expect(retriedState?.lastPhoto).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+    );
+    expect(retriedState?.lastPhotoSource).toBe("stored");
     expect(retriedState?.selectedStyle).toBe("gold");
     expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
       psid,
@@ -903,7 +933,7 @@ describe("messenger webhook dedupe", () => {
     timeoutError.name = "AbortError";
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
+      if (isSourceImageFetchUrl(url, "https://img.example/source.jpg")) {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -974,7 +1004,7 @@ describe("messenger webhook dedupe", () => {
       | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn((url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
+      if (isSourceImageFetchUrl(url, "https://img.example/source.jpg")) {
         return Promise.resolve({
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -1030,7 +1060,7 @@ describe("messenger webhook dedupe", () => {
       });
 
       await vi.waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(resolveFetch).toBeTypeOf("function");
       });
 
@@ -1055,7 +1085,7 @@ describe("messenger webhook dedupe", () => {
         ],
       });
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(sendTextMock).toHaveBeenCalledWith(
         "busy-user",
         "⏳ even geduld, ik ben nog bezig met jouw restyle"
@@ -1084,7 +1114,7 @@ describe("messenger webhook dedupe", () => {
       | undefined;
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn((url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
+      if (isSourceImageFetchUrl(url, "https://img.example/source.jpg")) {
         return Promise.resolve({
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -1140,7 +1170,7 @@ describe("messenger webhook dedupe", () => {
       });
 
       await vi.waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
         expect(resolveFetch).toBeTypeOf("function");
       });
 
@@ -1185,7 +1215,7 @@ describe("messenger webhook dedupe", () => {
 describe("messenger text brain rollout", () => {
   beforeEach(() => {
     process.env.GENERATOR_MODE = "openai";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     sendImageMock.mockClear();
@@ -1421,7 +1451,7 @@ describe("messenger text brain rollout", () => {
 
 describe("messenger greeting behavior", () => {
   beforeEach(() => {
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     sendImageMock.mockClear();
@@ -1513,7 +1543,7 @@ describe("messenger greeting behavior", () => {
 
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === "https://img.example/source.jpg") {
+      if (isSourceImageFetchUrl(url, "https://img.example/source.jpg")) {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),
@@ -1959,7 +1989,7 @@ describe("acknowledgement edgecases", () => {
 
 describe("bot rate limit feature", () => {
   beforeEach(() => {
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     sendImageMock.mockClear();
     sendQuickRepliesMock.mockClear();
     sendTextMock.mockClear();
@@ -1996,7 +2026,7 @@ describe("bot rate limit feature", () => {
 describe("disabled bot features stay out of the runtime flow", () => {
   beforeEach(() => {
     process.env.GENERATOR_MODE = "openai";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example,fbsbx.com";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = DEFAULT_ALLOWED_SOURCE_IMAGE_HOSTS;
     process.env.OPENAI_API_KEY = "dummy-key";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     sendImageMock.mockClear();
@@ -2301,18 +2331,60 @@ describe("disabled bot features stay out of the runtime flow", () => {
         expect.objectContaining({ payload: "STYLE_CATEGORY_BOLD" }),
       ])
     );
-    expect(getState(anonymizePsid("stale-preselect-user"))?.lastPhotoUrl).toBe(
-      "https://img.example/new-source.jpg"
+    expect(getState(anonymizePsid("stale-preselect-user"))?.lastPhotoUrl).toMatch(
+      /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
     );
+    expect(getState(anonymizePsid("stale-preselect-user"))?.lastPhotoSource).toBe("stored");
     expect(
       getState(anonymizePsid("stale-preselect-user"))?.preselectedStyle
     ).toBe("cyberpunk");
   });
 
+  it("stores Messenger attachment URLs before downstream generation fetches them again", async () => {
+    const fetchMock = installOpenAiSuccessFetchMock();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: "stored-boundary-user" },
+              message: {
+                mid: "mid-stored-boundary-photo",
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
+              },
+            },
+            {
+              sender: { id: "stored-boundary-user" },
+              message: {
+                mid: "mid-stored-boundary-style",
+                quick_reply: { payload: "gold" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const fetchedUrls = fetchMock.mock.calls.map(([url]) => toUrlString(url));
+    expect(fetchedUrls.filter(url => url === "https://img.example/source.jpg")).toHaveLength(1);
+    expect(
+      fetchedUrls.some(url => url.startsWith(GENERATED_SOURCE_IMAGE_URL_PREFIX))
+    ).toBe(true);
+    expect(getState(anonymizePsid("stored-boundary-user"))?.lastPhotoSource).toBe(
+      "stored"
+    );
+  });
+
   it("handles /style Afroman and routes the next generation through afroman-americana", async () => {
     const sourceImage = Buffer.alloc(6000, 7);
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      if (toUrlString(url).startsWith("https://img.example/")) {
+      if (isSourceImageFetchUrl(url)) {
         return {
           ok: true,
           headers: new Headers({ "content-type": "image/jpeg" }),


### PR DESCRIPTION
 Deze PR trekt een echte trust boundary rond source images, in plaats van alleen de SSRF-sink cosmetisch anders te
  laten lijken.

  Voorheen:

  - Messenger ontving externe attachment-URLs
  - die ruwe externe URL werd in state bewaard
  - downstream generation/retry flows konden die later opnieuw gebruiken

  Na deze wijziging:

  - Messenger normalizeert externe image attachments meteen bij ingress
  - de image wordt eerst via de bestaande source-image fetch/validation flow opgehaald
  - daarna wordt ze in storage gezet
  - vanaf dat punt gebruiken interne flows alleen nog de stored asset-URL

  Wat is aangepast:

  - nieuwe helper in server/_core/sourceImageStore.ts
      - ingestExternalSourceImage(...)
  - nieuwe Messenger-specifieke seam in server/_core/messengerImageIngress.ts
      - normalizeMessengerInboundImage(...)
      - getStoredMessengerImageDecision(...)
  - server/_core/webhookHandlers.ts
      - Messenger image attachments worden nu eerst stored
      - feature hooks krijgen de stored URL
      - state bewaart alleen nog stored URLs voor deze ingress path
  - server/messengerWebhook.test.ts
      - mocks en assertions bijgewerkt voor de stored-URL route
      - regressietest toegevoegd die bewijst dat externe URLs niet downstream blijven doorlekken

  Waarom dit nuttig is:

  - dit is een echte architecturale verbetering, geen scanner-workaround
  - externe image references blijven beperkt tot ingress
  - downstream generation/retry gebruikt nu een trusted stored asset URL
  - het maakt de code ook beter voorbereid op toekomstige preview modules en extra channel adapters

  Impact / gedrag:

  - Messenger image ingress doet nu altijd een ingest-naar-storage stap vóór verdere verwerking
  - bij ingest failure blijft het gedrag veilig en begrijpelijk:
      - flow terug naar AWAITING_PHOTO
      - bestaande missingInputImage tekst naar de gebruiker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images received through Messenger are now normalized and stored before processing to ensure consistency.
  * Enhanced image decision logic automatically determines whether to show a style picker or run pre-selected styles based on prior state.

* **Bug Fixes**
  * Improved error handling for failed image ingestion with structured logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->