### PR TITLE
Send restyle starter pills after consent

### DIFF
--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -109,6 +109,13 @@ function deleteCancelledText(lang: Lang): string {
   return lang === "en" ? "Deletion cancelled." : "Verwijderen geannuleerd.";
 }
 
+function messengerConsentAcceptedText(lang: Lang): string {
+  const command = deleteCommand(lang);
+  return lang === "en"
+    ? `You're all set ✅\nYou can delete your data anytime by typing '${command}'.`
+    : `Je bent klaar ✅\nJe kan je data altijd verwijderen door '${command}' te typen.`;
+}
+
 function consentReplies(lang: Lang): QuickReply[] {
   return [
     {
@@ -191,6 +198,7 @@ export async function handleMessengerConsentGate(
 ): Promise<boolean> {
   if (input.payload === GDPR_CONSENT_AGREE) {
     await Promise.resolve(setConsentState(input.psid, true));
+<<<<<<< HEAD
 function messengerConsentAcceptedText(lang: Lang): string {
   const command = deleteCommand(lang);
   return lang === "en"
@@ -203,6 +211,8 @@ export async function handleMessengerConsentGate(
 ): Promise<boolean> {
   if (input.payload === GDPR_CONSENT_AGREE) {
     await Promise.resolve(setConsentState(input.psid, true));
+=======
+>>>>>>> 99c6af5 (Set messenger consent flow state to awaiting style)
     await input.sendText(messengerConsentAcceptedText(input.lang));
     await input.sendRestyleStarterPills();
     return true;

--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -191,8 +191,22 @@ export async function handleMessengerConsentGate(
 ): Promise<boolean> {
   if (input.payload === GDPR_CONSENT_AGREE) {
     await Promise.resolve(setConsentState(input.psid, true));
-    await input.sendText(consentAcceptedText(input.lang));
+function messengerConsentAcceptedText(lang: Lang): string {
+  const command = deleteCommand(lang);
+  return lang === "en"
+    ? `You're all set ✅\nYou can delete your data anytime by typing '${command}'.`
+    : `Je bent klaar ✅\nJe kan je data altijd verwijderen door '${command}' te typen.`;
+}
+
+export async function handleMessengerConsentGate(
+  input: MessengerConsentGateInput
+): Promise<boolean> {
+  if (input.payload === GDPR_CONSENT_AGREE) {
+    await Promise.resolve(setConsentState(input.psid, true));
+    await input.sendText(messengerConsentAcceptedText(input.lang));
     await input.sendRestyleStarterPills();
+    return true;
+  }
     return true;
   }
 

--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -198,25 +198,8 @@ export async function handleMessengerConsentGate(
 ): Promise<boolean> {
   if (input.payload === GDPR_CONSENT_AGREE) {
     await Promise.resolve(setConsentState(input.psid, true));
-<<<<<<< HEAD
-function messengerConsentAcceptedText(lang: Lang): string {
-  const command = deleteCommand(lang);
-  return lang === "en"
-    ? `You're all set ✅\nYou can delete your data anytime by typing '${command}'.`
-    : `Je bent klaar ✅\nJe kan je data altijd verwijderen door '${command}' te typen.`;
-}
-
-export async function handleMessengerConsentGate(
-  input: MessengerConsentGateInput
-): Promise<boolean> {
-  if (input.payload === GDPR_CONSENT_AGREE) {
-    await Promise.resolve(setConsentState(input.psid, true));
-=======
->>>>>>> 99c6af5 (Set messenger consent flow state to awaiting style)
     await input.sendText(messengerConsentAcceptedText(input.lang));
     await input.sendRestyleStarterPills();
-    return true;
-  }
     return true;
   }
 

--- a/server/_core/consentService.ts
+++ b/server/_core/consentService.ts
@@ -34,6 +34,7 @@ type MessengerConsentGateInput = {
   state: MessengerUserState;
   sendText: (text: string) => Promise<void>;
   sendQuickReplies: (text: string, replies: QuickReply[]) => Promise<void>;
+  sendRestyleStarterPills: () => Promise<void>;
 };
 
 type WhatsAppConsentGateInput = {
@@ -190,10 +191,8 @@ export async function handleMessengerConsentGate(
 ): Promise<boolean> {
   if (input.payload === GDPR_CONSENT_AGREE) {
     await Promise.resolve(setConsentState(input.psid, true));
-    await input.sendQuickReplies(
-      consentAcceptedText(input.lang),
-      deleteNoticeReplies(input.lang)
-    );
+    await input.sendText(consentAcceptedText(input.lang));
+    await input.sendRestyleStarterPills();
     return true;
   }
 

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -340,8 +340,7 @@ function createTrackedHandlerContext(
     outcome: MessengerSendOutcome | undefined
   ) => void
 ): HandlerContext {
-  let trackedCtx: HandlerContext;
-  trackedCtx = {
+  const trackedCtx: HandlerContext = {
     ...ctx,
     createFeatureImageContext: (
       userPsid,

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -762,6 +762,7 @@ async function handleEvent(
           await trackedCtx.sendLoggedQuickReplies(psid, text, replies, reqId);
         },
         sendRestyleStarterPills: async () => {
+          await setFlowState(psid, "AWAITING_STYLE");
           await trackedCtx.sendStylePicker(psid, lang, reqId);
         },
       })

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -334,28 +334,14 @@ async function handleEntry(
   }
 }
 
-async function handleEvent(
+function createTrackedHandlerContext(
   ctx: HandlerContext,
-  event: FacebookWebhookEvent,
-  entryId?: string
-): Promise<void> {
-  const psid = event.sender?.id;
-  if (!psid) return;
-
-  const userId = toUserKey(psid);
-  const reqId = `${psid}-${Date.now()}`;
-  let responseSent = false;
-  const markResponseSent = () => {
-    responseSent = true;
-  };
-  const markResponseSentFromOutcome = (
+  markResponseSentFromOutcome: (
     outcome: MessengerSendOutcome | undefined
-  ) => {
-    if (outcome?.sent) {
-      markResponseSent();
-    }
-  };
-  const trackedCtx: HandlerContext = {
+  ) => void
+): HandlerContext {
+  let trackedCtx: HandlerContext;
+  trackedCtx = {
     ...ctx,
     createFeatureImageContext: (
       userPsid,
@@ -701,6 +687,32 @@ async function handleEvent(
       return outcome;
     },
   };
+
+  return trackedCtx;
+}
+
+async function handleEvent(
+  ctx: HandlerContext,
+  event: FacebookWebhookEvent,
+  entryId?: string
+): Promise<void> {
+  const psid = event.sender?.id;
+  if (!psid) return;
+
+  const userId = toUserKey(psid);
+  const reqId = `${psid}-${Date.now()}`;
+  let responseSent = false;
+  const markResponseSent = () => {
+    responseSent = true;
+  };
+  const markResponseSentFromOutcome = (
+    outcome: MessengerSendOutcome | undefined
+  ) => {
+    if (outcome?.sent) {
+      markResponseSent();
+    }
+  };
+  const trackedCtx = createTrackedHandlerContext(ctx, markResponseSentFromOutcome);
 
   if (!(await ctx.claimEventReplayOrLog(event, entryId, userId))) {
     return;

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -749,6 +749,9 @@ async function handleEvent(
         sendQuickReplies: async (text, replies) => {
           await trackedCtx.sendLoggedQuickReplies(psid, text, replies, reqId);
         },
+        sendRestyleStarterPills: async () => {
+          await trackedCtx.sendStylePicker(psid, lang, reqId);
+        },
       })
     ) {
       logMessengerWebhookTrace("selected_branch", {

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -167,6 +167,36 @@ function expectDistinctivePrompt(
   );
 }
 
+function installStoredSourcePromptFetchMock(
+  assertPrompt: (prompt: string) => void
+) {
+  process.env.OPENAI_API_KEY = "dummy-key";
+  process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+  process.env.SOURCE_IMAGE_ALLOWED_HOSTS = STORED_SOURCE_IMAGE_ALLOWED_HOSTS;
+
+  const fixture = Buffer.alloc(7000, 9);
+  const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "image/jpeg" }),
+        arrayBuffer: async () => fixture,
+      } as Response;
+    }
+
+    const formData = init?.body as FormData;
+    assertPrompt(String(formData.get("prompt")));
+
+    return {
+      ok: true,
+      json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+    } as Response;
+  });
+
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
 describe("OpenAi image-to-image proof", () => {
   beforeEach(() => {
     setSourceImageDnsLookupForTests(async () => [
@@ -251,38 +281,16 @@ describe("OpenAi image-to-image proof", () => {
   );
 
   it("uses the cyberpunk preset prompt for OpenAI edits", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = STORED_SOURCE_IMAGE_ALLOWED_HOSTS;
-
-    const fixture = Buffer.alloc(7000, 9);
-
-    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "image/jpeg" }),
-          arrayBuffer: async () => fixture,
-        } as Response;
-      }
-
-      const formData = init?.body as FormData;
-      expect(formData.get("prompt")).toContain(
+    const fetchMock = installStoredSourcePromptFetchMock(prompt => {
+      expect(prompt).toContain(
         "Transform this photo into a cyberpunk portrait"
       );
-      expect(formData.get("prompt")).toContain("neon signage glow");
-      expect(formData.get("prompt")).toContain("rain-slick reflections");
-      expect(formData.get("prompt")).toContain(
+      expect(prompt).toContain("neon signage glow");
+      expect(prompt).toContain("rain-slick reflections");
+      expect(prompt).toContain(
         "vivid palette of electric pink, cyan, ultraviolet, and toxic blue"
       );
-
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
     });
-
-    vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
     await generator.generate({
@@ -297,23 +305,7 @@ describe("OpenAi image-to-image proof", () => {
   });
 
   it("uses the Norman Blackwell preset prompt for OpenAI edits", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = STORED_SOURCE_IMAGE_ALLOWED_HOSTS;
-
-    const fixture = Buffer.alloc(7000, 9);
-
-    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "image/jpeg" }),
-          arrayBuffer: async () => fixture,
-        } as Response;
-      }
-
-      const formData = init?.body as FormData;
-      const prompt = String(formData.get("prompt"));
+    const fetchMock = installStoredSourcePromptFetchMock(prompt => {
       expect(prompt).toContain(
         "Reimagine this photo as a nostalgic mid-century American editorial illustration"
       );
@@ -324,14 +316,7 @@ describe("OpenAi image-to-image proof", () => {
       expect(prompt).toContain(
         "polished finish of a vintage family magazine cover from the 1940s or 1950s"
       );
-
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
     });
-
-    vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
     await generator.generate({
@@ -346,23 +331,7 @@ describe("OpenAi image-to-image proof", () => {
   });
 
   it("uses the oil-paint preset prompt for OpenAI edits", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    process.env.SOURCE_IMAGE_ALLOWED_HOSTS = STORED_SOURCE_IMAGE_ALLOWED_HOSTS;
-
-    const fixture = Buffer.alloc(7000, 9);
-
-    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
-      if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "image/jpeg" }),
-          arrayBuffer: async () => fixture,
-        } as Response;
-      }
-
-      const formData = init?.body as FormData;
-      const prompt = String(formData.get("prompt"));
+    const fetchMock = installStoredSourcePromptFetchMock(prompt => {
       expect(prompt).toContain(
         "Render this portrait as a classical oil painting"
       );
@@ -372,14 +341,7 @@ describe("OpenAi image-to-image proof", () => {
       expect(prompt).toContain(
         "rich museum-grade palette of umber, ochre, crimson, and deep blue"
       );
-
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
     });
-
-    vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
     await generator.generate({

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -573,6 +573,47 @@ describe("messenger webhook dedupe", () => {
     );
   });
 
+  it("continues with restyle starter pills after consent is granted", async () => {
+    const psid = "fresh-consent-accepted-user";
+
+    await processFacebookWebhookPayloadBase({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              timestamp: 1730000000555,
+              message: {
+                mid: "mid-fresh-consent-accepted",
+                quick_reply: { payload: "GDPR_CONSENT_AGREE" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(getState(psid)?.consentGiven).toBe(true);
+    expect(sendTextMock).toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Je bent klaar")
+    );
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      t("nl", "styleCategoryPicker"),
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "STYLE_CATEGORY_ILLUSTRATED" }),
+        expect.objectContaining({ payload: "STYLE_CATEGORY_ATMOSPHERE" }),
+        expect.objectContaining({ payload: "STYLE_CATEGORY_BOLD" }),
+      ])
+    );
+    expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Je bent klaar"),
+      expect.any(Array)
+    );
+  });
+
   it("opens the Messenger response window before postback routing", async () => {
     const psid = "fresh-postback-window-user";
     const timestamp = 1730000000789;

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -594,6 +594,7 @@ describe("messenger webhook dedupe", () => {
     });
 
     expect(getState(psid)?.consentGiven).toBe(true);
+    expect(getState(psid)?.stage).toBe("AWAITING_STYLE");
     expect(sendTextMock).toHaveBeenCalledWith(
       psid,
       expect.stringContaining("Je bent klaar")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GDPR consent acknowledgment flow: users now receive a distinct confirmation message followed by style-selection options to guide the next step.

* **Refactor**
  * Internal event handling streamlined to simplify request processing and improve reliability of downstream UI updates.

* **Tests**
  * Added end-to-end test for the consent flow verifying confirmation message and style picker display.
  * Consolidated image-service test setup with a shared fetch stub for OpenAI/image requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->