### PR TITLE
Fix preselected style after photo consent

### DIFF
--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -718,6 +718,9 @@ async function tryHandleImageMessage(
     if (state.faceMemoryConsent?.given) {
       await updateConsentedFaceMemorySource(input.psid, storedSourceImageUrl);
     } else if (!state.faceMemoryConsent) {
+      if (imageDecision.action === "show_style_picker") {
+        await setPreselectedStyle(input.psid, null);
+      }
       await ctx.sendFaceMemoryConsentPrompt(input.psid, input.lang, input.reqId);
       return true;
     }

--- a/server/_core/webhookHandlers.ts
+++ b/server/_core/webhookHandlers.ts
@@ -1585,6 +1585,7 @@ export function createWebhookHandlers({
 
     await setChosenStyle(psid, selectedStyle);
     if (!state.lastPhotoUrl) {
+      await setPreselectedStyle(psid, selectedStyle);
       await setFlowState(psid, "AWAITING_PHOTO");
       return await sendLoggedText(psid, t(lang, "styleWithoutPhoto"), reqId);
     }

--- a/server/_core/webhookPayloadBranch.ts
+++ b/server/_core/webhookPayloadBranch.ts
@@ -54,6 +54,7 @@ async function continueAfterFaceMemoryChoice(
     return;
   }
 
+  await setFlowState(input.psid, "AWAITING_STYLE");
   await ctx.sendPhotoReceivedPrompt(input.psid, input.lang, input.reqId);
 }
 

--- a/server/_core/webhookPayloadBranch.ts
+++ b/server/_core/webhookPayloadBranch.ts
@@ -16,7 +16,7 @@ import { getBotFeatures } from "./bot/features";
 import { handleMessengerPayload } from "./messengerPayloadRouting";
 import { safeLog } from "./messengerApi";
 import { toLogUser } from "./privacy";
-import type { FacebookWebhookEvent } from "./webhookHelpers";
+import { normalizeStyle, type FacebookWebhookEvent } from "./webhookHelpers";
 import type { HandlerContext } from "./webhookHandlers";
 import type { Lang } from "./i18n";
 
@@ -35,6 +35,27 @@ type PayloadFlowInput = {
   reqId: string;
   lang: Lang;
 };
+
+async function continueAfterFaceMemoryChoice(
+  ctx: HandlerContext,
+  input: PayloadFlowInput
+): Promise<void> {
+  const state = await getOrCreateState(input.psid);
+  const preselectedStyle = normalizeStyle(state.preselectedStyle ?? "");
+  if (preselectedStyle && state.lastPhotoUrl) {
+    await setPreselectedStyle(input.psid, null);
+    await ctx.handleStyleSelection(
+      input.psid,
+      input.userId,
+      preselectedStyle,
+      input.reqId,
+      input.lang
+    );
+    return;
+  }
+
+  await ctx.sendPhotoReceivedPrompt(input.psid, input.lang, input.reqId);
+}
 
 export async function handlePostbackEvent(
   ctx: HandlerContext,
@@ -75,13 +96,13 @@ export async function handlePayload(
     } else {
       await setFaceMemoryConsentGiven(input.psid);
     }
-    await ctx.sendPhotoReceivedPrompt(input.psid, input.lang, input.reqId);
+    await continueAfterFaceMemoryChoice(ctx, input);
     return;
   }
 
   if (input.payload === FACE_MEMORY_CONSENT_NO) {
     await declineFaceMemory(input.psid);
-    await ctx.sendPhotoReceivedPrompt(input.psid, input.lang, input.reqId);
+    await continueAfterFaceMemoryChoice(ctx, input);
     return;
   }
 

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -132,6 +132,73 @@ function installImageIngressFetchMock() {
   return fetchMock;
 }
 
+async function sendMessengerQuickReply(
+  processPayload: typeof processFacebookWebhookPayloadBase,
+  psid: string,
+  mid: string,
+  payload: string
+): Promise<void> {
+  await processPayload({
+    entry: [
+      {
+        messaging: [
+          {
+            sender: { id: psid },
+            message: {
+              mid,
+              quick_reply: { payload },
+            },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+async function sendMessengerPhoto(
+  processPayload: typeof processFacebookWebhookPayloadBase,
+  psid: string,
+  mid: string,
+  imageUrl: string
+): Promise<void> {
+  await processPayload({
+    entry: [
+      {
+        messaging: [
+          {
+            sender: { id: psid },
+            message: {
+              mid,
+              attachments: [
+                {
+                  type: "image",
+                  payload: { url: imageUrl },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  });
+}
+
+function clearMessengerSendMocks(): void {
+  sendImageMock.mockClear();
+  sendQuickRepliesMock.mockClear();
+  sendTextMock.mockClear();
+}
+
+function expectFaceMemoryConsentPrompt(psid: string): void {
+  expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+    psid,
+    expect.stringContaining("Mag ik je foto 30 dagen bewaren?"),
+    expect.arrayContaining([
+      expect.objectContaining({ payload: "CONSENT_FACE_YES" }),
+    ])
+  );
+}
+
 beforeAll(() => {
   process.env.PRIVACY_PEPPER = TEST_PEPPER;
 });
@@ -2293,21 +2360,12 @@ describe("disabled bot features stay out of the runtime flow", () => {
     process.env.ENABLE_FACE_MEMORY = "true";
     const psid = "gdpr-style-photo-user";
 
-    await processFacebookWebhookPayloadBase({
-      entry: [
-        {
-          messaging: [
-            {
-              sender: { id: psid },
-              message: {
-                mid: "mid-gdpr-style-photo-consent",
-                quick_reply: { payload: "GDPR_CONSENT_AGREE" },
-              },
-            },
-          ],
-        },
-      ],
-    });
+    await sendMessengerQuickReply(
+      processFacebookWebhookPayloadBase,
+      psid,
+      "mid-gdpr-style-photo-consent",
+      "GDPR_CONSENT_AGREE"
+    );
 
     await processFacebookWebhookPayloadBase({
       entry: [
@@ -2324,59 +2382,26 @@ describe("disabled bot features stay out of the runtime flow", () => {
 
     expect(getState(anonymizePsid(psid))?.preselectedStyle).toBe("cyberpunk");
 
-    sendImageMock.mockClear();
-    sendQuickRepliesMock.mockClear();
-    sendTextMock.mockClear();
+    clearMessengerSendMocks();
     installOpenAiSuccessFetchMock();
 
-    await processFacebookWebhookPayloadBase({
-      entry: [
-        {
-          messaging: [
-            {
-              sender: { id: psid },
-              message: {
-                mid: "mid-gdpr-style-photo-upload",
-                attachments: [
-                  {
-                    type: "image",
-                    payload: { url: "https://img.example/source.jpg" },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-      ],
-    });
-
-    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+    await sendMessengerPhoto(
+      processFacebookWebhookPayloadBase,
       psid,
-      expect.stringContaining("Mag ik je foto 30 dagen bewaren?"),
-      expect.arrayContaining([
-        expect.objectContaining({ payload: "CONSENT_FACE_YES" }),
-      ])
+      "mid-gdpr-style-photo-upload",
+      "https://img.example/source.jpg"
     );
 
-    sendImageMock.mockClear();
-    sendQuickRepliesMock.mockClear();
-    sendTextMock.mockClear();
+    expectFaceMemoryConsentPrompt(psid);
 
-    await processFacebookWebhookPayloadBase({
-      entry: [
-        {
-          messaging: [
-            {
-              sender: { id: psid },
-              message: {
-                mid: "mid-gdpr-style-photo-memory-yes",
-                quick_reply: { payload: "CONSENT_FACE_YES" },
-              },
-            },
-          ],
-        },
-      ],
-    });
+    clearMessengerSendMocks();
+
+    await sendMessengerQuickReply(
+      processFacebookWebhookPayloadBase,
+      psid,
+      "mid-gdpr-style-photo-memory-yes",
+      "CONSENT_FACE_YES"
+    );
 
     expect(sendTextMock).toHaveBeenCalledWith(
       psid,
@@ -2403,58 +2428,25 @@ describe("disabled bot features stay out of the runtime flow", () => {
     await setPendingImage(psid, "https://img.example/old-source.jpg");
     await setPreselectedStyle(psid, "cyberpunk");
 
-    sendImageMock.mockClear();
-    sendQuickRepliesMock.mockClear();
-    sendTextMock.mockClear();
+    clearMessengerSendMocks();
 
-    await processFacebookWebhookPayload({
-      entry: [
-        {
-          messaging: [
-            {
-              sender: { id: psid },
-              message: {
-                mid: "mid-face-memory-stale-photo",
-                attachments: [
-                  {
-                    type: "image",
-                    payload: { url: "https://img.example/new-source.jpg" },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-      ],
-    });
-
-    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+    await sendMessengerPhoto(
+      processFacebookWebhookPayload,
       psid,
-      expect.stringContaining("Mag ik je foto 30 dagen bewaren?"),
-      expect.arrayContaining([
-        expect.objectContaining({ payload: "CONSENT_FACE_YES" }),
-      ])
+      "mid-face-memory-stale-photo",
+      "https://img.example/new-source.jpg"
     );
 
-    sendImageMock.mockClear();
-    sendQuickRepliesMock.mockClear();
-    sendTextMock.mockClear();
+    expectFaceMemoryConsentPrompt(psid);
 
-    await processFacebookWebhookPayload({
-      entry: [
-        {
-          messaging: [
-            {
-              sender: { id: psid },
-              message: {
-                mid: "mid-face-memory-stale-yes",
-                quick_reply: { payload: "CONSENT_FACE_YES" },
-              },
-            },
-          ],
-        },
-      ],
-    });
+    clearMessengerSendMocks();
+
+    await sendMessengerQuickReply(
+      processFacebookWebhookPayload,
+      psid,
+      "mid-face-memory-stale-yes",
+      "CONSENT_FACE_YES"
+    );
 
     expect(sendImageMock).not.toHaveBeenCalled();
     expect(sendTextMock).not.toHaveBeenCalledWith(
@@ -2469,6 +2461,7 @@ describe("disabled bot features stay out of the runtime flow", () => {
       ])
     );
     expect(getState(anonymizePsid(psid))?.preselectedStyle).toBeNull();
+    expect(getState(anonymizePsid(psid))?.stage).toBe("AWAITING_STYLE");
   });
 
   it("does not auto-run a stale preselected style when a new photo replaces an older one", async () => {

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -2397,6 +2397,80 @@ describe("disabled bot features stay out of the runtime flow", () => {
     expect(getState(anonymizePsid(psid))?.selectedStyle).toBe("cyberpunk");
   });
 
+  it("does not resume a stale preselected style after face-memory consent for a replacement photo", async () => {
+    process.env.ENABLE_FACE_MEMORY = "true";
+    const psid = "face-memory-stale-preselect-user";
+    await setPendingImage(psid, "https://img.example/old-source.jpg");
+    await setPreselectedStyle(psid, "cyberpunk");
+
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-face-memory-stale-photo",
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/new-source.jpg" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Mag ik je foto 30 dagen bewaren?"),
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "CONSENT_FACE_YES" }),
+      ])
+    );
+
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+
+    await processFacebookWebhookPayload({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-face-memory-stale-yes",
+                quick_reply: { payload: "CONSENT_FACE_YES" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendImageMock).not.toHaveBeenCalled();
+    expect(sendTextMock).not.toHaveBeenCalledWith(
+      psid,
+      "Ik maak nu je Cyberpunk-stijl."
+    );
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      t("nl", "styleCategoryPicker"),
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "STYLE_CATEGORY_ILLUSTRATED" }),
+      ])
+    );
+    expect(getState(anonymizePsid(psid))?.preselectedStyle).toBeNull();
+  });
+
   it("does not auto-run a stale preselected style when a new photo replaces an older one", async () => {
     await setPendingImage("stale-preselect-user", "https://img.example/old-source.jpg");
     await setPreselectedStyle("stale-preselect-user", "cyberpunk");

--- a/server/messengerWebhook.test.ts
+++ b/server/messengerWebhook.test.ts
@@ -151,6 +151,7 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.APP_BASE_URL;
   delete process.env.SOURCE_IMAGE_ALLOWED_HOSTS;
+  delete process.env.ENABLE_FACE_MEMORY;
 });
 
 beforeEach(() => {
@@ -2286,6 +2287,114 @@ describe("disabled bot features stay out of the runtime flow", () => {
     expect(getState(anonymizePsid("style-preselect-user"))?.selectedStyle).toBe(
       "cyberpunk"
     );
+  });
+
+  it("continues generation after GDPR, style choice, photo upload, and face-memory consent", async () => {
+    process.env.ENABLE_FACE_MEMORY = "true";
+    const psid = "gdpr-style-photo-user";
+
+    await processFacebookWebhookPayloadBase({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-gdpr-style-photo-consent",
+                quick_reply: { payload: "GDPR_CONSENT_AGREE" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await processFacebookWebhookPayloadBase({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              postback: { payload: "STYLE_CYBERPUNK" },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(getState(anonymizePsid(psid))?.preselectedStyle).toBe("cyberpunk");
+
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+    installOpenAiSuccessFetchMock();
+
+    await processFacebookWebhookPayloadBase({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-gdpr-style-photo-upload",
+                attachments: [
+                  {
+                    type: "image",
+                    payload: { url: "https://img.example/source.jpg" },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendQuickRepliesMock).toHaveBeenCalledWith(
+      psid,
+      expect.stringContaining("Mag ik je foto 30 dagen bewaren?"),
+      expect.arrayContaining([
+        expect.objectContaining({ payload: "CONSENT_FACE_YES" }),
+      ])
+    );
+
+    sendImageMock.mockClear();
+    sendQuickRepliesMock.mockClear();
+    sendTextMock.mockClear();
+
+    await processFacebookWebhookPayloadBase({
+      entry: [
+        {
+          messaging: [
+            {
+              sender: { id: psid },
+              message: {
+                mid: "mid-gdpr-style-photo-memory-yes",
+                quick_reply: { payload: "CONSENT_FACE_YES" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sendTextMock).toHaveBeenCalledWith(
+      psid,
+      "Ik maak nu je Cyberpunk-stijl."
+    );
+    expect(sendImageMock).toHaveBeenCalledWith(
+      psid,
+      expect.stringMatching(
+        /^https:\/\/leaderbot-fb-image-gen\.fly\.dev\/generated\/[0-9a-f-]+\.jpg$/
+      )
+    );
+    expect(sendQuickRepliesMock).not.toHaveBeenCalledWith(
+      psid,
+      t("nl", "styleCategoryPicker"),
+      expect.any(Array)
+    );
+    expect(getState(anonymizePsid(psid))?.preselectedStyle).toBeNull();
+    expect(getState(anonymizePsid(psid))?.selectedStyle).toBe("cyberpunk");
   });
 
   it("does not auto-run a stale preselected style when a new photo replaces an older one", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved face-memory consent flow to properly clear style selections in specific scenarios before prompting for consent.
  * Fixed replacement photo handling after consent—now correctly shows the style picker instead of resuming a previously selected style.

* **Tests**
  * Added integration tests for face-memory consent flow with style selection and photo upload.
  * Added test for replacement photo behavior to ensure correct style picker display after consent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->