### PR TITLE
refactor: simplify messenger webhook event routing

### DIFF
--- a/server/_core/messengerExperienceRouting.ts
+++ b/server/_core/messengerExperienceRouting.ts
@@ -1,0 +1,174 @@
+import type { ActiveExperience } from "./activeExperience";
+import type { BotResponse } from "./botResponse";
+import { sendMessengerBotResponse } from "./botResponseAdapters";
+import type { EntryIntent } from "./entryIntent";
+import { parseGameEntryIntent } from "./entryIntent";
+import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
+import type { Lang } from "./i18n";
+import type {
+  ConversationState,
+  MessengerUserState,
+} from "./messengerState";
+import { toLogUser } from "./privacy";
+import type { FacebookWebhookEvent } from "./webhookHelpers";
+
+type RouteResult = {
+  handled: boolean;
+  response?: BotResponse | null;
+  afterSend?: (() => Promise<BotResponse | null>) | undefined;
+};
+
+type ResponseSenderDeps = {
+  userId: string;
+  sendText: (text: string) => Promise<void>;
+  sendStateText: (state: ConversationState, text: string) => Promise<void>;
+  sendOptionsPrompt: (
+    prompt: string,
+    options: Array<{ id: string; title: string }>,
+    fallbackLogName: string | undefined,
+    fallbackText: string | undefined
+  ) => Promise<void>;
+  sendImage: (imageUrl: string) => Promise<void>;
+  safeLog: (event: string, payload: Record<string, unknown>) => void;
+};
+
+type RouteDeps = ResponseSenderDeps & {
+  psid: string;
+  reqId: string;
+  setLastEntryIntent: (entryIntent: EntryIntent | null) => Promise<void>;
+  setActiveExperience: (
+    activeExperience: ActiveExperience | null
+  ) => Promise<void>;
+};
+
+function createMessengerResponseOptions(
+  deps: ResponseSenderDeps,
+  optionsFallbackLogName?: string
+): Parameters<typeof sendMessengerBotResponse>[1] {
+  return {
+    sendText: deps.sendText,
+    sendStateText: deps.sendStateText,
+    sendOptionsPrompt: async (prompt, options, fallbackText) => {
+      await deps.sendOptionsPrompt(
+        prompt,
+        options,
+        optionsFallbackLogName,
+        fallbackText
+      );
+
+      if (fallbackText && optionsFallbackLogName) {
+        deps.safeLog(optionsFallbackLogName, {
+          user: toLogUser(deps.userId),
+          fallbackText,
+        });
+      }
+    },
+    sendImage: async (imageUrl, caption) => {
+      if (caption) {
+        await deps.sendText(caption);
+      }
+
+      await deps.sendImage(imageUrl);
+    },
+  };
+}
+
+async function sendRouteResponse(
+  route: RouteResult,
+  deps: ResponseSenderDeps,
+  optionsFallbackLogName?: string
+): Promise<void> {
+  const options = createMessengerResponseOptions(deps, optionsFallbackLogName);
+  await sendMessengerBotResponse(route.response ?? null, options);
+  if (route.afterSend) {
+    await sendMessengerBotResponse(await route.afterSend(), options);
+  }
+}
+
+export function parseMessengerEntryIntent(input: {
+  event: FacebookWebhookEvent;
+  reqId: string;
+  userId: string;
+  localeLang: Lang;
+  safeLog: (event: string, payload: Record<string, unknown>) => void;
+}): {
+  referralRef: string | undefined;
+  entryIntent: EntryIntent | null;
+} {
+  const referralRef =
+    input.event.postback?.referral?.ref ?? input.event.referral?.ref;
+  const entryIntent = parseGameEntryIntent({
+    channel: "messenger",
+    ref: referralRef,
+    sourceType: input.event.postback?.payload ? "postback" : "referral",
+    localeHint: input.localeLang,
+    receivedAt: input.event.timestamp ?? Date.now(),
+  });
+
+  input.safeLog("entry_intent_parsed", {
+    reqId: input.reqId,
+    user: toLogUser(input.userId),
+    referralRef: referralRef ?? null,
+    entryIntent: entryIntent
+      ? {
+          targetExperienceType: entryIntent.targetExperienceType,
+          targetExperienceId: entryIntent.targetExperienceId,
+          sourceType: entryIntent.sourceType,
+          entryMode: entryIntent.entryMode ?? null,
+        }
+      : null,
+  });
+
+  return { referralRef, entryIntent };
+}
+
+export async function routeMessengerEntryIntent(input: {
+  deps: RouteDeps;
+  state: MessengerUserState;
+  entryIntent: EntryIntent | null;
+}): Promise<boolean> {
+  const entryIntentRoute = await routeEntryIntent({
+    state: input.state,
+    entryIntent: input.entryIntent,
+    setLastEntryIntent: input.deps.setLastEntryIntent,
+    setActiveExperience: input.deps.setActiveExperience,
+  });
+  if (!entryIntentRoute.handled) {
+    return false;
+  }
+
+  await sendRouteResponse(
+    entryIntentRoute,
+    input.deps,
+    "entry_intent_options_fallback_available"
+  );
+  return true;
+}
+
+export async function routeMessengerActiveExperience(input: {
+  deps: RouteDeps;
+  state: MessengerUserState;
+  event: FacebookWebhookEvent;
+}): Promise<boolean> {
+  const action =
+    input.event.postback?.payload ??
+    input.event.message?.quick_reply?.payload ??
+    input.event.message?.text?.trim() ??
+    null;
+  const activeExperienceRoute = await routeActiveExperience({
+    state: input.state,
+    action,
+    setLastEntryIntent: input.deps.setLastEntryIntent,
+    setActiveExperience: input.deps.setActiveExperience,
+  });
+  if (!activeExperienceRoute.handled) {
+    return false;
+  }
+
+  await sendRouteResponse(
+    activeExperienceRoute,
+    input.deps,
+    "active_experience_options_fallback_available"
+  );
+  return true;
+}

--- a/server/_core/messengerPayloadRouting.ts
+++ b/server/_core/messengerPayloadRouting.ts
@@ -1,0 +1,193 @@
+import type { BotPayloadContext } from "./botContext";
+import type { Lang } from "./i18n";
+import type { MessengerUserState } from "./messengerState";
+import type { Style, StyleCategory } from "./messengerStyles";
+import {
+  normalizeStyle,
+  parseStyle,
+  styleCategoryPayloadToCategory,
+  stylePayloadToStyle,
+} from "./webhookHelpers";
+
+type PayloadFeature = {
+  onPayload?: (
+    context: BotPayloadContext
+  ) => Promise<{ handled?: boolean } | void> | { handled?: boolean } | void;
+};
+
+type MessengerPayloadRoutingInput = {
+  psid: string;
+  userId: string;
+  payload: string;
+  reqId: string;
+  lang: Lang;
+  maybeSendInFlightMessage: (psid: string, reqId: string) => Promise<boolean>;
+  getState: (psid: string) => Promise<MessengerUserState>;
+  getFeatures: () => readonly PayloadFeature[];
+  createFeaturePayloadContext: (
+    psid: string,
+    userId: string,
+    reqId: string,
+    lang: Lang,
+    state: MessengerUserState,
+    payload: string
+  ) => BotPayloadContext;
+  runStyleGeneration: (
+    psid: string,
+    userId: string,
+    style: Style,
+    reqId: string,
+    lang: Lang
+  ) => Promise<void>;
+  handleStyleSelection: (
+    psid: string,
+    userId: string,
+    style: Style,
+    reqId: string,
+    lang: Lang
+  ) => Promise<void>;
+  showStylePicker: (psid: string, lang: Lang, reqId: string) => Promise<void>;
+  showStyleCategory: (
+    psid: string,
+    category: StyleCategory,
+    lang: Lang,
+    reqId: string
+  ) => Promise<void>;
+  sendFlowExplanation: (
+    psid: string,
+    lang: Lang,
+    reqId: string
+  ) => Promise<void>;
+  sendPrivacyInfo: (psid: string, lang: Lang, reqId: string) => Promise<void>;
+  sendUnknownPayloadLog: (userId: string) => void;
+};
+
+async function tryHandleFeaturePayload(
+  input: MessengerPayloadRoutingInput,
+  state: MessengerUserState
+): Promise<boolean> {
+  for (const feature of input.getFeatures()) {
+    const result = await feature.onPayload?.(
+      input.createFeaturePayloadContext(
+        input.psid,
+        input.userId,
+        input.reqId,
+        input.lang,
+        state,
+        input.payload
+      )
+    );
+    if (result?.handled) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function tryHandleRetryPayload(
+  input: MessengerPayloadRoutingInput
+): Promise<boolean> {
+  if (input.payload.startsWith("RETRY_STYLE_")) {
+    const retryStyle = normalizeStyle(
+      input.payload.slice("RETRY_STYLE_".length)
+    );
+    if (retryStyle) {
+      await input.runStyleGeneration(
+        input.psid,
+        input.userId,
+        retryStyle,
+        input.reqId,
+        input.lang
+      );
+      return true;
+    }
+  }
+
+  if (input.payload !== "RETRY_STYLE") {
+    return false;
+  }
+
+  const chosenStyle = (await input.getState(input.psid)).selectedStyle;
+  const retryStyle = chosenStyle ? parseStyle(chosenStyle) : undefined;
+  if (retryStyle) {
+    await input.handleStyleSelection(
+      input.psid,
+      input.userId,
+      retryStyle,
+      input.reqId,
+      input.lang
+    );
+    return true;
+  }
+
+  await input.showStylePicker(input.psid, input.lang, input.reqId);
+  return true;
+}
+
+async function tryHandleStylePayload(
+  input: MessengerPayloadRoutingInput
+): Promise<boolean> {
+  const selectedStyle = stylePayloadToStyle(input.payload);
+  if (selectedStyle) {
+    await input.handleStyleSelection(
+      input.psid,
+      input.userId,
+      selectedStyle,
+      input.reqId,
+      input.lang
+    );
+    return true;
+  }
+
+  const selectedCategory = styleCategoryPayloadToCategory(input.payload);
+  if (!selectedCategory) {
+    return false;
+  }
+
+  await input.showStyleCategory(
+    input.psid,
+    selectedCategory,
+    input.lang,
+    input.reqId
+  );
+  return true;
+}
+
+async function tryHandleUtilityPayload(
+  input: MessengerPayloadRoutingInput
+): Promise<boolean> {
+  switch (input.payload) {
+    case "CHOOSE_STYLE":
+      await input.showStylePicker(input.psid, input.lang, input.reqId);
+      return true;
+    case "WHAT_IS_THIS":
+      await input.sendFlowExplanation(input.psid, input.lang, input.reqId);
+      return true;
+    case "PRIVACY_INFO":
+      await input.sendPrivacyInfo(input.psid, input.lang, input.reqId);
+      return true;
+    default:
+      return false;
+  }
+}
+
+export async function handleMessengerPayload(
+  input: MessengerPayloadRoutingInput
+): Promise<void> {
+  if (await input.maybeSendInFlightMessage(input.psid, input.reqId)) {
+    return;
+  }
+
+  const state = await input.getState(input.psid);
+  if (
+    (await tryHandleFeaturePayload(input, state)) ||
+    (await tryHandleRetryPayload(input)) ||
+    (await tryHandleStylePayload(input)) ||
+    (await tryHandleUtilityPayload(input))
+  ) {
+    return;
+  }
+
+  input.sendUnknownPayloadLog(input.userId);
+}

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -87,6 +87,10 @@ type HandlerDeps = {
 };
 
 type FacebookWebhookMessage = NonNullable<FacebookWebhookEvent["message"]>;
+type FeatureContextBase = Omit<
+  BotPayloadContext,
+  "payload"
+>;
 
 const IN_FLIGHT_MESSAGE =
   "\u23F3 even geduld, ik ben nog bezig met jouw restyle";
@@ -358,14 +362,13 @@ export function createWebhookHandlers({
     };
   }
 
-  function createFeaturePayloadContext(
+  function createFeatureContextBase(
     psid: string,
     userId: string,
     reqId: string,
     lang: Lang,
-    state: Awaited<ReturnType<typeof getOrCreateState>>,
-    payload: string
-  ): BotPayloadContext {
+    state: Awaited<ReturnType<typeof getOrCreateState>>
+  ): FeatureContextBase {
     return {
       channel: "messenger",
       capabilities: MESSENGER_CAPABILITIES,
@@ -374,7 +377,6 @@ export function createWebhookHandlers({
       reqId,
       lang,
       state,
-      payload,
       sendText: text => sendLoggedText(psid, text, reqId),
       sendImage: imageUrl => sendLoggedImage(psid, imageUrl, reqId),
       sendQuickReplies: (text, replies) =>
@@ -404,6 +406,20 @@ export function createWebhookHandlers({
     };
   }
 
+  function createFeaturePayloadContext(
+    psid: string,
+    userId: string,
+    reqId: string,
+    lang: Lang,
+    state: Awaited<ReturnType<typeof getOrCreateState>>,
+    payload: string
+  ): BotPayloadContext {
+    return {
+      ...createFeatureContextBase(psid, userId, reqId, lang, state),
+      payload,
+    };
+  }
+
   function createFeatureImageContext(
     psid: string,
     userId: string,
@@ -413,40 +429,8 @@ export function createWebhookHandlers({
     imageUrl: string
   ): BotImageContext {
     return {
-      channel: "messenger",
-      capabilities: MESSENGER_CAPABILITIES,
-      senderId: psid,
-      userId,
-      reqId,
-      lang,
-      state,
+      ...createFeatureContextBase(psid, userId, reqId, lang, state),
       imageUrl,
-      sendText: text => sendLoggedText(psid, text, reqId),
-      sendImage: nextImageUrl => sendLoggedImage(psid, nextImageUrl, reqId),
-      sendQuickReplies: (text, replies) =>
-        sendLoggedQuickReplies(psid, text, replies, reqId),
-      sendStateQuickReplies: (nextState, text) =>
-        sendStateQuickReplies(psid, nextState, text, reqId),
-      setFlowState: async nextState => {
-        await setFlowState(psid, nextState);
-      },
-      preselectStyle: async style => {
-        await setPreselectedStyle(psid, style);
-      },
-      chooseStyle: style =>
-        handleStyleSelection(psid, userId, style, reqId, lang),
-      runStyleGeneration: (style, sourceImageUrl, promptHint) =>
-        runStyleGeneration(
-          psid,
-          userId,
-          style,
-          reqId,
-          lang,
-          sourceImageUrl,
-          promptHint
-        ),
-      getRuntimeStats: () => getTodayRuntimeStats(),
-      logger: createFeatureLogger(userId),
     };
   }
 
@@ -461,42 +445,10 @@ export function createWebhookHandlers({
     hasPhoto: boolean
   ): BotTextContext {
     return {
-      channel: "messenger",
-      capabilities: MESSENGER_CAPABILITIES,
-      senderId: psid,
-      userId,
-      reqId,
-      lang,
-      state,
+      ...createFeatureContextBase(psid, userId, reqId, lang, state),
       messageText,
       normalizedText,
       hasPhoto,
-      sendText: text => sendLoggedText(psid, text, reqId),
-      sendImage: imageUrl => sendLoggedImage(psid, imageUrl, reqId),
-      sendQuickReplies: (text, replies) =>
-        sendLoggedQuickReplies(psid, text, replies, reqId),
-      sendStateQuickReplies: (nextState, text) =>
-        sendStateQuickReplies(psid, nextState, text, reqId),
-      setFlowState: async nextState => {
-        await setFlowState(psid, nextState);
-      },
-      preselectStyle: async style => {
-        await setPreselectedStyle(psid, style);
-      },
-      chooseStyle: style =>
-        handleStyleSelection(psid, userId, style, reqId, lang),
-      runStyleGeneration: (style, sourceImageUrl, promptHint) =>
-        runStyleGeneration(
-          psid,
-          userId,
-          style,
-          reqId,
-          lang,
-          sourceImageUrl,
-          promptHint
-        ),
-      getRuntimeStats: () => getTodayRuntimeStats(),
-      logger: createFeatureLogger(userId),
     };
   }
 

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -1150,20 +1150,22 @@ export function createWebhookHandlers({
     if (!psid) return;
 
     const userId = toUserKey(psid);
-    recordActiveUserToday(userId);
     const reqId = `${psid}-${Date.now()}`;
-    const localeLang = normalizeLang(event.sender?.locale);
+
+    if (!(await claimEventReplayOrLog(event, entryId, userId))) {
+      return;
+    }
+
+    recordActiveUserToday(userId);
+    const senderLocale = event.sender?.locale?.trim();
+    const localeLang = senderLocale ? normalizeLang(senderLocale) : defaultLang;
     const state = await getOrCreateState(psid);
     logIncomingMessage(psid, userId, event, reqId);
     logUserState(psid, userId, state, reqId, "handle_event");
     const lang = state.preferredLang || localeLang || defaultLang;
 
-    if (localeLang && localeLang !== state.preferredLang) {
+    if (senderLocale && localeLang !== state.preferredLang) {
       await setPreferredLang(psid, localeLang);
-    }
-
-    if (!(await claimEventReplayOrLog(event, entryId, userId))) {
-      return;
     }
 
     const routeDeps = {

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -46,13 +46,9 @@ import {
   FacebookWebhookEvent,
   getEventDedupeKey,
   getGreetingResponse,
-  normalizeStyle,
   parseReferralStyle,
-  parseStyle,
   STYLE_CATEGORY_LABELS,
   STYLE_LABELS,
-  styleCategoryPayloadToCategory,
-  stylePayloadToStyle,
   toMessengerReplies,
   toMessengerStyleReplies,
 } from "./webhookHelpers";
@@ -69,6 +65,7 @@ import {
   routeMessengerActiveExperience,
   routeMessengerEntryIntent,
 } from "./messengerExperienceRouting";
+import { handleMessengerPayload } from "./messengerPayloadRouting";
 import type { EntryIntent } from "./entryIntent";
 import type { ActiveExperience } from "./activeExperience";
 import {
@@ -836,6 +833,33 @@ export function createWebhookHandlers({
     await runStyleGeneration(psid, userId, selectedStyle, reqId, lang);
   }
 
+  async function sendPrivacyInfo(
+    psid: string,
+    lang: Lang,
+    reqId: string
+  ): Promise<void> {
+    const resolvedPrivacyUrl = resolvePrivacyPolicyUrl();
+    const privacyText = t(lang, "privacy", { link: resolvedPrivacyUrl });
+
+    if (!resolvedPrivacyUrl) {
+      await sendLoggedText(psid, privacyText, reqId);
+      return;
+    }
+
+    await sendLoggedButtonTemplate(
+      psid,
+      privacyText,
+      [
+        {
+          type: "web_url",
+          title: t(lang, "privacyButtonLabel"),
+          url: resolvedPrivacyUrl,
+        },
+      ],
+      reqId
+    );
+  }
+
   async function handlePayload(
     psid: string,
     userId: string,
@@ -843,94 +867,41 @@ export function createWebhookHandlers({
     reqId: string,
     lang: Lang
   ): Promise<void> {
-    if (await maybeSendInFlightMessage(psid, reqId)) {
-      return;
-    }
-
-    const state = await getOrCreateState(psid);
-    for (const feature of getBotFeatures()) {
-      const result = await feature.onPayload?.(
-        createFeaturePayloadContext(psid, userId, reqId, lang, state, payload)
-      );
-      if (result?.handled) {
-        return;
-      }
-    }
-
-    if (payload.startsWith("RETRY_STYLE_")) {
-      const retryStyle = normalizeStyle(payload.slice("RETRY_STYLE_".length));
-      if (retryStyle) {
-        await runStyleGeneration(psid, userId, retryStyle, reqId, lang);
-        return;
-      }
-    }
-
-    const selectedStyle = stylePayloadToStyle(payload);
-    if (selectedStyle) {
-      await handleStyleSelection(psid, userId, selectedStyle, reqId, lang);
-      return;
-    }
-
-    const selectedCategory = styleCategoryPayloadToCategory(payload);
-    if (selectedCategory) {
-      await setSelectedStyleCategory(psid, selectedCategory);
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendStyleOptionsForCategory(psid, selectedCategory, lang, reqId);
-      return;
-    }
-
-    if (payload === "CHOOSE_STYLE") {
-      await setPreselectedStyle(psid, null);
-      await setSelectedStyleCategory(psid, null);
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendStylePicker(psid, lang, reqId);
-      return;
-    }
-
-    if (payload === "RETRY_STYLE") {
-      const chosenStyle = (await getOrCreateState(psid)).selectedStyle;
-      const retryStyle = chosenStyle ? parseStyle(chosenStyle) : undefined;
-
-      if (retryStyle) {
-        await handleStyleSelection(psid, userId, retryStyle, reqId, lang);
-        return;
-      }
-
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendStylePicker(psid, lang, reqId);
-      return;
-    }
-
-    if (payload === "WHAT_IS_THIS") {
-      await sendLoggedText(psid, t(lang, "flowExplanation"), reqId);
-      return;
-    }
-
-    if (payload === "PRIVACY_INFO") {
-      const resolvedPrivacyUrl = resolvePrivacyPolicyUrl();
-      const privacyText = t(lang, "privacy", { link: resolvedPrivacyUrl });
-
-      if (resolvedPrivacyUrl) {
-        await sendLoggedButtonTemplate(
-          psid,
-          privacyText,
-          [
-            {
-              type: "web_url",
-              title: t(lang, "privacyButtonLabel"),
-              url: resolvedPrivacyUrl,
-            },
-          ],
-          reqId
+    await handleMessengerPayload({
+      psid,
+      userId,
+      payload,
+      reqId,
+      lang,
+      maybeSendInFlightMessage,
+      getState: userPsid => Promise.resolve(getOrCreateState(userPsid)),
+      getFeatures: getBotFeatures,
+      createFeaturePayloadContext,
+      runStyleGeneration,
+      handleStyleSelection,
+      showStylePicker: async (userPsid, userLang, requestId) => {
+        await setPreselectedStyle(userPsid, null);
+        await setSelectedStyleCategory(userPsid, null);
+        await setFlowState(userPsid, "AWAITING_STYLE");
+        await sendStylePicker(userPsid, userLang, requestId);
+      },
+      showStyleCategory: async (userPsid, category, userLang, requestId) => {
+        await setSelectedStyleCategory(userPsid, category);
+        await setFlowState(userPsid, "AWAITING_STYLE");
+        await sendStyleOptionsForCategory(
+          userPsid,
+          category,
+          userLang,
+          requestId
         );
-        return;
-      }
-
-      await sendLoggedText(psid, privacyText, reqId);
-      return;
-    }
-
-    safeLog("unknown_payload", { user: toLogUser(userId) });
+      },
+      sendFlowExplanation: (userPsid, userLang, requestId) =>
+        sendLoggedText(userPsid, t(userLang, "flowExplanation"), requestId),
+      sendPrivacyInfo,
+      sendUnknownPayloadLog: unknownUserId => {
+        safeLog("unknown_payload", { user: toLogUser(unknownUserId) });
+      },
+    });
   }
 
   async function handleMessage(

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -27,11 +27,8 @@ import {
   markIntroSeen,
   anonymizePsid,
   type ConversationState,
-  type MessengerUserState,
 } from "./messengerState";
 import { normalizeLang, t, type Lang } from "./i18n";
-import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
-import { parseGameEntryIntent } from "./entryIntent";
 import { toLogUser, toUserKey } from "./privacy";
 import {
   getStoredMessengerImageDecision,
@@ -68,6 +65,13 @@ import { handleSharedTextMessage } from "./sharedTextHandler";
 import type { NormalizedInboundMessage } from "./normalizedInboundMessage";
 import { sendMessengerBotResponse } from "./botResponseAdapters";
 import {
+  parseMessengerEntryIntent,
+  routeMessengerActiveExperience,
+  routeMessengerEntryIntent,
+} from "./messengerExperienceRouting";
+import type { EntryIntent } from "./entryIntent";
+import type { ActiveExperience } from "./activeExperience";
+import {
   getTodayRuntimeStats,
   recordActiveUserToday,
   recordGenerationError,
@@ -79,11 +83,6 @@ import type {
   BotTextContext,
   BotImageContext,
 } from "./botContext";
-
-type MessengerBotResponseOptions = Parameters<
-  typeof sendMessengerBotResponse
->[1];
-type MessengerRouteResult = Awaited<ReturnType<typeof routeEntryIntent>>;
 
 type HandlerDeps = {
   defaultLang: Lang;
@@ -1132,156 +1131,6 @@ export function createWebhookHandlers({
     }
   }
 
-  function createMessengerResponseOptions(
-    psid: string,
-    userId: string,
-    reqId: string,
-    optionsFallbackLogName?: string
-  ): MessengerBotResponseOptions {
-    return {
-      sendText: text => sendLoggedText(psid, text, reqId),
-      sendStateText: (stateName, text) =>
-        sendStateQuickReplies(psid, stateName, text, reqId),
-      sendOptionsPrompt: async (prompt, options, fallbackText) => {
-        await sendLoggedQuickReplies(
-          psid,
-          prompt,
-          options.map(option => ({
-            content_type: "text",
-            title: option.title,
-            payload: option.id,
-          })),
-          reqId
-        );
-
-        if (fallbackText && optionsFallbackLogName) {
-          safeLog(optionsFallbackLogName, {
-            user: toLogUser(userId),
-            fallbackText,
-          });
-        }
-      },
-      sendImage: (imageUrl, caption) => {
-        if (caption) {
-          return sendLoggedText(psid, caption, reqId).then(() =>
-            sendLoggedImage(psid, imageUrl, reqId)
-          );
-        }
-
-        return sendLoggedImage(psid, imageUrl, reqId);
-      },
-    };
-  }
-
-  async function sendRouteResponse(
-    route: MessengerRouteResult,
-    options: MessengerBotResponseOptions
-  ): Promise<void> {
-    await sendMessengerBotResponse(route.response ?? null, options);
-    if (route.afterSend) {
-      await sendMessengerBotResponse(await route.afterSend(), options);
-    }
-  }
-
-  function parseEventEntryIntent(
-    event: FacebookWebhookEvent,
-    reqId: string,
-    userId: string,
-    localeLang: Lang
-  ) {
-    const referralRef = event.postback?.referral?.ref ?? event.referral?.ref;
-    const entryIntent = parseGameEntryIntent({
-      channel: "messenger",
-      ref: referralRef,
-      sourceType: event.postback?.payload ? "postback" : "referral",
-      localeHint: localeLang,
-      receivedAt: event.timestamp ?? Date.now(),
-    });
-
-    safeLog("entry_intent_parsed", {
-      reqId,
-      user: toLogUser(userId),
-      referralRef: referralRef ?? null,
-      entryIntent: entryIntent
-        ? {
-            targetExperienceType: entryIntent.targetExperienceType,
-            targetExperienceId: entryIntent.targetExperienceId,
-            sourceType: entryIntent.sourceType,
-            entryMode: entryIntent.entryMode ?? null,
-          }
-        : null,
-    });
-
-    return { referralRef, entryIntent };
-  }
-
-  async function routeEntryIntentEvent(input: {
-    psid: string;
-    userId: string;
-    reqId: string;
-    state: MessengerUserState;
-    entryIntent: ReturnType<typeof parseGameEntryIntent>;
-  }): Promise<boolean> {
-    const entryIntentRoute = await routeEntryIntent({
-      state: input.state,
-      entryIntent: input.entryIntent,
-      setLastEntryIntent: nextEntryIntent =>
-        Promise.resolve(setLastEntryIntent(input.psid, nextEntryIntent)),
-      setActiveExperience: nextActiveExperience =>
-        Promise.resolve(setActiveExperience(input.psid, nextActiveExperience)),
-    });
-    if (!entryIntentRoute.handled) {
-      return false;
-    }
-
-    await sendRouteResponse(
-      entryIntentRoute,
-      createMessengerResponseOptions(
-        input.psid,
-        input.userId,
-        input.reqId,
-        "entry_intent_options_fallback_available"
-      )
-    );
-    return true;
-  }
-
-  async function routeActiveExperienceEvent(input: {
-    psid: string;
-    userId: string;
-    reqId: string;
-    state: MessengerUserState;
-    event: FacebookWebhookEvent;
-  }): Promise<boolean> {
-    const action =
-      input.event.postback?.payload ??
-      input.event.message?.quick_reply?.payload ??
-      input.event.message?.text?.trim() ??
-      null;
-    const activeExperienceRoute = await routeActiveExperience({
-      state: input.state,
-      action,
-      setLastEntryIntent: nextEntryIntent =>
-        Promise.resolve(setLastEntryIntent(input.psid, nextEntryIntent)),
-      setActiveExperience: nextActiveExperience =>
-        Promise.resolve(setActiveExperience(input.psid, nextActiveExperience)),
-    });
-    if (!activeExperienceRoute.handled) {
-      return false;
-    }
-
-    await sendRouteResponse(
-      activeExperienceRoute,
-      createMessengerResponseOptions(
-        input.psid,
-        input.userId,
-        input.reqId,
-        "active_experience_options_fallback_available"
-      )
-    );
-    return true;
-  }
-
   async function claimEventReplayOrLog(
     event: FacebookWebhookEvent,
     entryId: string | undefined,
@@ -1346,20 +1195,60 @@ export function createWebhookHandlers({
       return;
     }
 
-    const { referralRef, entryIntent } = parseEventEntryIntent(
+    const routeDeps = {
+      psid,
+      userId,
+      reqId,
+      sendText: (text: string) => sendLoggedText(psid, text, reqId),
+      sendStateText: (stateName: ConversationState, text: string) =>
+        sendStateQuickReplies(psid, stateName, text, reqId),
+      sendOptionsPrompt: async (
+        prompt: string,
+        options: Array<{ id: string; title: string }>,
+        _fallbackLogName: string | undefined,
+        _fallbackText: string | undefined
+      ) => {
+        await sendLoggedQuickReplies(
+          psid,
+          prompt,
+          options.map(option => ({
+            content_type: "text",
+            title: option.title,
+            payload: option.id,
+          })),
+          reqId
+        );
+      },
+      sendImage: (imageUrl: string) => sendLoggedImage(psid, imageUrl, reqId),
+      safeLog,
+      setLastEntryIntent: (nextEntryIntent: EntryIntent | null) =>
+        Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
+      setActiveExperience: (nextActiveExperience: ActiveExperience | null) =>
+        Promise.resolve(setActiveExperience(psid, nextActiveExperience)),
+    };
+    const { referralRef, entryIntent } = parseMessengerEntryIntent({
       event,
       reqId,
       userId,
-      localeLang
-    );
+      localeLang,
+      safeLog,
+    });
     if (
-      await routeEntryIntentEvent({ psid, userId, reqId, state, entryIntent })
+      await routeMessengerEntryIntent({
+        deps: routeDeps,
+        state,
+        entryIntent,
+      })
     ) {
       return;
     }
 
     if (
-      await routeActiveExperienceEvent({ psid, userId, reqId, state, event })
+      await routeMessengerActiveExperience({
+        deps: routeDeps,
+        state,
+        event,
+      })
     ) {
       return;
     }

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -86,6 +86,8 @@ type HandlerDeps = {
   privacyPolicyUrl: string;
 };
 
+type FacebookWebhookMessage = NonNullable<FacebookWebhookEvent["message"]>;
+
 const IN_FLIGHT_MESSAGE =
   "\u23F3 even geduld, ik ben nog bezig met jouw restyle";
 const inFlightNoticeSent = new Set();
@@ -904,6 +906,191 @@ export function createWebhookHandlers({
     });
   }
 
+  async function tryHandleImageMessage(input: {
+    psid: string;
+    userId: string;
+    reqId: string;
+    lang: Lang;
+    attachments: FacebookWebhookMessage["attachments"];
+  }): Promise<boolean> {
+    const imageAttachment = input.attachments?.find(
+      att => att.type === "image" && att.payload?.url
+    );
+    if (!imageAttachment?.payload?.url) {
+      return false;
+    }
+
+    const inboundImageUrl = imageAttachment.payload.url;
+    debugWebhookLog({
+      level: "debug",
+      msg: "photo_received",
+      reqId: input.reqId,
+      psidHash: anonymizePsid(input.psid).slice(0, 12),
+      hasAttachments: !!input.attachments,
+      attachmentHostname: getAttachmentHostname(inboundImageUrl),
+    });
+
+    const storedSourceImageUrl = await normalizeMessengerInboundImage({
+      inboundImageUrl,
+      psidHash: anonymizePsid(input.psid).slice(0, 12),
+      reqId: input.reqId,
+    });
+    if (!storedSourceImageUrl) {
+      await clearPendingImageState(input.psid);
+      await setFlowState(input.psid, "AWAITING_PHOTO");
+      await sendLoggedText(
+        input.psid,
+        t(input.lang, "missingInputImage"),
+        input.reqId
+      );
+      return true;
+    }
+
+    const state = await getOrCreateState(input.psid);
+    for (const feature of getBotFeatures()) {
+      const result = await feature.onImage?.(
+        createFeatureImageContext(
+          input.psid,
+          input.userId,
+          input.reqId,
+          input.lang,
+          state,
+          storedSourceImageUrl
+        )
+      );
+      if (result?.handled) {
+        return true;
+      }
+    }
+
+    logUserState(input.psid, input.userId, state, input.reqId, "image_received");
+    const imageDecision = getStoredMessengerImageDecision({
+      lastPhotoUrl: state.lastPhotoUrl,
+      preselectedStyle: state.preselectedStyle,
+      storedSourceImageUrl,
+    });
+    await setPendingStoredImage(input.psid, storedSourceImageUrl);
+
+    logImageFlowDecision({
+      psid: input.psid,
+      userId: input.userId,
+      reqId: input.reqId,
+      stage: state.stage,
+      hadPreviousPhoto: imageDecision.hadPreviousPhoto,
+      incomingImageUrl: imageDecision.incomingImageUrl,
+      selectedStyle: state.selectedStyle,
+      preselectedStyle: imageDecision.preselectedStyle,
+      action: imageDecision.action,
+    });
+
+    if (imageDecision.action === "auto_run_preselected_style") {
+      await setPreselectedStyle(input.psid, null);
+      await setChosenStyle(input.psid, imageDecision.preselectedStyle);
+      await runStyleGeneration(
+        input.psid,
+        input.userId,
+        imageDecision.preselectedStyle,
+        input.reqId,
+        input.lang
+      );
+      return true;
+    }
+
+    await setFlowState(input.psid, "AWAITING_STYLE");
+    await sendPhotoReceivedPrompt(input.psid, input.lang, input.reqId);
+    return true;
+  }
+
+  async function handleTextMessage(input: {
+    psid: string;
+    userId: string;
+    reqId: string;
+    lang: Lang;
+    text: string;
+    timestamp?: number;
+  }): Promise<void> {
+    const normalizedMessage: NormalizedInboundMessage = {
+      channel: "messenger",
+      senderId: input.psid,
+      userId: input.userId,
+      messageType: "text",
+      textBody: input.text,
+      timestamp: input.timestamp ?? Date.now(),
+    };
+    console.log("[messenger webhook] normalized event handoff", {
+      channel: normalizedMessage.channel,
+      reqId: input.reqId,
+      user: toLogUser(input.userId),
+      messageType: normalizedMessage.messageType,
+    });
+
+    const result = await handleSharedTextMessage({
+      message: normalizedMessage,
+      reqId: input.reqId,
+      lang: input.lang,
+      getState: () => Promise.resolve(getOrCreateState(input.psid)),
+      setFlowState: nextState =>
+        Promise.resolve(setFlowState(input.psid, nextState)),
+      runTextFeatures: async ({
+        state,
+        messageText,
+        normalizedText,
+        hasPhoto,
+      }) => {
+        for (const feature of getBotFeatures()) {
+          const result = await feature.onText?.(
+            createFeatureTextContext(
+              input.psid,
+              input.userId,
+              input.reqId,
+              input.lang,
+              state,
+              messageText,
+              normalizedText,
+              hasPhoto
+            )
+          );
+          if (result?.handled) {
+            return true;
+          }
+        }
+
+        return false;
+      },
+      logState: (state, context) => {
+        logUserState(input.psid, input.userId, state, input.reqId, context);
+      },
+      logAckIgnored: ack => {
+        safeLog("ack_ignored", { ack });
+      },
+      logRolloutDecision: rolloutDecision => {
+        safeLog("messenger_chat_engine_decision", {
+          user: toLogUser(input.userId),
+          engine: rolloutDecision.engine,
+          canaryPercent: rolloutDecision.canaryPercent,
+          bucket: rolloutDecision.bucket,
+          selected: rolloutDecision.useResponses ? "responses" : "legacy",
+        });
+      },
+      logEngineResult: ({ source, errorCode }) => {
+        safeLog("messenger_chat_engine_result", {
+          user: toLogUser(input.userId),
+          source,
+          ...(errorCode ? { errorCode } : {}),
+        });
+      },
+    });
+    await sendMessengerBotResponse(result.response, {
+      replyState: result.replyState,
+      sendText: text => sendLoggedText(input.psid, text, input.reqId),
+      sendStateText: (stateName, text) =>
+        sendStateQuickReplies(input.psid, stateName, text, input.reqId),
+    });
+    if (result.afterSend === "markIntroSeen") {
+      await Promise.resolve(markIntroSeen(input.psid));
+    }
+  }
+
   async function handleMessage(
     psid: string,
     userId: string,
@@ -925,93 +1112,15 @@ export function createWebhookHandlers({
       return;
     }
 
-    const imageAttachment = message.attachments?.find(
-      att => att.type === "image" && att.payload?.url
-    );
-    if (imageAttachment?.payload?.url) {
-      const inboundImageUrl = imageAttachment.payload.url;
-      debugWebhookLog({
-        level: "debug",
-        msg: "photo_received",
-        reqId,
-        psidHash: anonymizePsid(psid).slice(0, 12),
-        hasAttachments: !!message.attachments,
-        attachmentHostname: getAttachmentHostname(inboundImageUrl),
-      });
-
-      const storedSourceImageUrl = await normalizeMessengerInboundImage({
-        inboundImageUrl,
-        psidHash: anonymizePsid(psid).slice(0, 12),
-        reqId,
-      });
-      if (!storedSourceImageUrl) {
-        await clearPendingImageState(psid);
-        await setFlowState(psid, "AWAITING_PHOTO");
-        await sendLoggedText(psid, t(lang, "missingInputImage"), reqId);
-        return;
-      }
-
-      const state = await getOrCreateState(psid);
-      for (const feature of getBotFeatures()) {
-        const result = await feature.onImage?.(
-          createFeatureImageContext(
-            psid,
-            userId,
-            reqId,
-            lang,
-            state,
-            storedSourceImageUrl
-          )
-        );
-        if (result?.handled) {
-          return;
-        }
-      }
-      logUserState(psid, userId, state, reqId, "image_received");
-      const imageDecision = getStoredMessengerImageDecision({
-        lastPhotoUrl: state.lastPhotoUrl,
-        preselectedStyle: state.preselectedStyle,
-        storedSourceImageUrl,
-      });
-      await setPendingStoredImage(psid, storedSourceImageUrl);
-
-      if (imageDecision.action === "auto_run_preselected_style") {
-        logImageFlowDecision({
-          psid,
-          userId,
-          reqId,
-          stage: state.stage,
-          hadPreviousPhoto: imageDecision.hadPreviousPhoto,
-          incomingImageUrl: imageDecision.incomingImageUrl,
-          selectedStyle: state.selectedStyle,
-          preselectedStyle: imageDecision.preselectedStyle,
-          action: imageDecision.action,
-        });
-        await setPreselectedStyle(psid, null);
-        await setChosenStyle(psid, imageDecision.preselectedStyle);
-        await runStyleGeneration(
-          psid,
-          userId,
-          imageDecision.preselectedStyle,
-          reqId,
-          lang
-        );
-        return;
-      }
-
-      logImageFlowDecision({
+    if (
+      await tryHandleImageMessage({
         psid,
         userId,
         reqId,
-        stage: state.stage,
-        hadPreviousPhoto: imageDecision.hadPreviousPhoto,
-        incomingImageUrl: imageDecision.incomingImageUrl,
-        selectedStyle: state.selectedStyle,
-        preselectedStyle: imageDecision.preselectedStyle,
-        action: imageDecision.action,
-      });
-      await setFlowState(psid, "AWAITING_STYLE");
-      await sendPhotoReceivedPrompt(psid, lang, reqId);
+        lang,
+        attachments: message.attachments,
+      })
+    ) {
       return;
     }
 
@@ -1021,85 +1130,14 @@ export function createWebhookHandlers({
       return;
     }
 
-    const normalizedMessage: NormalizedInboundMessage = {
-      channel: "messenger",
-      senderId: psid,
+    await handleTextMessage({
+      psid,
       userId,
-      messageType: "text",
-      textBody: trimmedText,
-      timestamp: event.timestamp ?? Date.now(),
-    };
-    console.log("[messenger webhook] normalized event handoff", {
-      channel: normalizedMessage.channel,
-      reqId,
-      user: toLogUser(userId),
-      messageType: normalizedMessage.messageType,
-    });
-
-    const result = await handleSharedTextMessage({
-      message: normalizedMessage,
       reqId,
       lang,
-      getState: () => Promise.resolve(getOrCreateState(psid)),
-      setFlowState: nextState => Promise.resolve(setFlowState(psid, nextState)),
-      runTextFeatures: async ({
-        state,
-        messageText,
-        normalizedText,
-        hasPhoto,
-      }) => {
-        for (const feature of getBotFeatures()) {
-          const result = await feature.onText?.(
-            createFeatureTextContext(
-              psid,
-              userId,
-              reqId,
-              lang,
-              state,
-              messageText,
-              normalizedText,
-              hasPhoto
-            )
-          );
-          if (result?.handled) {
-            return true;
-          }
-        }
-
-        return false;
-      },
-      logState: (state, context) => {
-        logUserState(psid, userId, state, reqId, context);
-      },
-      logAckIgnored: ack => {
-        safeLog("ack_ignored", { ack });
-      },
-      logRolloutDecision: rolloutDecision => {
-        safeLog("messenger_chat_engine_decision", {
-          user: toLogUser(userId),
-          engine: rolloutDecision.engine,
-          canaryPercent: rolloutDecision.canaryPercent,
-          bucket: rolloutDecision.bucket,
-          selected: rolloutDecision.useResponses ? "responses" : "legacy",
-        });
-      },
-      logEngineResult: ({ source, errorCode }) => {
-        safeLog("messenger_chat_engine_result", {
-          user: toLogUser(userId),
-          source,
-          ...(errorCode ? { errorCode } : {}),
-        });
-      },
+      text: trimmedText,
+      timestamp: event.timestamp ?? Date.now(),
     });
-    await sendMessengerBotResponse(result.response, {
-      replyState: result.replyState,
-      sendText: text => sendLoggedText(psid, text, reqId),
-      sendStateText: (stateName, text) =>
-        sendStateQuickReplies(psid, stateName, text, reqId),
-    });
-    if (result.afterSend === "markIntroSeen") {
-      await Promise.resolve(markIntroSeen(psid));
-    }
   }
 
   async function claimEventReplayOrLog(

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -27,6 +27,7 @@ import {
   markIntroSeen,
   anonymizePsid,
   type ConversationState,
+  type MessengerUserState,
 } from "./messengerState";
 import { normalizeLang, t, type Lang } from "./i18n";
 import { routeActiveExperience, routeEntryIntent } from "./experienceRouter";
@@ -78,6 +79,11 @@ import type {
   BotTextContext,
   BotImageContext,
 } from "./botContext";
+
+type MessengerBotResponseOptions = Parameters<
+  typeof sendMessengerBotResponse
+>[1];
+type MessengerRouteResult = Awaited<ReturnType<typeof routeEntryIntent>>;
 
 type HandlerDeps = {
   defaultLang: Lang;
@@ -1126,6 +1132,196 @@ export function createWebhookHandlers({
     }
   }
 
+  function createMessengerResponseOptions(
+    psid: string,
+    userId: string,
+    reqId: string,
+    optionsFallbackLogName?: string
+  ): MessengerBotResponseOptions {
+    return {
+      sendText: text => sendLoggedText(psid, text, reqId),
+      sendStateText: (stateName, text) =>
+        sendStateQuickReplies(psid, stateName, text, reqId),
+      sendOptionsPrompt: async (prompt, options, fallbackText) => {
+        await sendLoggedQuickReplies(
+          psid,
+          prompt,
+          options.map(option => ({
+            content_type: "text",
+            title: option.title,
+            payload: option.id,
+          })),
+          reqId
+        );
+
+        if (fallbackText && optionsFallbackLogName) {
+          safeLog(optionsFallbackLogName, {
+            user: toLogUser(userId),
+            fallbackText,
+          });
+        }
+      },
+      sendImage: (imageUrl, caption) => {
+        if (caption) {
+          return sendLoggedText(psid, caption, reqId).then(() =>
+            sendLoggedImage(psid, imageUrl, reqId)
+          );
+        }
+
+        return sendLoggedImage(psid, imageUrl, reqId);
+      },
+    };
+  }
+
+  async function sendRouteResponse(
+    route: MessengerRouteResult,
+    options: MessengerBotResponseOptions
+  ): Promise<void> {
+    await sendMessengerBotResponse(route.response ?? null, options);
+    if (route.afterSend) {
+      await sendMessengerBotResponse(await route.afterSend(), options);
+    }
+  }
+
+  function parseEventEntryIntent(
+    event: FacebookWebhookEvent,
+    reqId: string,
+    userId: string,
+    localeLang: Lang
+  ) {
+    const referralRef = event.postback?.referral?.ref ?? event.referral?.ref;
+    const entryIntent = parseGameEntryIntent({
+      channel: "messenger",
+      ref: referralRef,
+      sourceType: event.postback?.payload ? "postback" : "referral",
+      localeHint: localeLang,
+      receivedAt: event.timestamp ?? Date.now(),
+    });
+
+    safeLog("entry_intent_parsed", {
+      reqId,
+      user: toLogUser(userId),
+      referralRef: referralRef ?? null,
+      entryIntent: entryIntent
+        ? {
+            targetExperienceType: entryIntent.targetExperienceType,
+            targetExperienceId: entryIntent.targetExperienceId,
+            sourceType: entryIntent.sourceType,
+            entryMode: entryIntent.entryMode ?? null,
+          }
+        : null,
+    });
+
+    return { referralRef, entryIntent };
+  }
+
+  async function routeEntryIntentEvent(input: {
+    psid: string;
+    userId: string;
+    reqId: string;
+    state: MessengerUserState;
+    entryIntent: ReturnType<typeof parseGameEntryIntent>;
+  }): Promise<boolean> {
+    const entryIntentRoute = await routeEntryIntent({
+      state: input.state,
+      entryIntent: input.entryIntent,
+      setLastEntryIntent: nextEntryIntent =>
+        Promise.resolve(setLastEntryIntent(input.psid, nextEntryIntent)),
+      setActiveExperience: nextActiveExperience =>
+        Promise.resolve(setActiveExperience(input.psid, nextActiveExperience)),
+    });
+    if (!entryIntentRoute.handled) {
+      return false;
+    }
+
+    await sendRouteResponse(
+      entryIntentRoute,
+      createMessengerResponseOptions(
+        input.psid,
+        input.userId,
+        input.reqId,
+        "entry_intent_options_fallback_available"
+      )
+    );
+    return true;
+  }
+
+  async function routeActiveExperienceEvent(input: {
+    psid: string;
+    userId: string;
+    reqId: string;
+    state: MessengerUserState;
+    event: FacebookWebhookEvent;
+  }): Promise<boolean> {
+    const action =
+      input.event.postback?.payload ??
+      input.event.message?.quick_reply?.payload ??
+      input.event.message?.text?.trim() ??
+      null;
+    const activeExperienceRoute = await routeActiveExperience({
+      state: input.state,
+      action,
+      setLastEntryIntent: nextEntryIntent =>
+        Promise.resolve(setLastEntryIntent(input.psid, nextEntryIntent)),
+      setActiveExperience: nextActiveExperience =>
+        Promise.resolve(setActiveExperience(input.psid, nextActiveExperience)),
+    });
+    if (!activeExperienceRoute.handled) {
+      return false;
+    }
+
+    await sendRouteResponse(
+      activeExperienceRoute,
+      createMessengerResponseOptions(
+        input.psid,
+        input.userId,
+        input.reqId,
+        "active_experience_options_fallback_available"
+      )
+    );
+    return true;
+  }
+
+  async function claimEventReplayOrLog(
+    event: FacebookWebhookEvent,
+    entryId: string | undefined,
+    userId: string
+  ): Promise<boolean> {
+    const dedupeKey = getEventDedupeKey(event, userId, entryId);
+    if (!dedupeKey) {
+      return true;
+    }
+
+    const claimed = await claimWebhookReplayKey(dedupeKey);
+    if (claimed) {
+      return true;
+    }
+
+    safeLog("webhook_replay_ignored", {
+      user: toLogUser(userId),
+      eventId: dedupeKey,
+    });
+    return false;
+  }
+
+  async function handleReferralStyleEvent(
+    psid: string,
+    referralRef: string | undefined,
+    lang: Lang,
+    reqId: string
+  ): Promise<boolean> {
+    const referralStyle = parseReferralStyle(referralRef);
+    if (!referralStyle) {
+      return false;
+    }
+
+    await clearPendingImageState(psid);
+    await setPreselectedStyle(psid, referralStyle);
+    await setFlowState(psid, "AWAITING_PHOTO");
+    await sendReferralPhotoPrompt(psid, referralStyle, lang, reqId);
+    return true;
+  }
+
   async function handleEvent(
     event: FacebookWebhookEvent,
     entryId?: string
@@ -1146,193 +1342,30 @@ export function createWebhookHandlers({
       await setPreferredLang(psid, localeLang);
     }
 
-    const dedupeKey = getEventDedupeKey(event, userId, entryId);
-    if (dedupeKey) {
-      const claimed = await claimWebhookReplayKey(dedupeKey);
-      if (!claimed) {
-        safeLog("webhook_replay_ignored", {
-          user: toLogUser(userId),
-          eventId: dedupeKey,
-        });
-        return;
-      }
+    if (!(await claimEventReplayOrLog(event, entryId, userId))) {
+      return;
     }
 
-    const referralRef = event.postback?.referral?.ref ?? event.referral?.ref;
-    const entryIntent = parseGameEntryIntent({
-      channel: "messenger",
-      ref: referralRef,
-      sourceType: event.postback?.payload ? "postback" : "referral",
-      localeHint: localeLang ?? undefined,
-      receivedAt: event.timestamp ?? Date.now(),
-    });
-    safeLog("entry_intent_parsed", {
+    const { referralRef, entryIntent } = parseEventEntryIntent(
+      event,
       reqId,
-      user: toLogUser(userId),
-      referralRef: referralRef ?? null,
-      entryIntent: entryIntent
-        ? {
-            targetExperienceType: entryIntent.targetExperienceType,
-            targetExperienceId: entryIntent.targetExperienceId,
-            sourceType: entryIntent.sourceType,
-            entryMode: entryIntent.entryMode ?? null,
-          }
-        : null,
-    });
-    const entryIntentRoute = await routeEntryIntent({
-      state,
-      entryIntent,
-      setLastEntryIntent: nextEntryIntent =>
-        Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
-      setActiveExperience: nextActiveExperience =>
-        Promise.resolve(setActiveExperience(psid, nextActiveExperience)),
-    });
-    if (entryIntentRoute.handled) {
-      await sendMessengerBotResponse(entryIntentRoute.response ?? null, {
-        sendText: text => sendLoggedText(psid, text, reqId),
-        sendStateText: (stateName, text) =>
-          sendStateQuickReplies(psid, stateName, text, reqId),
-        sendOptionsPrompt: async (prompt, options, fallbackText) => {
-          await sendLoggedQuickReplies(
-            psid,
-            prompt,
-            options.map(option => ({
-              content_type: "text",
-              title: option.title,
-              payload: option.id,
-            })),
-            reqId
-          );
-
-          if (fallbackText) {
-            safeLog("entry_intent_options_fallback_available", {
-              user: toLogUser(userId),
-              fallbackText,
-            });
-          }
-        },
-        sendImage: (imageUrl, caption) => {
-          if (caption) {
-            return sendLoggedText(psid, caption, reqId).then(() =>
-              sendLoggedImage(psid, imageUrl, reqId)
-            );
-          }
-
-          return sendLoggedImage(psid, imageUrl, reqId);
-        },
-      });
-      if (entryIntentRoute.afterSend) {
-        const followUpResponse = await entryIntentRoute.afterSend();
-        await sendMessengerBotResponse(followUpResponse, {
-          sendText: text => sendLoggedText(psid, text, reqId),
-          sendStateText: (stateName, text) =>
-            sendStateQuickReplies(psid, stateName, text, reqId),
-          sendImage: (imageUrl, caption) => {
-            if (caption) {
-              return sendLoggedText(psid, caption, reqId).then(() =>
-                sendLoggedImage(psid, imageUrl, reqId)
-              );
-            }
-
-            return sendLoggedImage(psid, imageUrl, reqId);
-          },
-        });
-      }
+      userId,
+      localeLang
+    );
+    if (
+      await routeEntryIntentEvent({ psid, userId, reqId, state, entryIntent })
+    ) {
       return;
     }
 
-    const activeExperienceAction =
-      event.postback?.payload ??
-      event.message?.quick_reply?.payload ??
-      event.message?.text?.trim() ??
-      null;
-    const activeExperienceRoute = await routeActiveExperience({
-      state,
-      action: activeExperienceAction,
-      setLastEntryIntent: nextEntryIntent =>
-        Promise.resolve(setLastEntryIntent(psid, nextEntryIntent)),
-      setActiveExperience: nextActiveExperience =>
-        Promise.resolve(setActiveExperience(psid, nextActiveExperience)),
-    });
-    if (activeExperienceRoute.handled) {
-      await sendMessengerBotResponse(activeExperienceRoute.response ?? null, {
-        sendText: text => sendLoggedText(psid, text, reqId),
-        sendStateText: (stateName, text) =>
-          sendStateQuickReplies(psid, stateName, text, reqId),
-        sendOptionsPrompt: async (prompt, options, fallbackText) => {
-          await sendLoggedQuickReplies(
-            psid,
-            prompt,
-            options.map(option => ({
-              content_type: "text",
-              title: option.title,
-              payload: option.id,
-            })),
-            reqId
-          );
-
-          if (fallbackText) {
-            safeLog("active_experience_options_fallback_available", {
-              user: toLogUser(userId),
-              fallbackText,
-            });
-          }
-        },
-        sendImage: (imageUrl, caption) => {
-          if (caption) {
-            return sendLoggedText(psid, caption, reqId).then(() =>
-              sendLoggedImage(psid, imageUrl, reqId)
-            );
-          }
-
-          return sendLoggedImage(psid, imageUrl, reqId);
-        },
-      });
-      if (activeExperienceRoute.afterSend) {
-        const followUpResponse = await activeExperienceRoute.afterSend();
-        await sendMessengerBotResponse(followUpResponse, {
-          sendText: text => sendLoggedText(psid, text, reqId),
-          sendStateText: (stateName, text) =>
-            sendStateQuickReplies(psid, stateName, text, reqId),
-          sendOptionsPrompt: async (prompt, options, fallbackText) => {
-            await sendLoggedQuickReplies(
-              psid,
-              prompt,
-              options.map(option => ({
-                content_type: "text",
-                title: option.title,
-                payload: option.id,
-              })),
-              reqId
-            );
-
-            if (fallbackText) {
-              safeLog("active_experience_options_fallback_available", {
-                user: toLogUser(userId),
-                fallbackText,
-              });
-            }
-          },
-          sendImage: (imageUrl, caption) => {
-            if (caption) {
-              return sendLoggedText(psid, caption, reqId).then(() =>
-                sendLoggedImage(psid, imageUrl, reqId)
-              );
-            }
-
-            return sendLoggedImage(psid, imageUrl, reqId);
-          },
-        });
-      }
+    if (
+      await routeActiveExperienceEvent({ psid, userId, reqId, state, event })
+    ) {
       return;
     }
 
-    const referralStyle = parseReferralStyle(referralRef);
-    if (referralStyle) {
-      await clearPendingImageState(psid);
-      await setPreselectedStyle(psid, referralStyle);
-      await setFlowState(psid, "AWAITING_PHOTO");
-      return sendReferralPhotoPrompt(psid, referralStyle, lang, reqId);
+    if (await handleReferralStyleEvent(psid, referralRef, lang, reqId)) {
+      return;
     }
 
     if (event.postback?.payload) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Messenger webhook handling into clearer routing layers and helpers for text, image, payload and referral flows.
* **Bug Fixes**
  * Improved replay protection to avoid duplicate webhook processing.
  * More reliable entry-intent and in-chat action routing for consistent responses.
  * Referral photo prompts and image/text decision flows now behave predictably and advance conversation state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->