### PR TITLE
Make Fallow report generation non-blocking

### DIFF
--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -69,6 +69,7 @@ jobs:
           git push
 
       - name: Enforce maintainability gate
+        if: github.event_name != 'pull_request'
         run: |
           node scripts/check-fallow-gate.mjs .fallow/report.json
 

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -33,13 +33,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . -f json > .fallow/report.json
+          npx --yes fallow@2.27.0 --root . -f json > .fallow/report.json || true
 
       - name: Generate production Fallow report
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . --production -f json > .fallow/report-production.json
+          npx --yes fallow@2.27.0 --root . --production -f json > .fallow/report-production.json || true
 
       - name: Build maintainability badge
         run: |

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -33,13 +33,17 @@ jobs:
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . --summary --score -f json > .fallow/report.json || true
+          npx --yes fallow@2.27.0 --root . dead-code --summary -f json > .fallow/report-check.json || true
+          npx --yes fallow@2.27.0 --root . health --summary --score --file-scores -f json > .fallow/report-health.json || true
+          node -e "const fs=require('node:fs'); const check=JSON.parse(fs.readFileSync('.fallow/report-check.json','utf8')); const health=JSON.parse(fs.readFileSync('.fallow/report-health.json','utf8')); fs.writeFileSync('.fallow/report.json', JSON.stringify({ schema_version: check.schema_version ?? health.schema_version, version: check.version ?? health.version, elapsed_ms: (check.elapsed_ms ?? 0) + (health.elapsed_ms ?? 0), check, health }, null, 2) + '\n');"
 
       - name: Generate production Fallow report
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . --production --summary --score -f json > .fallow/report-production.json || true
+          npx --yes fallow@2.27.0 --root . --production dead-code --summary -f json > .fallow/report-production-check.json || true
+          npx --yes fallow@2.27.0 --root . --production health --summary --score --file-scores -f json > .fallow/report-production-health.json || true
+          node -e "const fs=require('node:fs'); const check=JSON.parse(fs.readFileSync('.fallow/report-production-check.json','utf8')); const health=JSON.parse(fs.readFileSync('.fallow/report-production-health.json','utf8')); fs.writeFileSync('.fallow/report-production.json', JSON.stringify({ schema_version: check.schema_version ?? health.schema_version, version: check.version ?? health.version, elapsed_ms: (check.elapsed_ms ?? 0) + (health.elapsed_ms ?? 0), check, health }, null, 2) + '\n');"
 
       - name: Build maintainability badge
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -33,13 +33,21 @@ jobs:
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . -f json > .fallow/report.json || true
+          if ! npx --yes fallow@2.27.0 --root . -f json > .fallow/report.json.tmp; then
+            echo "Fallow exited non-zero; validating generated report before continuing"
+          fi
+          node -e "JSON.parse(require('node:fs').readFileSync('.fallow/report.json.tmp','utf8'))"
+          mv .fallow/report.json.tmp .fallow/report.json
 
       - name: Generate production Fallow report
         shell: bash
         run: |
           mkdir -p .fallow
-          npx --yes fallow@2.27.0 --root . --production -f json > .fallow/report-production.json || true
+          if ! npx --yes fallow@2.27.0 --root . --production -f json > .fallow/report-production.json.tmp; then
+            echo "Fallow exited non-zero; validating generated production report before continuing"
+          fi
+          node -e "JSON.parse(require('node:fs').readFileSync('.fallow/report-production.json.tmp','utf8'))"
+          mv .fallow/report-production.json.tmp .fallow/report-production.json
 
       - name: Build maintainability badge
         run: |

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -33,21 +33,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p .fallow
-          if ! npx --yes fallow@2.27.0 --root . -f json > .fallow/report.json.tmp; then
-            echo "Fallow exited non-zero; validating generated report before continuing"
-          fi
-          node -e "JSON.parse(require('node:fs').readFileSync('.fallow/report.json.tmp','utf8'))"
-          mv .fallow/report.json.tmp .fallow/report.json
+          npx --yes fallow@2.27.0 --root . --summary --score -f json > .fallow/report.json || true
 
       - name: Generate production Fallow report
         shell: bash
         run: |
           mkdir -p .fallow
-          if ! npx --yes fallow@2.27.0 --root . --production -f json > .fallow/report-production.json.tmp; then
-            echo "Fallow exited non-zero; validating generated production report before continuing"
-          fi
-          node -e "JSON.parse(require('node:fs').readFileSync('.fallow/report-production.json.tmp','utf8'))"
-          mv .fallow/report-production.json.tmp .fallow/report-production.json
+          npx --yes fallow@2.27.0 --root . --production --summary --score -f json > .fallow/report-production.json || true
 
       - name: Build maintainability badge
         run: |

--- a/.github/workflows/fallow.yml
+++ b/.github/workflows/fallow.yml
@@ -42,6 +42,7 @@ jobs:
           npx --yes fallow@2.27.0 --root . --production --summary --score -f json > .fallow/report-production.json || true
 
       - name: Build maintainability badge
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
           node scripts/fallow-badge.mjs \
             .fallow/report.json \

--- a/scripts/fallow-badge.mjs
+++ b/scripts/fallow-badge.mjs
@@ -12,14 +12,19 @@ if (!inputPath || !badgePath || !metricsPath) {
 
 const raw = fs.readFileSync(inputPath, "utf8").replace(/^\uFEFF/, "");
 const report = JSON.parse(raw);
-const summary = report.check?.summary ?? report.summary ?? null;
+const summary = report.check?.summary ?? report.summary;
 const healthSummary = report.health?.summary;
+
+if (!summary) {
+  console.error("Fallow summary not found in report JSON");
+  process.exit(1);
+}
 
 const averageMaintainability = Number(healthSummary?.average_maintainability);
 
 if (!Number.isFinite(averageMaintainability)) {
-  console.log("Fallow native maintainability not found in report JSON; skipping badge update");
-  process.exit(0);
+  console.error("Fallow native maintainability not found in report JSON");
+  process.exit(1);
 }
 
 const score = Number(averageMaintainability.toFixed(1));

--- a/scripts/fallow-badge.mjs
+++ b/scripts/fallow-badge.mjs
@@ -12,13 +12,8 @@ if (!inputPath || !badgePath || !metricsPath) {
 
 const raw = fs.readFileSync(inputPath, "utf8").replace(/^\uFEFF/, "");
 const report = JSON.parse(raw);
-const summary = report.check?.summary ?? report.summary;
+const summary = report.check?.summary ?? report.summary ?? null;
 const healthSummary = report.health?.summary;
-
-if (!summary) {
-  console.error("Fallow summary not found in report JSON");
-  process.exit(1);
-}
 
 const averageMaintainability = Number(healthSummary?.average_maintainability);
 

--- a/scripts/fallow-badge.mjs
+++ b/scripts/fallow-badge.mjs
@@ -18,8 +18,8 @@ const healthSummary = report.health?.summary;
 const averageMaintainability = Number(healthSummary?.average_maintainability);
 
 if (!Number.isFinite(averageMaintainability)) {
-  console.error("Fallow native maintainability not found in report JSON");
-  process.exit(1);
+  console.log("Fallow native maintainability not found in report JSON; skipping badge update");
+  process.exit(0);
 }
 
 const score = Number(averageMaintainability.toFixed(1));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made code-analysis steps more resilient so workflow continues if an individual analysis run fails.
  * Collects separate analysis outputs and merges them into consolidated reports.
  * Adjusted maintainability enforcement to run only outside pull request workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->