### PR TITLE
Codex/client chunk splitting

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,22 +1,30 @@
 import Footer from "./components/Footer";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import NotFound from "@/pages/NotFound";
+import { lazy, Suspense } from "react";
 import { Route, Switch } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
-import Home from "./pages/Home";
-import Terms from "./pages/Terms";
+
+const Home = lazy(() => import("./pages/Home"));
+const NotFound = lazy(() => import("./pages/NotFound"));
+const Terms = lazy(() => import("./pages/Terms"));
+
+function RouteFallback() {
+  return <div className="min-h-full bg-background" />;
+}
 
 function Router() {
   return (
-    <Switch>
-      <Route path={"/terms"} component={Terms} />
-      <Route path={"/:?"} component={Home} />
-      <Route path={"/404"} component={NotFound} />
-      {/* Final fallback route */}
-      <Route component={NotFound} />
-    </Switch>
+    <Suspense fallback={<RouteFallback />}>
+      <Switch>
+        <Route path={"/terms"} component={Terms} />
+        <Route path={"/:?"} component={Home} />
+        <Route path={"/404"} component={NotFound} />
+        {/* Final fallback route */}
+        <Route component={NotFound} />
+      </Switch>
+    </Suspense>
   );
 }
 

--- a/server/_core/activeExperience.ts
+++ b/server/_core/activeExperience.ts
@@ -1,4 +1,4 @@
-export type ActiveExperienceStatus =
+type ActiveExperienceStatus =
   | "started"
   | "in_progress"
   | "resolving"

--- a/server/_core/entryIntent.ts
+++ b/server/_core/entryIntent.ts
@@ -1,8 +1,8 @@
 import type { BotChannel } from "./normalizedInboundMessage";
 
-export type EntryMode = "auto_start" | "confirm_first";
+type EntryMode = "auto_start" | "confirm_first";
 
-export type EntrySourceType =
+type EntrySourceType =
   | "deep_link"
   | "postback"
   | "organic_message"
@@ -10,7 +10,7 @@ export type EntrySourceType =
   | "ad"
   | "unknown";
 
-export type ExperienceType = "identity_game";
+type ExperienceType = "identity_game";
 
 export type EntryIntent = {
   sourceChannel: BotChannel;

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -234,7 +234,3 @@ export function createImageGenerator(provider: ImageProvider = getImageProvider(
 } {
   return { mode: provider, generator: new OpenAiImageGenerator() };
 }
-
-export {
-  getGenerationMetrics,
-};

--- a/server/_core/messengerQuota.ts
+++ b/server/_core/messengerQuota.ts
@@ -1,4 +1,5 @@
-import { getDayKey, getOrCreateState, type MessengerUserState } from "./messengerState";
+import { getDayKey } from "./messengerStateNormalization";
+import { getOrCreateState, type MessengerUserState } from "./messengerState";
 import { updateStoredState } from "./stateStore";
 
 const FREE_DAILY_LIMIT = 3;

--- a/server/_core/messengerState.ts
+++ b/server/_core/messengerState.ts
@@ -13,7 +13,6 @@ import {
   type MaybePromise,
 } from "./stateStore";
 import { toUserKey } from "./privacy";
-import { getDayKey } from "./messengerStateNormalization";
 import {
   getOrCreatePersistedState,
   getPersistedState,
@@ -109,8 +108,6 @@ export function getQuickRepliesForState(state: ConversationState): StateQuickRep
 export function anonymizePsid(psid: string): string {
   return toUserKey(psid);
 }
-
-export { getDayKey };
 
 function getMessengerResponseWindowMs(): number {
   const configured = Number(process.env.MESSENGER_RESPONSE_WINDOW_MS);

--- a/server/_core/messengerStateNormalization.ts
+++ b/server/_core/messengerStateNormalization.ts
@@ -108,6 +108,103 @@ function resolveLegacyStateFields(
   return { stage, lastPhoto, selectedStyle, lastGeneratedUrl };
 }
 
+function resolveConsentState(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState
+): Pick<
+  MessengerUserState,
+  "consentGiven" | "consentTimestamp" | "pendingDeleteConfirm" | "hasSeenIntro"
+> {
+  return {
+    consentGiven: value?.consentGiven ?? fallback.consentGiven,
+    consentTimestamp: value?.consentTimestamp ?? fallback.consentTimestamp,
+    pendingDeleteConfirm:
+      value?.pendingDeleteConfirm ?? fallback.pendingDeleteConfirm,
+    hasSeenIntro: value?.hasSeenIntro ?? fallback.hasSeenIntro,
+  };
+}
+
+function resolveConversationContext(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState
+): Pick<
+  MessengerUserState,
+  "lastEntryIntent" | "activeExperience" | "lastUserMessageAt"
+> {
+  return {
+    lastEntryIntent: value?.lastEntryIntent ?? fallback.lastEntryIntent,
+    activeExperience: value?.activeExperience ?? fallback.activeExperience,
+    lastUserMessageAt: value?.lastUserMessageAt ?? fallback.lastUserMessageAt,
+  };
+}
+
+function resolvePhotoAndStyleState(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState,
+  legacyFields: Pick<LegacyStateFields, "lastPhoto" | "selectedStyle">
+): Pick<
+  MessengerUserState,
+  | "lastPhotoUrl"
+  | "lastPhoto"
+  | "lastPhotoSource"
+  | "selectedStyle"
+  | "chosenStyle"
+  | "selectedStyleCategory"
+> {
+  const { lastPhoto, selectedStyle } = legacyFields;
+
+  return {
+    lastPhotoUrl: lastPhoto,
+    lastPhoto,
+    lastPhotoSource: value?.lastPhotoSource ?? fallback.lastPhotoSource,
+    selectedStyle,
+    chosenStyle: selectedStyle,
+    selectedStyleCategory:
+      value?.selectedStyleCategory ?? fallback.selectedStyleCategory,
+  };
+}
+
+function resolveGeneratedImageState(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState,
+  lastGeneratedUrl: LegacyStateFields["lastGeneratedUrl"]
+): Pick<MessengerUserState, "lastImageUrl" | "lastGeneratedUrl"> {
+  return {
+    lastImageUrl: value?.lastImageUrl ?? lastGeneratedUrl ?? fallback.lastImageUrl,
+    lastGeneratedUrl,
+  };
+}
+
+function resolveSourceImageState(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState
+): Pick<
+  MessengerUserState,
+  | "faceMemoryConsent"
+  | "lastSourceImageUrl"
+  | "lastSourceImageUpdatedAt"
+  | "pendingSourceImageDeleteUrl"
+> {
+  return {
+    faceMemoryConsent: value?.faceMemoryConsent ?? fallback.faceMemoryConsent,
+    lastSourceImageUrl: value?.lastSourceImageUrl ?? fallback.lastSourceImageUrl,
+    lastSourceImageUpdatedAt:
+      value?.lastSourceImageUpdatedAt ?? fallback.lastSourceImageUpdatedAt,
+    pendingSourceImageDeleteUrl:
+      value?.pendingSourceImageDeleteUrl ?? fallback.pendingSourceImageDeleteUrl,
+  };
+}
+
+function resolveQuotaState(
+  value: PartialState | null | undefined,
+  fallback: MessengerUserState
+): MessengerUserState["quota"] {
+  return {
+    dayKey: value?.quota?.dayKey ?? fallback.quota.dayKey,
+    count: value?.quota?.count ?? fallback.quota.count,
+  };
+}
+
 function applyNormalizedStateShape(
   value: PartialState | null | undefined,
   base: StateNormalizationBase,
@@ -121,35 +218,14 @@ function applyNormalizedStateShape(
     ...value,
     psid: resolvedPsid,
     userKey: value?.userKey ?? fallback.userKey,
-    consentGiven: value?.consentGiven ?? fallback.consentGiven,
-    consentTimestamp: value?.consentTimestamp ?? fallback.consentTimestamp,
-    pendingDeleteConfirm:
-      value?.pendingDeleteConfirm ?? fallback.pendingDeleteConfirm,
-    hasSeenIntro: value?.hasSeenIntro ?? fallback.hasSeenIntro,
+    ...resolveConsentState(value, fallback),
     stage,
     state: stage,
-    lastEntryIntent: value?.lastEntryIntent ?? fallback.lastEntryIntent,
-    activeExperience: value?.activeExperience ?? fallback.activeExperience,
-    lastUserMessageAt: value?.lastUserMessageAt ?? fallback.lastUserMessageAt,
-    lastPhotoUrl: lastPhoto,
-    lastPhoto,
-    lastPhotoSource: value?.lastPhotoSource ?? fallback.lastPhotoSource,
-    selectedStyle,
-    chosenStyle: selectedStyle,
-    selectedStyleCategory:
-      value?.selectedStyleCategory ?? fallback.selectedStyleCategory,
-    lastImageUrl: value?.lastImageUrl ?? lastGeneratedUrl ?? fallback.lastImageUrl,
-    lastGeneratedUrl,
-    faceMemoryConsent: value?.faceMemoryConsent ?? fallback.faceMemoryConsent,
-    lastSourceImageUrl: value?.lastSourceImageUrl ?? fallback.lastSourceImageUrl,
-    lastSourceImageUpdatedAt:
-      value?.lastSourceImageUpdatedAt ?? fallback.lastSourceImageUpdatedAt,
-    pendingSourceImageDeleteUrl:
-      value?.pendingSourceImageDeleteUrl ?? fallback.pendingSourceImageDeleteUrl,
-    quota: {
-      dayKey: value?.quota?.dayKey ?? fallback.quota.dayKey,
-      count: value?.quota?.count ?? fallback.quota.count,
-    },
+    ...resolveConversationContext(value, fallback),
+    ...resolvePhotoAndStyleState(value, fallback, { lastPhoto, selectedStyle }),
+    ...resolveGeneratedImageState(value, fallback, lastGeneratedUrl),
+    ...resolveSourceImageState(value, fallback),
+    quota: resolveQuotaState(value, fallback),
     updatedAt: value?.updatedAt ?? fallback.updatedAt,
   };
 }

--- a/server/_core/messengerStateNormalization.ts
+++ b/server/_core/messengerStateNormalization.ts
@@ -18,6 +18,12 @@ type LegacyStateFields = {
   lastGeneratedUrl: string | null | undefined;
 };
 
+type NormalizationCtx = {
+  value: PartialState | null | undefined;
+  fallback: MessengerUserState;
+  legacyFields: LegacyStateFields;
+};
+
 function looksLikeUserKey(value: string): boolean {
   return /^[a-f0-9]{64}$/i.test(value);
 }
@@ -109,12 +115,13 @@ function resolveLegacyStateFields(
 }
 
 function resolveConsentState(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState
+  ctx: NormalizationCtx
 ): Pick<
   MessengerUserState,
   "consentGiven" | "consentTimestamp" | "pendingDeleteConfirm" | "hasSeenIntro"
 > {
+  const { value, fallback } = ctx;
+
   return {
     consentGiven: value?.consentGiven ?? fallback.consentGiven,
     consentTimestamp: value?.consentTimestamp ?? fallback.consentTimestamp,
@@ -125,12 +132,13 @@ function resolveConsentState(
 }
 
 function resolveConversationContext(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState
+  ctx: NormalizationCtx
 ): Pick<
   MessengerUserState,
   "lastEntryIntent" | "activeExperience" | "lastUserMessageAt"
 > {
+  const { value, fallback } = ctx;
+
   return {
     lastEntryIntent: value?.lastEntryIntent ?? fallback.lastEntryIntent,
     activeExperience: value?.activeExperience ?? fallback.activeExperience,
@@ -139,8 +147,7 @@ function resolveConversationContext(
 }
 
 function resolvePhotoAndStyleState(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState,
+  ctx: NormalizationCtx,
   legacyFields: Pick<LegacyStateFields, "lastPhoto" | "selectedStyle">
 ): Pick<
   MessengerUserState,
@@ -151,6 +158,7 @@ function resolvePhotoAndStyleState(
   | "chosenStyle"
   | "selectedStyleCategory"
 > {
+  const { value, fallback } = ctx;
   const { lastPhoto, selectedStyle } = legacyFields;
 
   return {
@@ -165,10 +173,11 @@ function resolvePhotoAndStyleState(
 }
 
 function resolveGeneratedImageState(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState,
+  ctx: NormalizationCtx,
   lastGeneratedUrl: LegacyStateFields["lastGeneratedUrl"]
 ): Pick<MessengerUserState, "lastImageUrl" | "lastGeneratedUrl"> {
+  const { value, fallback } = ctx;
+
   return {
     lastImageUrl: value?.lastImageUrl ?? lastGeneratedUrl ?? fallback.lastImageUrl,
     lastGeneratedUrl,
@@ -176,8 +185,7 @@ function resolveGeneratedImageState(
 }
 
 function resolveSourceImageState(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState
+  ctx: NormalizationCtx
 ): Pick<
   MessengerUserState,
   | "faceMemoryConsent"
@@ -185,6 +193,8 @@ function resolveSourceImageState(
   | "lastSourceImageUpdatedAt"
   | "pendingSourceImageDeleteUrl"
 > {
+  const { value, fallback } = ctx;
+
   return {
     faceMemoryConsent: value?.faceMemoryConsent ?? fallback.faceMemoryConsent,
     lastSourceImageUrl: value?.lastSourceImageUrl ?? fallback.lastSourceImageUrl,
@@ -196,9 +206,10 @@ function resolveSourceImageState(
 }
 
 function resolveQuotaState(
-  value: PartialState | null | undefined,
-  fallback: MessengerUserState
+  ctx: NormalizationCtx
 ): MessengerUserState["quota"] {
+  const { value, fallback } = ctx;
+
   return {
     dayKey: value?.quota?.dayKey ?? fallback.quota.dayKey,
     count: value?.quota?.count ?? fallback.quota.count,
@@ -212,20 +223,21 @@ function applyNormalizedStateShape(
 ): MessengerUserState {
   const { resolvedPsid, fallback } = base;
   const { stage, lastPhoto, selectedStyle, lastGeneratedUrl } = legacyFields;
+  const ctx: NormalizationCtx = { value, fallback, legacyFields };
 
   return {
     ...fallback,
     ...value,
     psid: resolvedPsid,
     userKey: value?.userKey ?? fallback.userKey,
-    ...resolveConsentState(value, fallback),
+    ...resolveConsentState(ctx),
     stage,
     state: stage,
-    ...resolveConversationContext(value, fallback),
-    ...resolvePhotoAndStyleState(value, fallback, { lastPhoto, selectedStyle }),
-    ...resolveGeneratedImageState(value, fallback, lastGeneratedUrl),
-    ...resolveSourceImageState(value, fallback),
-    quota: resolveQuotaState(value, fallback),
+    ...resolveConversationContext(ctx),
+    ...resolvePhotoAndStyleState(ctx, { lastPhoto, selectedStyle }),
+    ...resolveGeneratedImageState(ctx, lastGeneratedUrl),
+    ...resolveSourceImageState(ctx),
+    quota: resolveQuotaState(ctx),
     updatedAt: value?.updatedAt ?? fallback.updatedAt,
   };
 }

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -7,9 +7,7 @@ import {
   safeLog,
 } from "./messengerApi";
 import type { MessengerSendOutcome } from "./messengerApi";
-import {
-  getGenerationMetrics,
-} from "./imageService";
+import { getGenerationMetrics } from "./image-generation/openAiImageClient";
 import { getConfiguredBaseUrl } from "./image-generation/imageServiceConfig";
 import { executeGenerationFlow } from "./generationFlow";
 import {

--- a/server/_core/whatsappFlows/styleGenerationFlow.ts
+++ b/server/_core/whatsappFlows/styleGenerationFlow.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { executeGenerationFlow } from "../generationFlow";
-import { getGenerationMetrics } from "../imageService";
+import { getGenerationMetrics } from "../image-generation/openAiImageClient";
 import { t, type Lang } from "../i18n";
 import type { Style } from "../messengerStyles";
 import { canGenerate, increment } from "../messengerQuota";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,6 +152,28 @@ function vitePluginManusDebugCollector(): Plugin {
 
 const plugins = [react(), tailwindcss(), jsxLocPlugin(), vitePluginManusRuntime(), vitePluginManusDebugCollector()];
 
+function manualChunks(id: string): string | undefined {
+  if (!id.includes("node_modules")) {
+    return undefined;
+  }
+
+  if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+    return "vendor-react";
+  }
+
+  if (/[\\/]node_modules[\\/](@tanstack|@trpc|superjson)[\\/]/.test(id)) {
+    return "vendor-api";
+  }
+
+  if (
+    /[\\/]node_modules[\\/](@radix-ui|lucide-react|sonner|next-themes|class-variance-authority|clsx|tailwind-merge)[\\/]/.test(id)
+  ) {
+    return "vendor-ui";
+  }
+
+  return "vendor";
+}
+
 export default defineConfig({
   plugins,
   resolve: {
@@ -167,6 +189,11 @@ export default defineConfig({
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
+    rolldownOptions: {
+      output: {
+        manualChunks,
+      },
+    },
   },
   server: {
     host: true,


### PR DESCRIPTION
Split the client bundle with route-level lazy loading and Vite/Rolldown manual vendor chunks.

This removes the production build chunk-size warning and reduces the main app chunk from ~626 kB to ~13 kB, while keeping React, API, and UI dependencies cached in separate vendor chunks.
