### PR TITLE
feat: add global consent and data deletion gate

### DIFF
--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -1,0 +1,235 @@
+import { deleteUserData } from "./dataDeletionService";
+import type { Lang } from "./i18n";
+import type { QuickReply } from "./messengerApi";
+import {
+  setConsentState,
+  setPendingDeleteConfirm,
+  type MessengerUserState,
+} from "./messengerState";
+import type { NormalizedWhatsAppEvent } from "./whatsappTypes";
+
+export const GDPR_CONSENT_AGREE = "GDPR_CONSENT_AGREE";
+export const GDPR_CONSENT_DECLINE = "GDPR_CONSENT_DECLINE";
+export const GDPR_DELETE_CONFIRM = "GDPR_DELETE_CONFIRM";
+export const GDPR_DELETE_CANCEL = "GDPR_DELETE_CANCEL";
+
+const DELETE_COMMANDS = new Set(["delete my data", "verwijder mijn data"]);
+
+type MessengerConsentGateInput = {
+  psid: string;
+  lang: Lang;
+  text?: string | null;
+  payload?: string | null;
+  state: MessengerUserState;
+  sendText: (text: string) => Promise<void>;
+  sendQuickReplies: (text: string, replies: QuickReply[]) => Promise<void>;
+};
+
+type WhatsAppConsentGateInput = {
+  event: NormalizedWhatsAppEvent;
+  lang: Lang;
+  state: MessengerUserState;
+  sendText: (text: string) => Promise<void>;
+  sendButtons: (
+    text: string,
+    options: Array<{ id: string; title: string }>
+  ) => Promise<void>;
+};
+
+function isDeleteCommand(text: string | null | undefined): boolean {
+  return DELETE_COMMANDS.has(text?.trim().toLocaleLowerCase("nl-BE") ?? "");
+}
+
+function consentText(lang: Lang): string {
+  return lang === "en"
+    ? "Hey! Before we continue, I need your permission to process your images and data."
+    : "Hey! Voor we verdergaan heb ik je toestemming nodig om je beelden en data te verwerken.";
+}
+
+function deletionConfirmText(lang: Lang): string {
+  return lang === "en"
+    ? "Are you sure you want to delete all your data? This includes your images, generated results, stored preferences, and chat history."
+    : "Weet je zeker dat je al je data wil verwijderen? Dit omvat je beelden, gegenereerde resultaten, opgeslagen voorkeuren en chatgeschiedenis.";
+}
+
+function deletionDoneText(lang: Lang): string {
+  return lang === "en"
+    ? "Your data has been deleted. If you contact me again, I will ask for consent first."
+    : "Je data is verwijderd. Als je opnieuw contact opneemt, vraag ik eerst opnieuw toestemming.";
+}
+
+function consentDeclinedText(lang: Lang): string {
+  return lang === "en"
+    ? "No problem. I cannot continue without your consent."
+    : "Geen probleem. Zonder je toestemming kan ik niet verdergaan.";
+}
+
+function consentAcceptedText(lang: Lang): string {
+  return lang === "en"
+    ? "Thanks. You can now send a photo or message."
+    : "Dank je. Je kan nu een foto of bericht sturen.";
+}
+
+function deleteCancelledText(lang: Lang): string {
+  return lang === "en" ? "Deletion cancelled." : "Verwijderen geannuleerd.";
+}
+
+function consentReplies(lang: Lang): QuickReply[] {
+  return [
+    {
+      content_type: "text",
+      title: lang === "en" ? "I Agree" : "Ik ga akkoord",
+      payload: GDPR_CONSENT_AGREE,
+    },
+    {
+      content_type: "text",
+      title: lang === "en" ? "No thanks" : "Nee bedankt",
+      payload: GDPR_CONSENT_DECLINE,
+    },
+  ];
+}
+
+function deleteReplies(lang: Lang): QuickReply[] {
+  return [
+    {
+      content_type: "text",
+      title: lang === "en" ? "Yes, delete" : "Ja, verwijder",
+      payload: GDPR_DELETE_CONFIRM,
+    },
+    {
+      content_type: "text",
+      title: "Cancel",
+      payload: GDPR_DELETE_CANCEL,
+    },
+  ];
+}
+
+function whatsAppConsentButtons(lang: Lang): Array<{ id: string; title: string }> {
+  return [
+    {
+      id: GDPR_CONSENT_AGREE,
+      title: lang === "en" ? "I Agree" : "Akkoord",
+    },
+    {
+      id: GDPR_CONSENT_DECLINE,
+      title: lang === "en" ? "No thanks" : "Nee",
+    },
+  ];
+}
+
+function whatsAppDeleteButtons(lang: Lang): Array<{ id: string; title: string }> {
+  return [
+    {
+      id: GDPR_DELETE_CONFIRM,
+      title: lang === "en" ? "Yes, delete" : "Verwijder",
+    },
+    {
+      id: GDPR_DELETE_CANCEL,
+      title: "Cancel",
+    },
+  ];
+}
+
+export async function handleMessengerConsentGate(
+  input: MessengerConsentGateInput
+): Promise<boolean> {
+  if (input.payload === GDPR_CONSENT_AGREE) {
+    await Promise.resolve(setConsentState(input.psid, true));
+    await input.sendText(consentAcceptedText(input.lang));
+    return true;
+  }
+
+  if (input.payload === GDPR_CONSENT_DECLINE) {
+    await Promise.resolve(setConsentState(input.psid, false));
+    await input.sendText(consentDeclinedText(input.lang));
+    return true;
+  }
+
+  if (input.payload === GDPR_DELETE_CANCEL) {
+    await Promise.resolve(setPendingDeleteConfirm(input.psid, false));
+    await input.sendText(deleteCancelledText(input.lang));
+    return true;
+  }
+
+  if (input.payload === GDPR_DELETE_CONFIRM) {
+    await deleteUserData(input.psid);
+    await input.sendText(deletionDoneText(input.lang));
+    return true;
+  }
+
+  if (isDeleteCommand(input.text)) {
+    await Promise.resolve(setPendingDeleteConfirm(input.psid, true));
+    await input.sendQuickReplies(deletionConfirmText(input.lang), deleteReplies(input.lang));
+    return true;
+  }
+
+  if (input.state.pendingDeleteConfirm) {
+    await input.sendQuickReplies(deletionConfirmText(input.lang), deleteReplies(input.lang));
+    return true;
+  }
+
+  if (input.state.consentGiven !== true) {
+    await input.sendQuickReplies(consentText(input.lang), consentReplies(input.lang));
+    return true;
+  }
+
+  return false;
+}
+
+export async function handleWhatsAppConsentGate(
+  input: WhatsAppConsentGateInput
+): Promise<boolean> {
+  const payload =
+    typeof input.event.rawEventMeta?.interactiveReplyId === "string"
+      ? input.event.rawEventMeta.interactiveReplyId
+      : null;
+  const text = input.event.textBody;
+
+  if (payload === GDPR_CONSENT_AGREE) {
+    await Promise.resolve(setConsentState(input.event.senderId, true));
+    await input.sendText(consentAcceptedText(input.lang));
+    return true;
+  }
+
+  if (payload === GDPR_CONSENT_DECLINE) {
+    await Promise.resolve(setConsentState(input.event.senderId, false));
+    await input.sendText(consentDeclinedText(input.lang));
+    return true;
+  }
+
+  if (payload === GDPR_DELETE_CANCEL) {
+    await Promise.resolve(setPendingDeleteConfirm(input.event.senderId, false));
+    await input.sendText(deleteCancelledText(input.lang));
+    return true;
+  }
+
+  if (payload === GDPR_DELETE_CONFIRM) {
+    await deleteUserData(input.event.senderId);
+    await input.sendText(deletionDoneText(input.lang));
+    return true;
+  }
+
+  if (isDeleteCommand(text)) {
+    await Promise.resolve(setPendingDeleteConfirm(input.event.senderId, true));
+    await input.sendButtons(
+      deletionConfirmText(input.lang),
+      whatsAppDeleteButtons(input.lang)
+    );
+    return true;
+  }
+
+  if (input.state.pendingDeleteConfirm) {
+    await input.sendButtons(
+      deletionConfirmText(input.lang),
+      whatsAppDeleteButtons(input.lang)
+    );
+    return true;
+  }
+
+  if (input.state.consentGiven !== true) {
+    await input.sendButtons(consentText(input.lang), whatsAppConsentButtons(input.lang));
+    return true;
+  }
+
+  return false;
+}

--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -98,7 +98,7 @@ function deleteReplies(lang: Lang): QuickReply[] {
     },
     {
       content_type: "text",
-      title: "Cancel",
+      title: lang === "en" ? "Cancel" : "Annuleer",
       payload: GDPR_DELETE_CANCEL,
     },
   ];
@@ -125,7 +125,7 @@ function whatsAppDeleteButtons(lang: Lang): Array<{ id: string; title: string }>
     },
     {
       id: GDPR_DELETE_CANCEL,
-      title: "Cancel",
+      title: lang === "en" ? "Cancel" : "Annuleer",
     },
   ];
 }

--- a/server/_core/dataDeletionService.ts
+++ b/server/_core/dataDeletionService.ts
@@ -45,8 +45,22 @@ export async function deleteUserData(psid: string): Promise<void> {
 
   const urls = Array.from(new Set(getStateImageUrls(state)));
 
-  await deleteFaceMemoryForUser(psid);
+  const runStep = async (step: string, fn: () => Promise<void>) => {
+    try {
+      await fn();
+    } catch (error) {
+      safeLog("user_data_delete_step_failed", {
+        psid,
+        step,
+        errorCode: error instanceof Error ? error.constructor.name : "UnknownError",
+      });
+    }
+  };
+
+  await runStep("face_memory", () => deleteFaceMemoryForUser(psid));
   await Promise.all(urls.map(url => deleteStoredUrl(psid, url)));
-  await clearMessengerChatHistory(state.userKey);
+  await runStep("chat_history", () =>
+    Promise.resolve(clearMessengerChatHistory(state.userKey))
+  );
   await Promise.resolve(clearUserState(psid));
 }

--- a/server/_core/dataDeletionService.ts
+++ b/server/_core/dataDeletionService.ts
@@ -1,0 +1,52 @@
+import { storageDelete, storageKeyFromPublicUrl } from "../storage";
+import { deleteFaceMemoryForUser } from "./faceMemory";
+import { safeLog } from "./messengerApi";
+import { clearMessengerChatHistory } from "./messengerChatMemory";
+import {
+  clearUserState,
+  getState,
+  type MessengerUserState,
+} from "./messengerState";
+
+function getStateImageUrls(state: MessengerUserState): string[] {
+  return [
+    state.lastPhotoUrl,
+    state.pendingImageUrl,
+    state.lastSourceImageUrl,
+    state.pendingSourceImageDeleteUrl,
+    state.lastGeneratedUrl,
+    state.lastImageUrl,
+  ].filter((url): url is string => Boolean(url));
+}
+
+async function deleteStoredUrl(psid: string, imageUrl: string): Promise<void> {
+  const key = storageKeyFromPublicUrl(imageUrl);
+  if (!key) {
+    return;
+  }
+
+  try {
+    await storageDelete(key);
+  } catch (error) {
+    safeLog("user_data_storage_delete_failed", {
+      psid,
+      key,
+      errorCode: error instanceof Error ? error.constructor.name : "UnknownError",
+    });
+  }
+}
+
+export async function deleteUserData(psid: string): Promise<void> {
+  const state = await getState(psid);
+  if (!state) {
+    await Promise.resolve(clearUserState(psid));
+    return;
+  }
+
+  const urls = Array.from(new Set(getStateImageUrls(state)));
+
+  await deleteFaceMemoryForUser(psid);
+  await Promise.all(urls.map(url => deleteStoredUrl(psid, url)));
+  await clearMessengerChatHistory(state.userKey);
+  await Promise.resolve(clearUserState(psid));
+}

--- a/server/_core/messengerChatMemory.ts
+++ b/server/_core/messengerChatMemory.ts
@@ -107,7 +107,7 @@ export async function appendMessengerChatHistory(
   return nextHistory;
 }
 
-async function clearMessengerChatHistory(userKey: string): Promise<void> {
+export async function clearMessengerChatHistory(userKey: string): Promise<void> {
   await Promise.resolve(deleteScopedState(CHAT_HISTORY_SCOPE, userKey));
 }
 

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -9,6 +9,7 @@ import type { Lang } from "./i18n";
 import { toUserKey } from "./privacy";
 import {
   clearStateStore,
+  deleteState,
   findInMemoryState,
   getOrCreateStoredState,
   isPromiseLike,
@@ -56,6 +57,9 @@ export type MessengerUserState = {
   selectedStyleCategory?: StyleCategory | null;
   preselectedStyle?: string | null;
   preferredLang?: Lang;
+  consentGiven: boolean;
+  consentTimestamp?: number;
+  pendingDeleteConfirm?: boolean;
   hasSeenIntro: boolean;
   pendingImageUrl?: string;
   pendingImageAt?: number;
@@ -137,6 +141,9 @@ function createDefaultState(psid: string, now = Date.now()): MessengerUserState 
     selectedStyleCategory: null,
     preselectedStyle: null,
     preferredLang: "nl",
+    consentGiven: false,
+    consentTimestamp: undefined,
+    pendingDeleteConfirm: false,
     hasSeenIntro: false,
     pendingImageUrl: undefined,
     pendingImageAt: undefined,
@@ -205,6 +212,10 @@ function applyNormalizedStateShape(
     ...value,
     psid: resolvedPsid,
     userKey: value?.userKey ?? fallback.userKey,
+    consentGiven: value?.consentGiven ?? fallback.consentGiven,
+    consentTimestamp: value?.consentTimestamp ?? fallback.consentTimestamp,
+    pendingDeleteConfirm:
+      value?.pendingDeleteConfirm ?? fallback.pendingDeleteConfirm,
     hasSeenIntro: value?.hasSeenIntro ?? fallback.hasSeenIntro,
     stage,
     state: stage,
@@ -334,6 +345,10 @@ export function getState(psid: string): MaybePromise<MessengerUserState | null> 
   return getStateFromRedis(psid);
 }
 
+export function clearUserState(psid: string): MaybePromise<void> {
+  return deleteState(psid);
+}
+
 export function hasOpenMessengerResponseWindow(psid: string, now = Date.now()): MaybePromise<boolean> {
   const state = getState(psid);
 
@@ -375,6 +390,44 @@ export function setFlowState(psid: string, nextState: MessengerFlowState): Maybe
     stage: nextState,
     state: nextState,
   });
+
+  if (isPromiseLike(result)) {
+    return result.then(() => undefined);
+  }
+}
+
+export function setConsentState(
+  psid: string,
+  consentGiven: boolean,
+  now = Date.now()
+): MaybePromise<void> {
+  const result = patchState(
+    psid,
+    {
+      consentGiven,
+      consentTimestamp: consentGiven ? now : undefined,
+      pendingDeleteConfirm: false,
+    },
+    now
+  );
+
+  if (isPromiseLike(result)) {
+    return result.then(() => undefined);
+  }
+}
+
+export function setPendingDeleteConfirm(
+  psid: string,
+  pendingDeleteConfirm: boolean,
+  now = Date.now()
+): MaybePromise<void> {
+  const result = patchState(
+    psid,
+    {
+      pendingDeleteConfirm,
+    },
+    now
+  );
 
   if (isPromiseLike(result)) {
     return result.then(() => undefined);

--- a/server/_core/stateStore.ts
+++ b/server/_core/stateStore.ts
@@ -159,6 +159,10 @@ export function readState<T>(psid: string): MaybePromise<T | null> {
   return readRawState<T>(getStateKey(psid));
 }
 
+export function deleteState(psid: string): MaybePromise<void> {
+  return deleteRawState(getStateKey(psid));
+}
+
 export function writeState<T>(psid: string, value: T): MaybePromise<void> {
   const faceMemoryValue = value as {
     faceMemoryConsent?: { given?: boolean } | null;

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -317,8 +317,12 @@ async function handleEvent(
     : ctx.defaultLang;
   const state = await getOrCreateState(psid);
   const lang = state.preferredLang || localeLang || ctx.defaultLang;
+  const isInboundUserEvent = Boolean(
+    event.postback || (event.message && !event.message.is_echo)
+  );
 
   if (
+    isInboundUserEvent &&
     await handleMessengerConsentGate({
       psid,
       lang,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -34,10 +34,10 @@ import {
 import {
   FACE_MEMORY_CONSENT_NO,
   FACE_MEMORY_CONSENT_YES,
-  deleteFaceMemoryForUser,
   isFaceMemoryEnabled,
   updateConsentedFaceMemorySource,
 } from "./faceMemory";
+import { handleMessengerConsentGate } from "./consentService";
 import { normalizeLang, t, type Lang } from "./i18n";
 import { toLogUser, toUserKey } from "./privacy";
 import {
@@ -316,9 +316,25 @@ async function handleEvent(
     ? normalizeLang(senderLocale)
     : ctx.defaultLang;
   const state = await getOrCreateState(psid);
+  const lang = state.preferredLang || localeLang || ctx.defaultLang;
+
+  if (
+    await handleMessengerConsentGate({
+      psid,
+      lang,
+      text: event.message?.text,
+      payload: event.message?.quick_reply?.payload ?? event.postback?.payload,
+      state,
+      sendText: text => ctx.sendLoggedText(psid, text, reqId),
+      sendQuickReplies: (text, replies) =>
+        ctx.sendLoggedQuickReplies(psid, text, replies, reqId),
+    })
+  ) {
+    return;
+  }
+
   ctx.logIncomingMessage(psid, userId, event, reqId);
   ctx.logUserState(psid, userId, state, reqId, "handle_event");
-  const lang = state.preferredLang || localeLang || ctx.defaultLang;
 
   if (senderLocale && localeLang !== state.preferredLang) {
     await setPreferredLang(psid, localeLang);
@@ -440,22 +456,6 @@ async function handleMessageEvent(
   const text = message.text;
   const trimmedText = text?.trim();
   if (!trimmedText) {
-    return;
-  }
-
-  const normalizedDeleteText = trimmedText.toLocaleLowerCase("nl-BE");
-  if (
-    normalizedDeleteText === "verwijder mijn data" ||
-    normalizedDeleteText === "delete my data"
-  ) {
-    await deleteFaceMemoryForUser(input.psid);
-    await ctx.sendLoggedText(
-      input.psid,
-      input.lang === "en"
-        ? "Your retained photo and face-memory data have been deleted."
-        : "Je bewaarde foto en face-memory data zijn gewist.",
-      input.reqId
-    );
     return;
   }
 

--- a/server/_core/whatsappWebhook.ts
+++ b/server/_core/whatsappWebhook.ts
@@ -36,19 +36,6 @@ export async function processWhatsAppWebhookPayload(
     };
     const state = await Promise.resolve(getOrCreateState(event.senderId));
 
-    if (
-      await handleWhatsAppConsentGate({
-        event,
-        lang: context.lang,
-        state,
-        sendText: text => sendWhatsAppTextReply(event.senderId, text),
-        sendButtons: (text, options) =>
-          sendWhatsAppButtonsReply(event.senderId, text, options),
-      })
-    ) {
-      continue;
-    }
-
     console.log("[whatsapp webhook] normalized inbound event", {
       channel: event.channel,
       user: toLogUser(event.userId),
@@ -61,6 +48,19 @@ export async function processWhatsAppWebhookPayload(
     );
 
     try {
+      if (
+        await handleWhatsAppConsentGate({
+          event,
+          lang: context.lang,
+          state,
+          sendText: text => sendWhatsAppTextReply(event.senderId, text),
+          sendButtons: (text, options) =>
+            sendWhatsAppButtonsReply(event.senderId, text, options),
+        })
+      ) {
+        continue;
+      }
+
       if (await handleWhatsAppExperienceRouting(event)) {
         continue;
       }

--- a/server/_core/whatsappWebhook.ts
+++ b/server/_core/whatsappWebhook.ts
@@ -1,12 +1,13 @@
 import { normalizeLang, t } from "./i18n";
-import { setLastUserMessageAt } from "./messengerState";
+import { getOrCreateState, setLastUserMessageAt } from "./messengerState";
 import { toLogUser } from "./privacy";
+import { handleWhatsAppConsentGate } from "./consentService";
 import { extractWhatsAppEvents, logWhatsAppWebhookPayload } from "./inbound/whatsappInbound";
 import { handleWhatsAppImageEvent } from "./whatsappHandlers/imageHandler";
 import { handleWhatsAppInteractiveEvent } from "./whatsappHandlers/interactiveHandler";
 import { handleWhatsAppTextEvent } from "./whatsappHandlers/textHandler";
 import { handleWhatsAppExperienceRouting } from "./whatsappRouting";
-import { sendWhatsAppTextReply } from "./whatsappResponseService";
+import { sendWhatsAppButtonsReply, sendWhatsAppTextReply } from "./whatsappResponseService";
 import type { NormalizedWhatsAppEvent } from "./whatsappTypes";
 
 const DEFAULT_LANG = normalizeLang(process.env.DEFAULT_MESSENGER_LANG);
@@ -33,6 +34,20 @@ export async function processWhatsAppWebhookPayload(
       reqId: `${event.senderId}-${Date.now()}`,
       lang: DEFAULT_LANG,
     };
+    const state = await Promise.resolve(getOrCreateState(event.senderId));
+
+    if (
+      await handleWhatsAppConsentGate({
+        event,
+        lang: context.lang,
+        state,
+        sendText: text => sendWhatsAppTextReply(event.senderId, text),
+        sendButtons: (text, options) =>
+          sendWhatsAppButtonsReply(event.senderId, text, options),
+      })
+    ) {
+      continue;
+    }
 
     console.log("[whatsapp webhook] normalized inbound event", {
       channel: event.channel,

--- a/server/botFeatures.test.ts
+++ b/server/botFeatures.test.ts
@@ -30,10 +30,18 @@ vi.mock("./_core/messengerResponsesService", () => ({
 
 import { t } from "./_core/i18n";
 import {
-  processFacebookWebhookPayload,
+  processFacebookWebhookPayload as processFacebookWebhookPayloadBase,
   resetMessengerEventDedupe,
 } from "./_core/messengerWebhook";
 import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
+import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
+
+function processFacebookWebhookPayload(payload: unknown): Promise<void> {
+  return processConsentedFacebookWebhookPayload(
+    processFacebookWebhookPayloadBase,
+    payload
+  );
+}
 
 describe("bot features", () => {
   beforeEach(() => {

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -33,6 +33,7 @@ import {
   getState,
   resetStateStore,
 } from "./_core/messengerState";
+import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 
 describe("identity-ai-v1 routing", () => {
   let psidSeq = 0;
@@ -51,7 +52,7 @@ describe("identity-ai-v1 routing", () => {
   it("auto-start deep links send question 1 immediately without touching legacy style state", async () => {
     const psid = mkPsid("identity-ai-v1-deep-link-user");
 
-    await messengerWebhook.processFacebookWebhookPayload({
+    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
       entry: [
         {
           messaging: [
@@ -106,7 +107,7 @@ describe("identity-ai-v1 routing", () => {
   it("starts Identity AI V1 from a bare ref value like the m.me deep-link payload", async () => {
     const psid = mkPsid("identity-ai-v1-bare-ref-user");
 
-    await messengerWebhook.processFacebookWebhookPayload({
+    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
       entry: [
         {
           messaging: [
@@ -610,7 +611,7 @@ describe("identity-ai-v1 routing", () => {
   it("keeps mandatory routing order by letting the active game win over legacy commands", async () => {
     const psid = mkPsid("identity-ai-v1-routing-order-user");
 
-    await messengerWebhook.processFacebookWebhookPayload({
+    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
       entry: [
         {
           messaging: [
@@ -631,7 +632,7 @@ describe("identity-ai-v1 routing", () => {
     sendTextMock.mockClear();
     sendQuickRepliesMock.mockClear();
 
-    await messengerWebhook.processFacebookWebhookPayload({
+    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
       entry: [
         {
           messaging: [
@@ -1387,7 +1388,7 @@ describe("identity-ai-v1 routing", () => {
       });
 
     try {
-      await messengerWebhook.processFacebookWebhookPayload({
+      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
         entry: [
           {
             messaging: [
@@ -1405,7 +1406,7 @@ describe("identity-ai-v1 routing", () => {
         ],
       });
 
-      await messengerWebhook.processFacebookWebhookPayload({
+      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
         entry: [
           {
             messaging: [
@@ -1420,7 +1421,7 @@ describe("identity-ai-v1 routing", () => {
           },
         ],
       });
-      await messengerWebhook.processFacebookWebhookPayload({
+      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
         entry: [
           {
             messaging: [
@@ -1439,7 +1440,7 @@ describe("identity-ai-v1 routing", () => {
       sendTextMock.mockClear();
       sendQuickRepliesMock.mockClear();
 
-      await messengerWebhook.processFacebookWebhookPayload({
+      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
         entry: [
           {
             messaging: [
@@ -1458,7 +1459,7 @@ describe("identity-ai-v1 routing", () => {
       sendTextMock.mockClear();
       sendQuickRepliesMock.mockClear();
 
-      await messengerWebhook.processFacebookWebhookPayload({
+      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
         entry: [
           {
             messaging: [

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -194,7 +194,7 @@ describe("photo-first onboarding", () => {
     expect(userState?.lastSourceImageUpdatedAt).toEqual(expect.any(Number));
   });
 
-  it("deletes retained face-memory data via text command", async () => {
+  it("deletes retained face-memory data after confirmation", async () => {
     process.env.ENABLE_FACE_MEMORY = "true";
     const psid = "face-memory-delete-user";
 
@@ -228,16 +228,39 @@ describe("photo-first onboarding", () => {
       ],
     });
 
-    const userState = getState(anonymizePsid(psid));
-    expect(userState?.faceMemoryConsent).toBeNull();
-    expect(userState?.lastSourceImageUrl).toBeNull();
-    expect(userState?.lastPhotoUrl).toBeNull();
-    expect(userState?.pendingSourceImageDeleteUrl).toMatch(
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Weet je zeker dat je al je data wil verwijderen?"),
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "GDPR_DELETE_CONFIRM" }),
+        expect.objectContaining({ payload: "GDPR_DELETE_CANCEL" }),
+      ])
+    );
+    expect(getState(anonymizePsid(psid))?.lastSourceImageUrl).toMatch(
       /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
     );
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-face-memory-delete-confirm",
+                quick_reply: { payload: "GDPR_DELETE_CONFIRM" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const userState = getState(anonymizePsid(psid));
+    expect(userState).toBeNull();
     expect(sendTextMock).toHaveBeenCalledWith(
       psid,
-      "Je bewaarde foto en face-memory data zijn gewist."
+      "Je data is verwijderd. Als je opnieuw contact opneemt, vraag ik eerst opnieuw toestemming."
     );
   });
 

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -25,13 +25,24 @@ vi.mock("./_core/messengerApi", () => ({
   safeLog: safeLogMock,
 }));
 
-import { processFacebookWebhookPayload, resetMessengerEventDedupe } from "./_core/messengerWebhook";
+import {
+  processFacebookWebhookPayload as processFacebookWebhookPayloadBase,
+  resetMessengerEventDedupe,
+} from "./_core/messengerWebhook";
 import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
 import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 const originalEnableFaceMemory = process.env.ENABLE_FACE_MEMORY;
+
+function processFacebookWebhookPayload(payload: unknown): Promise<void> {
+  return processConsentedFacebookWebhookPayload(
+    processFacebookWebhookPayloadBase,
+    payload
+  );
+}
 
 describe("photo-first onboarding", () => {
   beforeAll(() => {

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -41,7 +41,7 @@ vi.mock("./_core/messengerResponsesService", () => ({
 }));
 
 import {
-  processFacebookWebhookPayload,
+  processFacebookWebhookPayload as processFacebookWebhookPayloadBase,
   resetMessengerEventDedupe,
 } from "./_core/messengerWebhook";
 import { t } from "./_core/i18n";
@@ -60,9 +60,17 @@ import {
 } from "./_core/webhookHelpers";
 import { getBotFeatures } from "./_core/bot/features";
 import { setSourceImageDnsLookupForTests } from "./_core/image-generation/sourceImageFetcher";
+import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
+
+function processFacebookWebhookPayload(payload: unknown): Promise<void> {
+  return processConsentedFacebookWebhookPayload(
+    processFacebookWebhookPayloadBase,
+    payload
+  );
+}
 
 function toUrlString(url: string | URL): string {
   return typeof url === "string" ? url : url.toString();

--- a/server/testConsentHelpers.ts
+++ b/server/testConsentHelpers.ts
@@ -1,0 +1,77 @@
+import { setConsentState } from "./_core/messengerState";
+
+function getMessengerSenderIds(payload: unknown): string[] {
+  const ids = new Set<string>();
+  const entries = (payload as { entry?: unknown[] })?.entry;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const events = (entry as { messaging?: unknown[] })?.messaging;
+    if (!Array.isArray(events)) {
+      continue;
+    }
+
+    for (const event of events) {
+      const senderId = (event as { sender?: { id?: unknown } })?.sender?.id;
+      if (typeof senderId === "string") {
+        ids.add(senderId);
+      }
+    }
+  }
+
+  return Array.from(ids);
+}
+
+function getWhatsAppSenderIds(payload: unknown): string[] {
+  const ids = new Set<string>();
+  const entries = (payload as { entry?: unknown[] })?.entry;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  for (const entry of entries) {
+    const changes = (entry as { changes?: unknown[] })?.changes;
+    if (!Array.isArray(changes)) {
+      continue;
+    }
+
+    for (const change of changes) {
+      const messages = (change as { value?: { messages?: unknown[] } })?.value
+        ?.messages;
+      if (!Array.isArray(messages)) {
+        continue;
+      }
+
+      for (const message of messages) {
+        const senderId = (message as { from?: unknown })?.from;
+        if (typeof senderId === "string") {
+          ids.add(senderId);
+        }
+      }
+    }
+  }
+
+  return Array.from(ids);
+}
+
+async function grantConsent(senderIds: string[]): Promise<void> {
+  await Promise.all(senderIds.map(senderId => setConsentState(senderId, true)));
+}
+
+export async function processConsentedFacebookWebhookPayload(
+  processPayload: (payload: unknown) => Promise<void>,
+  payload: unknown
+): Promise<void> {
+  await grantConsent(getMessengerSenderIds(payload));
+  await processPayload(payload);
+}
+
+export async function processConsentedWhatsAppWebhookPayload(
+  processPayload: (payload: unknown) => Promise<void>,
+  payload: unknown
+): Promise<void> {
+  await grantConsent(getWhatsAppSenderIds(payload));
+  await processPayload(payload);
+}

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -27,7 +27,7 @@ import {
   OpenAiImageGenerator,
 } from "./_core/imageService";
 import {
-  processWhatsAppWebhookPayload,
+  processWhatsAppWebhookPayload as processWhatsAppWebhookPayloadBase,
   resetMessengerEventDedupe,
 } from "./_core/messengerWebhook";
 import { t } from "./_core/i18n";
@@ -38,12 +38,20 @@ import {
   setFlowState,
 } from "./_core/messengerState";
 import { buildStateResponseText } from "./_core/stateResponseText";
+import { processConsentedWhatsAppWebhookPayload } from "./testConsentHelpers";
 
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 const originalAppBaseUrl = process.env.APP_BASE_URL;
 const originalAllowedHosts = process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
 const originalOpenAiKey = process.env.OPENAI_API_KEY;
+
+function processWhatsAppWebhookPayload(payload: unknown): Promise<void> {
+  return processConsentedWhatsAppWebhookPayload(
+    processWhatsAppWebhookPayloadBase,
+    payload
+  );
+}
 
 function createWhatsAppPayload(message: Record<string, unknown>) {
   return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now manage GDPR consent preferences on Messenger and WhatsApp
  * Added ability to request complete data deletion with confirmation prompts
  * Automatic removal of chat history and stored personal data upon deletion request
  * Multi-language support for consent and deletion workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->