### PR TITLE
Harden source image SSRF follow-up

### DIFF
--- a/server/_core/image-generation/sourceImageFetcher.ts
+++ b/server/_core/image-generation/sourceImageFetcher.ts
@@ -1,9 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { lookup } from "node:dns/promises";
+import https from "node:https";
 import net from "node:net";
 import os from "node:os";
 import fs from "fs/promises";
 import path from "path";
+import { Readable } from "node:stream";
 import { safeLen, sha256 } from "../imageProof";
 
 export class MissingInputImageError extends Error {}
@@ -20,15 +22,26 @@ export type DownloadedSourceImage = SourceImageData & {
   fbImageFetchMs: number;
 };
 
-type SourceImageDownloadOptions = {
-  trustedSourceImageUrl?: boolean;
-  sourceImageProvenance?: "storeInbound";
-};
-
 type SourceImageFetchAttemptResult = {
   response: Response;
   contentType: string;
 };
+
+type PinnedSourceImageAddress = {
+  address: string;
+  family: 4 | 6;
+};
+
+type SourceImageDnsLookup = (
+  hostname: string,
+  options: { all: true; verbatim: true }
+) => Promise<PinnedSourceImageAddress[]>;
+
+type SourceImageHttpFetch = (
+  sourceImageUrl: string,
+  signal: AbortSignal,
+  pinnedAddress: PinnedSourceImageAddress
+) => Promise<Response>;
 
 type SourceImageResolveInput = {
   sourceImageUrl?: string;
@@ -41,7 +54,22 @@ type SourceImageResolveInput = {
 const MIN_INPUT_IMAGE_BYTES = 5 * 1024;
 const MAX_INBOUND_IMAGE_BYTES = 20 * 1024 * 1024;
 const FB_IMAGE_FETCH_RETRY_LIMIT = 1;
-let dnsLookup = lookup;
+let dnsLookup: SourceImageDnsLookup = lookup as SourceImageDnsLookup;
+let sourceImageHttpFetch: SourceImageHttpFetch = fetchPinnedHttpsSourceImage;
+const blockedIpRanges = new net.BlockList();
+
+blockedIpRanges.addSubnet("10.0.0.0", 8, "ipv4");
+blockedIpRanges.addSubnet("127.0.0.0", 8, "ipv4");
+blockedIpRanges.addSubnet("169.254.0.0", 16, "ipv4");
+blockedIpRanges.addSubnet("172.16.0.0", 12, "ipv4");
+blockedIpRanges.addSubnet("192.168.0.0", 16, "ipv4");
+blockedIpRanges.addAddress("::", "ipv6");
+blockedIpRanges.addAddress("::1", "ipv6");
+blockedIpRanges.addSubnet("fc00::", 7, "ipv6");
+blockedIpRanges.addSubnet("fe80::", 10, "ipv6");
+blockedIpRanges.addSubnet("ff00::", 8, "ipv6");
+blockedIpRanges.addSubnet("64:ff9b::", 96, "ipv6");
+blockedIpRanges.addSubnet("2001:db8::", 32, "ipv6");
 
 function getSourceUrlDiagnostics(sourceImageUrl: string): {
   hostname?: string;
@@ -89,45 +117,57 @@ function parseAllowedHostsFromEnv(): string[] {
 }
 
 function isPrivateIPv4(ip: string): boolean {
-  const parts = ip.split(".").map(x => Number(x));
-  if (
-    parts.length !== 4 ||
-    parts.some(n => !Number.isInteger(n) || n < 0 || n > 255)
-  ) {
+  if (net.isIP(ip) !== 4) {
     return true;
   }
 
-  const [a, b] = parts;
+  return blockedIpRanges.check(ip, "ipv4");
+}
 
-  if (a === 10) return true;
-  if (a === 127) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 168) return true;
+function extractIPv4MappedIPv6(ip: string): string | null {
+  const normalized = ip.toLowerCase();
+  const mappedPrefix = "::ffff:";
+  if (!normalized.startsWith(mappedPrefix)) {
+    return null;
+  }
 
-  return false;
+  const mapped = normalized.slice(mappedPrefix.length);
+  if (net.isIP(mapped) === 4) {
+    return mapped;
+  }
+
+  const parts = mapped.split(":");
+  if (parts.length !== 2) {
+    return null;
+  }
+
+  const [high, low] = parts.map(part => Number.parseInt(part, 16));
+  if (
+    !Number.isInteger(high) ||
+    !Number.isInteger(low) ||
+    high < 0 ||
+    high > 0xffff ||
+    low < 0 ||
+    low > 0xffff
+  ) {
+    return null;
+  }
+
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join(".");
 }
 
 function isBlockedIPv6(ip: string): boolean {
-  const normalized = ip.toLowerCase();
-
-  if (normalized === "::" || normalized === "::1") {
-    return true;
+  const mappedIPv4 = extractIPv4MappedIPv6(ip);
+  if (mappedIPv4) {
+    return isPrivateIPv4(mappedIPv4);
   }
 
-  if (normalized.startsWith("fc") || normalized.startsWith("fd")) {
-    return true;
-  }
-
-  if (normalized.startsWith("fe8") || normalized.startsWith("fe9")) {
-    return true;
-  }
-
-  if (normalized.startsWith("fea") || normalized.startsWith("feb")) {
-    return true;
-  }
-
-  return false;
+  return blockedIpRanges.check(ip, "ipv6");
 }
 
 function isBlockedIpAddress(ip: string): boolean {
@@ -208,8 +248,7 @@ function blockSourceImageUrl(
 
 function validateSourceImageUrlOrThrow(
   sourceImageUrl: string,
-  reqId?: string,
-  options?: SourceImageDownloadOptions
+  reqId?: string
 ): URL {
   let parsedUrl: URL;
 
@@ -273,7 +312,8 @@ function buildCanonicalSourceImageUrlString(sourceImageUrl: URL): string {
 
 async function fetchSourceImageAttempt(
   sourceImageUrl: string,
-  timeoutMs: number
+  timeoutMs: number,
+  pinnedAddress: PinnedSourceImageAddress
 ): Promise<SourceImageFetchAttemptResult> {
   const controller = new AbortController();
   const timeout = setTimeout(() => {
@@ -281,10 +321,11 @@ async function fetchSourceImageAttempt(
   }, timeoutMs);
   let response: Response;
   try {
-    response = await fetch(sourceImageUrl, {
-      redirect: "manual",
-      signal: controller.signal,
-    });
+    response = await sourceImageHttpFetch(
+      sourceImageUrl,
+      controller.signal,
+      pinnedAddress
+    );
   } finally {
     clearTimeout(timeout);
   }
@@ -296,17 +337,62 @@ async function fetchSourceImageAttempt(
   };
 }
 
+function buildResponseHeaders(rawHeaders: string[]): Headers {
+  const headers = new Headers();
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index];
+    const value = rawHeaders[index + 1];
+    if (name && value !== undefined) {
+      headers.append(name, value);
+    }
+  }
+  return headers;
+}
+
+async function fetchPinnedHttpsSourceImage(
+  sourceImageUrl: string,
+  signal: AbortSignal,
+  pinnedAddress: PinnedSourceImageAddress
+): Promise<Response> {
+  return new Promise<Response>((resolve, reject) => {
+    const request = https.request(
+      sourceImageUrl,
+      {
+        method: "GET",
+        signal,
+        lookup: (_hostname, _options, callback) => {
+          callback(null, pinnedAddress.address, pinnedAddress.family);
+        },
+      },
+      incoming => {
+        resolve(
+          new Response(Readable.toWeb(incoming) as ReadableStream, {
+            status: incoming.statusCode ?? 500,
+            headers: buildResponseHeaders(incoming.rawHeaders),
+          })
+        );
+      }
+    );
+
+    request.on("error", reject);
+    request.end();
+  });
+}
+
 async function assertHostnameResolvesToPublicIpOrThrow(
   sourceImageUrl: URL,
   reqId: string
-): Promise<void> {
+): Promise<PinnedSourceImageAddress> {
   const hostname = sourceImageUrl.hostname.toLowerCase();
 
   if (net.isIP(hostname)) {
-    return;
+    return {
+      address: hostname,
+      family: net.isIP(hostname) as 4 | 6,
+    };
   }
 
-  let addresses: Awaited<ReturnType<typeof lookup>>;
+  let addresses: PinnedSourceImageAddress[];
   try {
     addresses = await dnsLookup(hostname, { all: true, verbatim: true });
   } catch {
@@ -331,12 +417,24 @@ async function assertHostnameResolvesToPublicIpOrThrow(
       family: blockedAddress.family,
     });
   }
+
+  const pinnedAddress = addresses[0];
+  return {
+    address: pinnedAddress.address,
+    family: pinnedAddress.family as 4 | 6,
+  };
 }
 
 export function setSourceImageDnsLookupForTests(
-  override: typeof lookup | null
+  override: SourceImageDnsLookup | null
 ): void {
-  dnsLookup = override ?? lookup;
+  dnsLookup = override ?? (lookup as SourceImageDnsLookup);
+}
+
+export function setSourceImageHttpFetchForTests(
+  override: SourceImageHttpFetch | null
+): void {
+  sourceImageHttpFetch = override ?? fetchPinnedHttpsSourceImage;
 }
 
 function assertNoRedirectResponse(response: Response, reqId: string): void {
@@ -566,13 +664,11 @@ function rethrowSourceImageError(error: unknown, reqId: string): never {
 
 async function downloadSourceImageOrThrow(
   sourceImageUrl: string,
-  reqId: string,
-  options?: SourceImageDownloadOptions
+  reqId: string
 ): Promise<DownloadedSourceImage> {
   const validatedSourceImageUrl = validateSourceImageUrlOrThrow(
     sourceImageUrl,
-    reqId,
-    options
+    reqId
   );
   const canonicalSourceImageUrl = buildCanonicalSourceImageUrlString(
     validatedSourceImageUrl
@@ -585,10 +681,14 @@ async function downloadSourceImageOrThrow(
     const attemptStartedAt = Date.now();
 
     try {
-      await assertHostnameResolvesToPublicIpOrThrow(validatedSourceImageUrl, reqId);
+      const pinnedAddress = await assertHostnameResolvesToPublicIpOrThrow(
+        validatedSourceImageUrl,
+        reqId
+      );
       const { response, contentType } = await fetchSourceImageAttempt(
         canonicalSourceImageUrl,
-        timeoutMs
+        timeoutMs,
+        pinnedAddress
       );
       assertNoRedirectResponse(response, reqId);
 
@@ -675,8 +775,5 @@ export async function resolveStoredSourceImage(
     );
   }
 
-  return downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId, {
-    trustedSourceImageUrl: input.trustedSourceImageUrl,
-    sourceImageProvenance: input.sourceImageProvenance,
-  });
+  return downloadSourceImageOrThrow(input.sourceImageUrl, input.reqId);
 }

--- a/server/_core/messengerImageIngress.ts
+++ b/server/_core/messengerImageIngress.ts
@@ -9,6 +9,14 @@ type NormalizeMessengerInboundImageInput = {
   reqId: string;
 };
 
+function getSafeHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function normalizeMessengerInboundImage(
   input: NormalizeMessengerInboundImageInput
 ): Promise<string | null> {
@@ -22,7 +30,7 @@ export async function normalizeMessengerInboundImage(
     safeLog("messenger_inbound_image_ingest_failed", {
       psidHash: input.psidHash,
       reqId: input.reqId,
-      inboundImageUrl: input.inboundImageUrl,
+      inboundImageHost: getSafeHostname(input.inboundImageUrl),
       errorCode:
         error instanceof Error ? error.constructor.name : String(error),
     });

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -4,7 +4,10 @@ import {
   OpenAiImageGenerator,
 } from "./_core/imageService";
 import { sha256 } from "./_core/imageProof";
-import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import {
+  setSourceImageDnsLookupForTests,
+  setSourceImageHttpFetchForTests,
+} from "./_core/image-generation/sourceImageFetcher";
 
 const GENERATED_IMAGE_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
@@ -172,12 +175,16 @@ describe("OpenAi image-to-image proof", () => {
     setSourceImageDnsLookupForTests(async () => [
       { address: "93.184.216.34", family: 4 },
     ]);
+    setSourceImageHttpFetchForTests((sourceImageUrl, signal) =>
+      fetch(sourceImageUrl, { redirect: "manual", signal })
+    );
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     setSourceImageDnsLookupForTests(null);
+    setSourceImageHttpFetchForTests(null);
     delete process.env.NODE_ENV;
     delete process.env.OPENAI_API_KEY;
     delete process.env.APP_BASE_URL;
@@ -615,6 +622,31 @@ describe("OpenAi image-to-image proof", () => {
         sourceImageUrl: "https://img.example/source.jpg",
         userKey: "user-1",
         reqId: "req-private-dns-resolution",
+      })
+    ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects allowlisted hosts that resolve to IPv4-mapped loopback before fetch", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "img.example";
+
+    setSourceImageDnsLookupForTests(async () => [
+      { address: "::ffff:7f00:1", family: 6 },
+    ]);
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await expect(
+      generator.generate({
+        style: "disco",
+        sourceImageUrl: "https://img.example/source.jpg",
+        userKey: "user-1",
+        reqId: "req-ipv4-mapped-loopback",
       })
     ).rejects.toBeInstanceOf(InvalidSourceImageUrlError);
 

--- a/server/imageService.storage.test.ts
+++ b/server/imageService.storage.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import {
+  setSourceImageDnsLookupForTests,
+  setSourceImageHttpFetchForTests,
+} from "./_core/image-generation/sourceImageFetcher";
 
 const GENERATED_IMAGE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0ioAAAAASUVORK5CYII=";
 const STORED_SOURCE_IMAGE_URL =
@@ -14,12 +17,16 @@ describe("OpenAi image delivery via object storage", () => {
     setSourceImageDnsLookupForTests(async () => [
       { address: "93.184.216.34", family: 4 },
     ]);
+    setSourceImageHttpFetchForTests((sourceImageUrl, signal) =>
+      fetch(sourceImageUrl, { redirect: "manual", signal })
+    );
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.resetModules();
     setSourceImageDnsLookupForTests(null);
+    setSourceImageHttpFetchForTests(null);
     delete process.env.NODE_ENV;
     delete process.env.OPENAI_API_KEY;
     delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -27,7 +27,10 @@ vi.mock("./_core/messengerApi", () => ({
 
 import { processFacebookWebhookPayload, resetMessengerEventDedupe } from "./_core/messengerWebhook";
 import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
-import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import {
+  setSourceImageDnsLookupForTests,
+  setSourceImageHttpFetchForTests,
+} from "./_core/image-generation/sourceImageFetcher";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
@@ -41,6 +44,9 @@ describe("photo-first onboarding", () => {
     setSourceImageDnsLookupForTests(async () => [
       { address: "93.184.216.34", family: 4 },
     ]);
+    setSourceImageHttpFetchForTests((sourceImageUrl, signal) =>
+      fetch(sourceImageUrl, { redirect: "manual", signal })
+    );
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS =
       "img.example,fbsbx.com,leaderbot-fb-image-gen.fly.dev";
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
@@ -75,6 +81,7 @@ describe("photo-first onboarding", () => {
 
   afterEach(() => {
     setSourceImageDnsLookupForTests(null);
+    setSourceImageHttpFetchForTests(null);
     vi.unstubAllGlobals();
   });
 

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -59,7 +59,10 @@ import {
   getEventDedupeKey,
 } from "./_core/webhookHelpers";
 import { getBotFeatures } from "./_core/bot/features";
-import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import {
+  setSourceImageDnsLookupForTests,
+  setSourceImageHttpFetchForTests,
+} from "./_core/image-generation/sourceImageFetcher";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
@@ -149,6 +152,7 @@ afterAll(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   setSourceImageDnsLookupForTests(null);
+  setSourceImageHttpFetchForTests(null);
   delete process.env.OPENAI_API_KEY;
   delete process.env.APP_BASE_URL;
   delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
@@ -158,6 +162,9 @@ beforeEach(() => {
   setSourceImageDnsLookupForTests(async () => [
     { address: "93.184.216.34", family: 4 },
   ]);
+  setSourceImageHttpFetchForTests((sourceImageUrl, signal) =>
+    fetch(sourceImageUrl, { redirect: "manual", signal })
+  );
   delete process.env.MESSENGER_CHAT_ENGINE;
   delete process.env.MESSENGER_CHAT_CANARY_PERCENT;
 

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -27,6 +27,10 @@ import {
   OpenAiImageGenerator,
 } from "./_core/imageService";
 import {
+  setSourceImageDnsLookupForTests,
+  setSourceImageHttpFetchForTests,
+} from "./_core/image-generation/sourceImageFetcher";
+import {
   processWhatsAppWebhookPayload,
   resetMessengerEventDedupe,
 } from "./_core/messengerWebhook";
@@ -94,10 +98,18 @@ afterAll(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  setSourceImageDnsLookupForTests(null);
+  setSourceImageHttpFetchForTests(null);
 });
 
 describe("whatsapp webhook flow", () => {
   beforeEach(() => {
+    setSourceImageDnsLookupForTests(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]);
+    setSourceImageHttpFetchForTests((sourceImageUrl, signal) =>
+      fetch(sourceImageUrl, { redirect: "manual", signal })
+    );
     process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = "leaderbot-fb-image-gen.fly.dev";
     process.env.OPENAI_API_KEY = "dummy-key";


### PR DESCRIPTION
Follow-up for merged PR #297 and CodeQL alert #21.\n\nChanges:\n- Pin source-image downloads to the DNS address validated during preflight.\n- Replace naive IPv6 string checks with BlockList-backed CIDR checks and IPv4-mapped IPv6 handling.\n- Avoid logging full inbound image URLs on Messenger ingest failures.\n- Keep test fixtures explicit via DNS/HTTP source-image hooks.\n\nValidation:\n- pnpm -s tsc --noEmit\n- vitest run server (49 files, 311 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Enhanced source image fetching with HTTPS-only requirements and DNS address pinning.
  * Improved private address filtering, including IPv4-mapped IPv6 address handling.

* **Tests**
  * Added test infrastructure for HTTP and DNS resolution mocking during image generation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->