### PR TITLE
style: normalize spacing in dark theme CSS variables

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -94,7 +94,7 @@
   --muted: oklch(0.274 0.006 286.033);
   --muted-foreground: oklch(0.705 0.015 286.067);
   --accent: oklch(0.274 0.006 286.033);
-  --accent-foreground:  oklch(0.92 0.005 65);
+  --accent-foreground: oklch(0.92 0.005 65);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
@@ -108,7 +108,7 @@
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.85 0.005 65);
   --sidebar-accent: oklch(0.274 0.006 286.033);
-  --sidebar-accent-foreground:  oklch(0.985 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.488 0.243 264.376);
 }


### PR DESCRIPTION
### Motivation
- Fix a small formatting nit in the dark theme CSS custom properties to keep code style consistent and avoid spurious diffs.

### Description
- Normalized spacing for `--accent-foreground` and `--sidebar-accent-foreground` in `client/src/index.css` (no functional change).

### Testing
- Verified the change with `git diff -- client/src/index.css`, `git status --short`, and committed with `git add`/`git commit`; no automated test suite was run and no runtime behavior is expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8c71c17908325a987646d8653540c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor CSS formatting updates to dark theme styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->