### PR TITLE
test: centralize webhook consent setup helpers

### DIFF
--- a/server/botFeatures.test.ts
+++ b/server/botFeatures.test.ts
@@ -36,12 +36,9 @@ import {
 import { anonymizePsid, getState, resetStateStore } from "./_core/messengerState";
 import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 
-function processFacebookWebhookPayload(payload: unknown): Promise<void> {
-  return processConsentedFacebookWebhookPayload(
-    processFacebookWebhookPayloadBase,
-    payload
-  );
-}
+const processFacebookWebhookPayload = processConsentedFacebookWebhookPayload(
+  processFacebookWebhookPayloadBase
+);
 
 describe("bot features", () => {
   beforeEach(() => {

--- a/server/experienceRouting.test.ts
+++ b/server/experienceRouting.test.ts
@@ -35,6 +35,10 @@ import {
 } from "./_core/messengerState";
 import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 
+const processFacebookWebhookPayload = processConsentedFacebookWebhookPayload(
+  messengerWebhook.processFacebookWebhookPayload
+);
+
 describe("identity-ai-v1 routing", () => {
   let psidSeq = 0;
   const mkPsid = (base: string) => `${base}-${++psidSeq}`;
@@ -52,7 +56,7 @@ describe("identity-ai-v1 routing", () => {
   it("auto-start deep links send question 1 immediately without touching legacy style state", async () => {
     const psid = mkPsid("identity-ai-v1-deep-link-user");
 
-    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+    await processFacebookWebhookPayload({
       entry: [
         {
           messaging: [
@@ -107,7 +111,7 @@ describe("identity-ai-v1 routing", () => {
   it("starts Identity AI V1 from a bare ref value like the m.me deep-link payload", async () => {
     const psid = mkPsid("identity-ai-v1-bare-ref-user");
 
-    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+    await processFacebookWebhookPayload({
       entry: [
         {
           messaging: [
@@ -611,7 +615,7 @@ describe("identity-ai-v1 routing", () => {
   it("keeps mandatory routing order by letting the active game win over legacy commands", async () => {
     const psid = mkPsid("identity-ai-v1-routing-order-user");
 
-    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+    await processFacebookWebhookPayload({
       entry: [
         {
           messaging: [
@@ -632,7 +636,7 @@ describe("identity-ai-v1 routing", () => {
     sendTextMock.mockClear();
     sendQuickRepliesMock.mockClear();
 
-    await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+    await processFacebookWebhookPayload({
       entry: [
         {
           messaging: [
@@ -1388,7 +1392,7 @@ describe("identity-ai-v1 routing", () => {
       });
 
     try {
-      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+      await processFacebookWebhookPayload({
         entry: [
           {
             messaging: [
@@ -1406,7 +1410,7 @@ describe("identity-ai-v1 routing", () => {
         ],
       });
 
-      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+      await processFacebookWebhookPayload({
         entry: [
           {
             messaging: [
@@ -1421,7 +1425,7 @@ describe("identity-ai-v1 routing", () => {
           },
         ],
       });
-      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+      await processFacebookWebhookPayload({
         entry: [
           {
             messaging: [
@@ -1440,7 +1444,7 @@ describe("identity-ai-v1 routing", () => {
       sendTextMock.mockClear();
       sendQuickRepliesMock.mockClear();
 
-      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+      await processFacebookWebhookPayload({
         entry: [
           {
             messaging: [
@@ -1459,7 +1463,7 @@ describe("identity-ai-v1 routing", () => {
       sendTextMock.mockClear();
       sendQuickRepliesMock.mockClear();
 
-      await processConsentedFacebookWebhookPayload(messengerWebhook.processFacebookWebhookPayload, {
+      await processFacebookWebhookPayload({
         entry: [
           {
             messaging: [

--- a/server/messengerWebhook.photoFirst.test.ts
+++ b/server/messengerWebhook.photoFirst.test.ts
@@ -37,12 +37,9 @@ const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 const originalEnableFaceMemory = process.env.ENABLE_FACE_MEMORY;
 
-function processFacebookWebhookPayload(payload: unknown): Promise<void> {
-  return processConsentedFacebookWebhookPayload(
-    processFacebookWebhookPayloadBase,
-    payload
-  );
-}
+const processFacebookWebhookPayload = processConsentedFacebookWebhookPayload(
+  processFacebookWebhookPayloadBase
+);
 
 describe("photo-first onboarding", () => {
   beforeAll(() => {

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -65,12 +65,9 @@ import { processConsentedFacebookWebhookPayload } from "./testConsentHelpers";
 const TEST_PEPPER = "ci-test-pepper";
 const originalPrivacyPepper = process.env.PRIVACY_PEPPER;
 
-function processFacebookWebhookPayload(payload: unknown): Promise<void> {
-  return processConsentedFacebookWebhookPayload(
-    processFacebookWebhookPayloadBase,
-    payload
-  );
-}
+const processFacebookWebhookPayload = processConsentedFacebookWebhookPayload(
+  processFacebookWebhookPayloadBase
+);
 
 function toUrlString(url: string | URL): string {
   return typeof url === "string" ? url : url.toString();

--- a/server/testConsentHelpers.ts
+++ b/server/testConsentHelpers.ts
@@ -1,59 +1,55 @@
 import { setConsentState } from "./_core/messengerState";
 
-function getMessengerSenderIds(payload: unknown): string[] {
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function collectSenderIds(
+  values: unknown[],
+  getSenderId: (value: unknown) => unknown
+): string[] {
   const ids = new Set<string>();
-  const entries = (payload as { entry?: unknown[] })?.entry;
-  if (!Array.isArray(entries)) {
-    return [];
-  }
 
-  for (const entry of entries) {
-    const events = (entry as { messaging?: unknown[] })?.messaging;
-    if (!Array.isArray(events)) {
-      continue;
-    }
-
-    for (const event of events) {
-      const senderId = (event as { sender?: { id?: unknown } })?.sender?.id;
-      if (typeof senderId === "string") {
-        ids.add(senderId);
-      }
+  for (const value of values) {
+    const senderId = getSenderId(value);
+    if (typeof senderId === "string") {
+      ids.add(senderId);
     }
   }
 
   return Array.from(ids);
 }
 
+function getPayloadEntries(payload: unknown): unknown[] {
+  return asArray((payload as { entry?: unknown[] })?.entry);
+}
+
+function getMessengerEvents(payload: unknown): unknown[] {
+  return getPayloadEntries(payload).flatMap(entry =>
+    asArray((entry as { messaging?: unknown[] })?.messaging)
+  );
+}
+
+function getWhatsAppMessages(payload: unknown): unknown[] {
+  return getPayloadEntries(payload)
+    .flatMap(entry => asArray((entry as { changes?: unknown[] })?.changes))
+    .flatMap(change =>
+      asArray((change as { value?: { messages?: unknown[] } })?.value?.messages)
+    );
+}
+
+function getMessengerSenderIds(payload: unknown): string[] {
+  return collectSenderIds(
+    getMessengerEvents(payload),
+    event => (event as { sender?: { id?: unknown } })?.sender?.id
+  );
+}
+
 function getWhatsAppSenderIds(payload: unknown): string[] {
-  const ids = new Set<string>();
-  const entries = (payload as { entry?: unknown[] })?.entry;
-  if (!Array.isArray(entries)) {
-    return [];
-  }
-
-  for (const entry of entries) {
-    const changes = (entry as { changes?: unknown[] })?.changes;
-    if (!Array.isArray(changes)) {
-      continue;
-    }
-
-    for (const change of changes) {
-      const messages = (change as { value?: { messages?: unknown[] } })?.value
-        ?.messages;
-      if (!Array.isArray(messages)) {
-        continue;
-      }
-
-      for (const message of messages) {
-        const senderId = (message as { from?: unknown })?.from;
-        if (typeof senderId === "string") {
-          ids.add(senderId);
-        }
-      }
-    }
-  }
-
-  return Array.from(ids);
+  return collectSenderIds(
+    getWhatsAppMessages(payload),
+    message => (message as { from?: unknown })?.from
+  );
 }
 
 async function grantConsent(senderIds: string[]): Promise<void> {
@@ -70,7 +66,7 @@ export function processConsentedFacebookWebhookPayload(
   payload: unknown
 ): Promise<void>;
 export function processConsentedFacebookWebhookPayload(
-  processPayload: (payload: unknown) => Promise<void>,
+  processPayload: WebhookPayloadProcessor,
   payload?: unknown
 ): Promise<void> | WebhookPayloadProcessor {
   async function processConsentedPayload(nextPayload: unknown): Promise<void> {

--- a/server/testConsentHelpers.ts
+++ b/server/testConsentHelpers.ts
@@ -57,49 +57,39 @@ async function grantConsent(senderIds: string[]): Promise<void> {
 }
 
 type WebhookPayloadProcessor = (payload: unknown) => Promise<void>;
+type SenderIdExtractor = (payload: unknown) => string[];
 
-export function processConsentedFacebookWebhookPayload(
-  processPayload: WebhookPayloadProcessor
-): WebhookPayloadProcessor;
-export function processConsentedFacebookWebhookPayload(
-  processPayload: WebhookPayloadProcessor,
-  payload: unknown
-): Promise<void>;
-export function processConsentedFacebookWebhookPayload(
-  processPayload: WebhookPayloadProcessor,
-  payload?: unknown
-): Promise<void> | WebhookPayloadProcessor {
-  async function processConsentedPayload(nextPayload: unknown): Promise<void> {
-    await grantConsent(getMessengerSenderIds(nextPayload));
-    await processPayload(nextPayload);
+function createConsentedWebhookPayloadProcessor(
+  getSenderIds: SenderIdExtractor
+) {
+  function processConsentedPayload(
+    processPayload: WebhookPayloadProcessor
+  ): WebhookPayloadProcessor;
+  function processConsentedPayload(
+    processPayload: WebhookPayloadProcessor,
+    payload: unknown
+  ): Promise<void>;
+  function processConsentedPayload(
+    processPayload: WebhookPayloadProcessor,
+    payload?: unknown
+  ): Promise<void> | WebhookPayloadProcessor {
+    const processWithConsent: WebhookPayloadProcessor = async nextPayload => {
+      await grantConsent(getSenderIds(nextPayload));
+      await processPayload(nextPayload);
+    };
+
+    if (payload === undefined) {
+      return processWithConsent;
+    }
+
+    return processWithConsent(payload);
   }
 
-  if (arguments.length === 1) {
-    return processConsentedPayload;
-  }
-
-  return processConsentedPayload(payload);
+  return processConsentedPayload;
 }
 
-export function processConsentedWhatsAppWebhookPayload(
-  processPayload: WebhookPayloadProcessor
-): WebhookPayloadProcessor;
-export function processConsentedWhatsAppWebhookPayload(
-  processPayload: WebhookPayloadProcessor,
-  payload: unknown
-): Promise<void>;
-export function processConsentedWhatsAppWebhookPayload(
-  processPayload: WebhookPayloadProcessor,
-  payload?: unknown
-): Promise<void> | WebhookPayloadProcessor {
-  async function processConsentedPayload(nextPayload: unknown): Promise<void> {
-    await grantConsent(getWhatsAppSenderIds(nextPayload));
-    await processPayload(nextPayload);
-  }
+export const processConsentedFacebookWebhookPayload =
+  createConsentedWebhookPayloadProcessor(getMessengerSenderIds);
 
-  if (arguments.length === 1) {
-    return processConsentedPayload;
-  }
-
-  return processConsentedPayload(payload);
-}
+export const processConsentedWhatsAppWebhookPayload =
+  createConsentedWebhookPayloadProcessor(getWhatsAppSenderIds);

--- a/server/testConsentHelpers.ts
+++ b/server/testConsentHelpers.ts
@@ -60,18 +60,50 @@ async function grantConsent(senderIds: string[]): Promise<void> {
   await Promise.all(senderIds.map(senderId => setConsentState(senderId, true)));
 }
 
-export async function processConsentedFacebookWebhookPayload(
-  processPayload: (payload: unknown) => Promise<void>,
+type WebhookPayloadProcessor = (payload: unknown) => Promise<void>;
+
+export function processConsentedFacebookWebhookPayload(
+  processPayload: WebhookPayloadProcessor
+): WebhookPayloadProcessor;
+export function processConsentedFacebookWebhookPayload(
+  processPayload: WebhookPayloadProcessor,
   payload: unknown
-): Promise<void> {
-  await grantConsent(getMessengerSenderIds(payload));
-  await processPayload(payload);
+): Promise<void>;
+export function processConsentedFacebookWebhookPayload(
+  processPayload: (payload: unknown) => Promise<void>,
+  payload?: unknown
+): Promise<void> | WebhookPayloadProcessor {
+  async function processConsentedPayload(nextPayload: unknown): Promise<void> {
+    await grantConsent(getMessengerSenderIds(nextPayload));
+    await processPayload(nextPayload);
+  }
+
+  if (arguments.length === 1) {
+    return processConsentedPayload;
+  }
+
+  return processConsentedPayload(payload);
 }
 
-export async function processConsentedWhatsAppWebhookPayload(
-  processPayload: (payload: unknown) => Promise<void>,
+export function processConsentedWhatsAppWebhookPayload(
+  processPayload: WebhookPayloadProcessor
+): WebhookPayloadProcessor;
+export function processConsentedWhatsAppWebhookPayload(
+  processPayload: WebhookPayloadProcessor,
   payload: unknown
-): Promise<void> {
-  await grantConsent(getWhatsAppSenderIds(payload));
-  await processPayload(payload);
+): Promise<void>;
+export function processConsentedWhatsAppWebhookPayload(
+  processPayload: WebhookPayloadProcessor,
+  payload?: unknown
+): Promise<void> | WebhookPayloadProcessor {
+  async function processConsentedPayload(nextPayload: unknown): Promise<void> {
+    await grantConsent(getWhatsAppSenderIds(nextPayload));
+    await processPayload(nextPayload);
+  }
+
+  if (arguments.length === 1) {
+    return processConsentedPayload;
+  }
+
+  return processConsentedPayload(payload);
 }

--- a/server/whatsappWebhook.test.ts
+++ b/server/whatsappWebhook.test.ts
@@ -46,12 +46,9 @@ const originalAppBaseUrl = process.env.APP_BASE_URL;
 const originalAllowedHosts = process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
 const originalOpenAiKey = process.env.OPENAI_API_KEY;
 
-function processWhatsAppWebhookPayload(payload: unknown): Promise<void> {
-  return processConsentedWhatsAppWebhookPayload(
-    processWhatsAppWebhookPayloadBase,
-    payload
-  );
-}
+const processWhatsAppWebhookPayload = processConsentedWhatsAppWebhookPayload(
+  processWhatsAppWebhookPayloadBase
+);
 
 function createWhatsAppPayload(message: Record<string, unknown>) {
   return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored webhook payload test helpers to support both immediate execution and pre-bound (partial application) usage; updated tests to use the simplified invocation without changing behavior.
  * Added shared extraction utilities to standardize payload flattening and deduplication.

* **Refactor**
  * Introduced a reusable test processor type and reorganized consent-processing helpers for clearer, more flexible test flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->