### PR TITLE
Normalize messenger image ingress errorCode fallback

### DIFF
--- a/server/_core/messengerImageIngress.ts
+++ b/server/_core/messengerImageIngress.ts
@@ -24,7 +24,7 @@ export async function normalizeMessengerInboundImage(
       reqId: input.reqId,
       inboundImageUrl: input.inboundImageUrl,
       errorCode:
-        error instanceof Error ? error.constructor.name : String(error),
+        error instanceof Error ? error.constructor.name : "UnknownError",
     });
     return null;
   }


### PR DESCRIPTION
Issue #295: SafeLog Inbound Image Ingest Failures
Summary
Issue #295 asks to stop logging signed Messenger lookaside URLs from normalizeMessengerInboundImage. The current branch already has the main fix: server/_core/messengerImageIngress.ts imports safeLog and logs messenger_inbound_image_ingest_failed, so inboundImageUrl is redacted by safeLog because keys containing url are dropped.

Key Change
Make the remaining issue-alignment tweak in server/_core/messengerImageIngress.ts only:
Keep safeLog("messenger_inbound_image_ingest_failed", ...).
Keep inboundImageUrl as the key so safeLog redaction drops it.
Change non-Error errorCode fallback from String(error) to "UnknownError" to match the issue’s requested observability shape and avoid logging arbitrary thrown values.
Guardrails
Do not touch webhook handlers, Messenger state refactors, WhatsApp, docs, admin auth, or tests.
Do not change ingest behavior or return behavior: catch still returns null.
Do not remove inboundImageUrl from the safeLog details; keeping it verifies redaction behavior through the existing safeLog key filter.
Test Plan
Run pnpm -s tsc --noEmit.
If Vitest can start locally, run the nearest Messenger image ingress/photo flow test:
pnpm -s test server/messengerWebhook.photoFirst.test.ts
No broad Fallow cleanup; optional fallow.cmd only to confirm no new unrelated maintainability signal.
Assumptions
Current branch already includes the safeLog replacement from issue #295.
The intended remaining fix is strict alignment with the issue suggestion, not a larger logging redesign.