### PR TITLE
Address provider logging and OpenAI fetch-mock nits

### DIFF
--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -31,8 +31,11 @@ import {
   MissingAppBaseUrlError,
   MissingObjectStorageConfigError,
 } from "./image-generation/imageServiceErrors";
+import { createLogger } from "./logger";
 
-export type ImageProvider = "openai-images";
+const OPENAI_IMAGES_PROVIDER = "openai-images" as const;
+
+export type ImageProvider = typeof OPENAI_IMAGES_PROVIDER;
 
 interface ImageGenerator {
   generate(input: {
@@ -100,15 +103,15 @@ export function getGeneratorStartupConfig(): {
 function getImageProvider(): ImageProvider {
   const configured = process.env.IMAGE_PROVIDER?.trim();
   if (!configured) {
-    return "openai-images";
+    return OPENAI_IMAGES_PROVIDER;
   }
 
-  if (configured === "openai-images") {
+  if (configured === OPENAI_IMAGES_PROVIDER) {
     return configured;
   }
 
   throw new Error(
-    `Unsupported IMAGE_PROVIDER "${configured}". Expected "openai-images".`
+    `Unsupported IMAGE_PROVIDER "${configured}". Expected "${OPENAI_IMAGES_PROVIDER}".`
   );
 }
 
@@ -140,10 +143,26 @@ async function prepareGenerationInput(
   logSourceImageFetchStart(input);
 
   return {
-    hasSourceImage: Boolean(input.sourceImageUrl || input.sourceImageData),
+    hasSourceImage: computeHasSourceImage(input),
     prompt: buildStylePrompt(input.style, input.promptHint),
     sourceImage: await resolveStoredSourceImage(input),
   };
+}
+
+function computeHasSourceImage(input: GeneratorInput): boolean {
+  return Boolean(input.sourceImageUrl || input.sourceImageData);
+}
+
+function logImageProviderUsed(
+  input: GeneratorInput,
+  provider: ImageProvider,
+  hasSourceImage: boolean
+): void {
+  createLogger({ reqId: input.reqId }).info({
+    msg: "image_provider_used",
+    provider,
+    hasSourceImage,
+  });
 }
 
 export class OpenAiImageGenerator implements ImageGenerator {
@@ -168,7 +187,9 @@ export class OpenAiImageGenerator implements ImageGenerator {
     }
 
     try {
+      const provider = getImageProvider();
       const preparedInput = await prepareGenerationInput(input);
+      logImageProviderUsed(input, provider, preparedInput.hasSourceImage);
       const sourceImage = preparedInput.sourceImage;
       partialMetrics.fbImageFetchMs = sourceImage.fbImageFetchMs;
 

--- a/server/imageService.proof.test.ts
+++ b/server/imageService.proof.test.ts
@@ -28,6 +28,46 @@ function createStoredSourceImageInput(input: {
   };
 }
 
+function createOpenAiEditsFetchMock(options?: {
+  sourceImageFixture?: Buffer;
+  failuresBeforeSuccess?: number;
+  payload?: { data: Array<{ b64_json: string }> };
+  failureFactory?: (attempt: number) => Error;
+}) {
+  const sourceImageFixture = options?.sourceImageFixture ?? Buffer.alloc(7000, 9);
+  const failuresBeforeSuccess = options?.failuresBeforeSuccess ?? 0;
+  const payload = options?.payload ?? {
+    data: [{ b64_json: GENERATED_IMAGE_BASE64 }],
+  };
+  let openAiCallCount = 0;
+
+  const fetchMock = vi.fn(async (url: string | URL) => {
+    if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
+      return {
+        ok: true,
+        headers: new Headers({ "content-type": "image/jpeg" }),
+        arrayBuffer: async () => sourceImageFixture,
+      } as Response;
+    }
+
+    expect(toUrlString(url)).toBe("https://api.openai.com/v1/images/edits");
+    openAiCallCount += 1;
+    if (openAiCallCount <= failuresBeforeSuccess) {
+      const failure =
+        options?.failureFactory?.(openAiCallCount) ??
+        Object.assign(new Error("request failed"), { name: "AbortError" });
+      throw failure;
+    }
+
+    return {
+      ok: true,
+      json: async () => payload,
+    } as Response;
+  });
+
+  return { fetchMock, getOpenAiCallCount: () => openAiCallCount };
+}
+
 type StylePromptCase = {
   style:
     | "caricature"
@@ -933,28 +973,13 @@ describe("OpenAi image-to-image proof", () => {
     process.env.OPENAI_IMAGE_TIMEOUT_MS = "5";
     process.env.SOURCE_IMAGE_ALLOWED_HOSTS = STORED_SOURCE_IMAGE_ALLOWED_HOSTS;
 
-    const fixture = Buffer.alloc(7000, 9);
-    let openAiCallCount = 0;
-    const fetchMock = vi.fn(async (url: string | URL) => {
-      if (toUrlString(url) === STORED_SOURCE_IMAGE_URL) {
-        return {
-          ok: true,
-          headers: new Headers({ "content-type": "image/jpeg" }),
-          arrayBuffer: async () => fixture,
-        } as Response;
-      }
-
-      openAiCallCount += 1;
-      if (openAiCallCount === 1) {
+    const { fetchMock } = createOpenAiEditsFetchMock({
+      failuresBeforeSuccess: 1,
+      failureFactory: () => {
         const abortError = new Error("request aborted");
         abortError.name = "AbortError";
-        throw abortError;
-      }
-
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+        return abortError;
+      },
     });
 
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
### Motivation
- Fix two nits reported around image provider logging semantics and duplicated OpenAI edits mock setup in tests by centralizing the provider literal and consolidating source-image bookkeeping.

### Description
- Introduced `OPENAI_IMAGES_PROVIDER` and derived `ImageProvider` from it, and updated `getImageProvider()` to use the constant and include it in the error message.
- Extracted `computeHasSourceImage()` and used it from `prepareGenerationInput()` to avoid repeated `hasSourceImage` computation.
- Added `logImageProviderUsed()` (uses `createLogger`) and call it from `OpenAiImageGenerator.generate()` with the resolved provider and `hasSourceImage` to produce a consistent `image_provider_used` log entry.
- Added `createOpenAiEditsFetchMock()` test helper to `server/imageService.proof.test.ts` and refactored the timeout-retry test to use the helper for clearer, reusable OpenAI fetch mocking.

### Testing
- Ran `pnpm vitest run server/imageProvider.test.ts server/imageService.proof.test.ts` and all tests passed (2 test files, 33 tests total).
- Ran `pnpm check` (`tsc --noEmit`) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee396670588325b4e54d4602982f71)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored image provider implementation and centralized source image detection logic
  * Enhanced observability with logging that records image provider usage and source image presence per request

* **Tests**
  * Improved test infrastructure with reusable mock helpers for image retrieval and editing scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->