### PR TITLE
feat(image): add automatic director photo analysis

### DIFF
--- a/server/_core/image-generation/director/directorPhotoAnalyzer.ts
+++ b/server/_core/image-generation/director/directorPhotoAnalyzer.ts
@@ -1,0 +1,173 @@
+import type { DownloadedSourceImage } from "../sourceImageFetcher";
+
+type ResponsesApiPayload = {
+  model: string;
+  input: Array<{
+    role: "system" | "user";
+    content:
+      | string
+      | Array<
+          | { type: "input_text"; text: string }
+          | { type: "input_image"; image_url: string; detail: "low" | "high" | "auto" }
+        >;
+  }>;
+  temperature: number;
+  max_output_tokens: number;
+};
+
+const RESPONSES_API_URL = "https://api.openai.com/v1/responses";
+const DEFAULT_MODEL = "gpt-4.1-mini";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const MAX_ANALYSIS_LENGTH = 700;
+
+function getModel(): string {
+  return process.env.OPENAI_DIRECTOR_ANALYSIS_MODEL?.trim() || DEFAULT_MODEL;
+}
+
+function getTimeoutMs(): number {
+  const configured = Number(process.env.OPENAI_DIRECTOR_ANALYSIS_TIMEOUT_MS);
+  if (Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+
+  return DEFAULT_TIMEOUT_MS;
+}
+
+function sanitizeAnalysis(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, MAX_ANALYSIS_LENGTH);
+}
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function trimmedText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function textProperty(value: unknown, key: string): string | null {
+  return trimmedText(objectValue(value)?.[key]);
+}
+
+function extractContentText(item: unknown): string | null {
+  const content = objectValue(item)?.content;
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  for (const part of content) {
+    const text = textProperty(part, "text");
+    if (text) {
+      return text;
+    }
+  }
+
+  return null;
+}
+
+function extractOutputItemText(item: unknown): string | null {
+  return textProperty(item, "text") ?? extractContentText(item);
+}
+
+function extractOutputText(raw: unknown): string | null {
+  const output = objectValue(raw)?.output;
+  if (!Array.isArray(output)) {
+    return null;
+  }
+
+  for (const item of output) {
+    const text = extractOutputItemText(item);
+    if (text) {
+      return text;
+    }
+  }
+
+  return null;
+}
+
+function extractResponseText(raw: unknown): string | null {
+  return textProperty(raw, "output_text") ?? extractOutputText(raw);
+}
+
+function toDataUrl(sourceImage: DownloadedSourceImage): string {
+  return `data:${sourceImage.contentType};base64,${sourceImage.buffer.toString("base64")}`;
+}
+
+function buildAnalysisPayload(sourceImage: DownloadedSourceImage): ResponsesApiPayload {
+  return {
+    model: getModel(),
+    input: [
+      {
+        role: "system",
+        content: [
+          "You are a photo analysis assistant for an AI creative director.",
+          "Describe only visual facts and useful transformation guidance.",
+          "Do not identify the person, infer sensitive traits, or make demographic guesses beyond visible styling and apparent pose.",
+          "Return concise plain text with notes about subject, pose, lighting, background, framing, image quality, and improvement opportunities.",
+        ].join(" "),
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: "Analyze this uploaded photo for a social-ready creative restyle. Keep it concise and practical.",
+          },
+          {
+            type: "input_image",
+            image_url: toDataUrl(sourceImage),
+            detail: "low",
+          },
+        ],
+      },
+    ],
+    temperature: 0,
+    max_output_tokens: 180,
+  };
+}
+
+export async function analyzeDirectorPhoto(
+  sourceImage: DownloadedSourceImage,
+  reqId: string
+): Promise<string | undefined> {
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    return undefined;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), getTimeoutMs());
+
+  try {
+    const response = await fetch(RESPONSES_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(buildAnalysisPayload(sourceImage)),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.warn("director_photo_analysis_failed", {
+        reqId,
+        status: response.status,
+      });
+      return undefined;
+    }
+
+    const responseText = extractResponseText(await response.json());
+    return responseText ? sanitizeAnalysis(responseText) : undefined;
+  } catch (error) {
+    console.warn("director_photo_analysis_failed", {
+      reqId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/server/_core/imageService.ts
+++ b/server/_core/imageService.ts
@@ -1,6 +1,7 @@
 import { type Style } from "./messengerStyles";
 import { safeLen, sha256 } from "./imageProof";
 import { buildDirectorPrompt } from "./image-generation/director/directorPromptBuilder";
+import { analyzeDirectorPhoto } from "./image-generation/director/directorPhotoAnalyzer";
 import type { DirectorMode } from "./image-generation/director/directorTypes";
 import {
   attachGenerationMetrics,
@@ -122,6 +123,11 @@ async function prepareGenerationInput(
 ): Promise<PreparedGenerationInput> {
   // TODO: collapse this orchestration into a dedicated ImageService once prompt and source-image paths are fully extracted.
   logSourceImageFetchStart(input);
+  const sourceImage = await resolveStoredSourceImage(input);
+  const photoAnalysis =
+    input.directorMode && !input.directorPhotoAnalysis
+      ? await analyzeDirectorPhoto(sourceImage, input.reqId)
+      : input.directorPhotoAnalysis;
 
   return {
     hasSourceImage: computeHasSourceImage(input),
@@ -129,10 +135,10 @@ async function prepareGenerationInput(
       ? buildDirectorPrompt({
           mode: input.directorMode,
           userInstruction: input.directorInstruction,
-          photoAnalysis: input.directorPhotoAnalysis,
+          photoAnalysis,
         })
       : buildStylePrompt(input.style, input.promptHint),
-    sourceImage: await resolveStoredSourceImage(input),
+    sourceImage,
   };
 }
 

--- a/server/imageProvider.test.ts
+++ b/server/imageProvider.test.ts
@@ -43,6 +43,10 @@ async function promptFromRequest(init: RequestInit | undefined): Promise<string>
   return "";
 }
 
+function requestJson(init: RequestInit | undefined): unknown {
+  return typeof init?.body === "string" ? JSON.parse(init.body) : null;
+}
+
 describe("image provider boundary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -209,5 +213,99 @@ describe("image provider boundary", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("analyzes the source photo before building an automatic director prompt", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const resolved = toUrlString(url);
+
+      if (resolved === "https://api.openai.com/v1/responses") {
+        const payload = requestJson(init) as {
+          input?: Array<{ content?: Array<{ type?: string; image_url?: string }> }>;
+        };
+        const imagePart = payload.input?.[1]?.content?.find(
+          part => part.type === "input_image"
+        );
+        expect(imagePart?.image_url).toMatch(/^data:image\/jpeg;base64,/);
+
+        return {
+          ok: true,
+          json: async () => ({
+            output_text:
+              "Single subject, flat indoor lighting, cluttered background, centered selfie framing.",
+          }),
+        } as Response;
+      }
+
+      expect(resolved).toBe("https://api.openai.com/v1/images/edits");
+      expect(await promptFromRequest(init)).toContain(
+        "Single subject, flat indoor lighting, cluttered background, centered selfie framing."
+      );
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "cinematic",
+      sourceImageData: {
+        buffer: Buffer.alloc(7000, 8),
+        contentType: "image/jpeg",
+      },
+      directorMode: "vogue_editorial",
+      userKey: "user-1",
+      reqId: "req-director-analysis",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues director generation when photo analysis fails", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const resolved = toUrlString(url);
+
+      if (resolved === "https://api.openai.com/v1/responses") {
+        return {
+          ok: false,
+          status: 500,
+        } as Response;
+      }
+
+      expect(resolved).toBe("https://api.openai.com/v1/images/edits");
+      expect(await promptFromRequest(init)).toContain("No photo analysis provided");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "cinematic",
+      sourceImageData: {
+        buffer: Buffer.alloc(7000, 8),
+        contentType: "image/jpeg",
+      },
+      directorMode: "old_money",
+      userKey: "user-1",
+      reqId: "req-director-analysis-fail",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
Add automatic photo analysis for Smart Restyle Director generation.

Director generation now performs an OpenAI Responses API analysis pass on the source image before prompt construction. The analysis is automatically threaded into the director prompt builder, allowing director modes to adapt to lighting, framing, pose, background, and image quality.

The flow preserves existing fallback behavior:
- analysis only runs for `directorMode`
- explicitly provided `directorPhotoAnalysis` skips auto-analysis
- analysis failure falls back to the existing no-analysis path
