### PR TITLE
Centralize OpenAI image model configuration

### DIFF
--- a/server/_core/image-generation/imageServiceConfig.ts
+++ b/server/_core/image-generation/imageServiceConfig.ts
@@ -3,6 +3,23 @@ import {
   MissingObjectStorageConfigError,
 } from "./imageServiceErrors";
 
+export type OpenAiImageModelConfig = {
+  imageGenerationModel: string;
+};
+
+const DEFAULT_OPENAI_IMAGE_GENERATION_MODEL = "gpt-image-1";
+
+export function getOpenAiImageModelConfig(): OpenAiImageModelConfig {
+  const imageGenerationModel = process.env.OPENAI_IMAGE_MODEL?.trim();
+
+  return {
+    imageGenerationModel:
+      imageGenerationModel && imageGenerationModel.length > 0
+        ? imageGenerationModel
+        : DEFAULT_OPENAI_IMAGE_GENERATION_MODEL,
+  };
+}
+
 export function getConfiguredBaseUrl(): string | undefined {
   const configuredBaseUrl = process.env.APP_BASE_URL?.trim()
     ? process.env.APP_BASE_URL.trim()

--- a/server/_core/image-generation/imageServiceConfig.ts
+++ b/server/_core/image-generation/imageServiceConfig.ts
@@ -3,7 +3,7 @@ import {
   MissingObjectStorageConfigError,
 } from "./imageServiceErrors";
 
-export type OpenAiImageModelConfig = {
+type OpenAiImageModelConfig = {
   imageGenerationModel: string;
 };
 

--- a/server/_core/image-generation/openAiImageClient.ts
+++ b/server/_core/image-generation/openAiImageClient.ts
@@ -1,3 +1,5 @@
+import { getOpenAiImageModelConfig } from "./imageServiceConfig";
+
 class OpenAiGenerationError extends Error {}
 export class OpenAiBudgetExceededError extends Error {}
 
@@ -171,9 +173,11 @@ async function fetchWithTimeout(
 export function buildOpenAiRequest(
   input: OpenAiRequestInput
 ): OpenAiRequestContext {
+  const { imageGenerationModel } = getOpenAiImageModelConfig();
+
   if (input.hasSourceImage) {
     const formData = new FormData();
-    formData.set("model", "gpt-image-1");
+    formData.set("model", imageGenerationModel);
     formData.set("prompt", input.prompt);
     formData.set("size", "1024x1024");
     formData.set("output_format", "jpeg");
@@ -206,7 +210,7 @@ export function buildOpenAiRequest(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-image-1",
+        model: imageGenerationModel,
         prompt: input.prompt,
         size: "1024x1024",
         output_format: "jpeg",

--- a/server/imageProvider.test.ts
+++ b/server/imageProvider.test.ts
@@ -48,6 +48,38 @@ function requestJson(init: RequestInit | undefined): unknown {
   return typeof init?.body === "string" ? JSON.parse(init.body) : null;
 }
 
+function configureOpenAiImagesEnv(imageModel?: string): void {
+  process.env.OPENAI_API_KEY = "dummy-key";
+  process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+
+  if (imageModel) {
+    process.env.OPENAI_IMAGE_MODEL = imageModel;
+  }
+}
+
+function createGeneratedImageResponse(): Response {
+  return {
+    ok: true,
+    json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+  } as Response;
+}
+
+function generateWithSourceImageData(
+  generator: OpenAiImageGenerator,
+  input: Omit<
+    Parameters<OpenAiImageGenerator["generate"]>[0],
+    "sourceImageData"
+  >
+) {
+  return generator.generate({
+    ...input,
+    sourceImageData: {
+      buffer: Buffer.alloc(7000, 8),
+      contentType: "image/jpeg",
+    },
+  });
+}
+
 describe("image provider boundary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -82,8 +114,7 @@ describe("image provider boundary", () => {
   );
 
   it("logs the active provider once per generation even when OpenAI retries", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
     process.env.OPENAI_IMAGE_MAX_RETRIES = "1";
     process.env.OPENAI_IMAGE_RETRY_BASE_MS = "1";
 
@@ -104,21 +135,14 @@ describe("image provider boundary", () => {
         } as Response;
       }
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    const result = await generator.generate({
+    const result = await generateWithSourceImageData(generator, {
       style: "disco",
-      sourceImageData: {
-        buffer: Buffer.alloc(7000, 8),
-        contentType: "image/jpeg",
-      },
       userKey: "user-1",
       reqId: "req-provider-log",
     });
@@ -145,29 +169,21 @@ describe("image provider boundary", () => {
   });
 
   it("uses the existing style prompt when no director mode is provided", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
 
     const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
       expect(await promptFromRequest(init)).toBe(
         buildStylePrompt("disco", "more glitter in the background")
       );
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    await generator.generate({
+    await generateWithSourceImageData(generator, {
       style: "disco",
-      sourceImageData: {
-        buffer: Buffer.alloc(7000, 8),
-        contentType: "image/jpeg",
-      },
       promptHint: "more glitter in the background",
       userKey: "user-1",
       reqId: "req-style-prompt",
@@ -177,18 +193,14 @@ describe("image provider boundary", () => {
   });
 
   it("uses gpt-image-1 as the default OpenAI image model", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
     delete process.env.OPENAI_IMAGE_MODEL;
 
     const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
       const body = requestJson(init) as { model?: string };
       expect(body.model).toBe("gpt-image-1");
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
@@ -204,18 +216,13 @@ describe("image provider boundary", () => {
   });
 
   it("uses OPENAI_IMAGE_MODEL when configured", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
-    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+    configureOpenAiImagesEnv("gpt-image-2");
 
     const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
       const body = requestJson(init) as { model?: string };
       expect(body.model).toBe("gpt-image-2");
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
@@ -230,9 +237,31 @@ describe("image provider boundary", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("uses OPENAI_IMAGE_MODEL in OpenAI edits FormData when source image data is provided", async () => {
+    configureOpenAiImagesEnv("gpt-image-2");
+
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = init?.body;
+      expect(body).toBeInstanceOf(FormData);
+      expect((body as FormData).get("model")).toBe("gpt-image-2");
+
+      return createGeneratedImageResponse();
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generateWithSourceImageData(generator, {
+      style: "disco",
+      userKey: "user-form-data-model",
+      reqId: "req-form-data-model",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("sends a director prompt to OpenAI when director mode is provided", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
 
     const directorInput = {
       mode: "berlin_underground" as const,
@@ -245,21 +274,14 @@ describe("image provider boundary", () => {
         buildDirectorPrompt(directorInput)
       );
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    await generator.generate({
+    await generateWithSourceImageData(generator, {
       style: "cyberpunk",
-      sourceImageData: {
-        buffer: Buffer.alloc(7000, 8),
-        contentType: "image/jpeg",
-      },
       promptHint: "this should not be used for director prompts",
       directorMode: directorInput.mode,
       directorInstruction: directorInput.userInstruction,
@@ -272,8 +294,7 @@ describe("image provider boundary", () => {
   });
 
   it("analyzes the source photo before building an automatic director prompt", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
 
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
       const resolved = toUrlString(url);
@@ -301,21 +322,14 @@ describe("image provider boundary", () => {
         "Single subject, flat indoor lighting, cluttered background, centered selfie framing."
       );
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    await generator.generate({
+    await generateWithSourceImageData(generator, {
       style: "cinematic",
-      sourceImageData: {
-        buffer: Buffer.alloc(7000, 8),
-        contentType: "image/jpeg",
-      },
       directorMode: "vogue_editorial",
       userKey: "user-1",
       reqId: "req-director-analysis",
@@ -325,8 +339,7 @@ describe("image provider boundary", () => {
   });
 
   it("continues director generation when photo analysis fails", async () => {
-    process.env.OPENAI_API_KEY = "dummy-key";
-    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    configureOpenAiImagesEnv();
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
@@ -342,21 +355,14 @@ describe("image provider boundary", () => {
       expect(resolved).toBe("https://api.openai.com/v1/images/edits");
       expect(await promptFromRequest(init)).toContain("No photo analysis provided");
 
-      return {
-        ok: true,
-        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
-      } as Response;
+      return createGeneratedImageResponse();
     });
 
     vi.stubGlobal("fetch", fetchMock);
 
     const generator = new OpenAiImageGenerator();
-    await generator.generate({
+    await generateWithSourceImageData(generator, {
       style: "cinematic",
-      sourceImageData: {
-        buffer: Buffer.alloc(7000, 8),
-        contentType: "image/jpeg",
-      },
       directorMode: "old_money",
       userKey: "user-1",
       reqId: "req-director-analysis-fail",

--- a/server/imageProvider.test.ts
+++ b/server/imageProvider.test.ts
@@ -14,6 +14,7 @@ const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
 const originalAppBaseUrl = process.env.APP_BASE_URL;
 const originalOpenAiImageMaxRetries = process.env.OPENAI_IMAGE_MAX_RETRIES;
 const originalOpenAiImageRetryBaseMs = process.env.OPENAI_IMAGE_RETRY_BASE_MS;
+const originalOpenAiImageModel = process.env.OPENAI_IMAGE_MODEL;
 
 function restoreEnv(name: string, value: string | undefined): void {
   if (value === undefined) {
@@ -56,6 +57,7 @@ describe("image provider boundary", () => {
     restoreEnv("APP_BASE_URL", originalAppBaseUrl);
     restoreEnv("OPENAI_IMAGE_MAX_RETRIES", originalOpenAiImageMaxRetries);
     restoreEnv("OPENAI_IMAGE_RETRY_BASE_MS", originalOpenAiImageRetryBaseMs);
+    restoreEnv("OPENAI_IMAGE_MODEL", originalOpenAiImageModel);
   });
 
   it("defaults to the current OpenAI Images provider", () => {
@@ -169,6 +171,60 @@ describe("image provider boundary", () => {
       promptHint: "more glitter in the background",
       userKey: "user-1",
       reqId: "req-style-prompt",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses gpt-image-1 as the default OpenAI image model", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    delete process.env.OPENAI_IMAGE_MODEL;
+
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = requestJson(init) as { model?: string };
+      expect(body.model).toBe("gpt-image-1");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "disco",
+      userKey: "user-default-model",
+      reqId: "req-default-model",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses OPENAI_IMAGE_MODEL when configured", async () => {
+    process.env.OPENAI_API_KEY = "dummy-key";
+    process.env.APP_BASE_URL = "https://leaderbot-fb-image-gen.fly.dev";
+    process.env.OPENAI_IMAGE_MODEL = "gpt-image-2";
+
+    const fetchMock = vi.fn(async (_url: string | URL, init?: RequestInit) => {
+      const body = requestJson(init) as { model?: string };
+      expect(body.model).toBe("gpt-image-2");
+
+      return {
+        ok: true,
+        json: async () => ({ data: [{ b64_json: GENERATED_IMAGE_BASE64 }] }),
+      } as Response;
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const generator = new OpenAiImageGenerator();
+    await generator.generate({
+      style: "storybook-anime",
+      userKey: "user-configured-model",
+      reqId: "req-configured-model",
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### Motivation
- Remove hardcoded OpenAI image model names from generation logic and centralize selection in the image provider/config layer to make model upgrades (e.g., Images 2.0) easier.
- Preserve existing default behavior while exposing a typed configuration and an environment override.

### Description
- Added `OpenAiImageModelConfig` and `getOpenAiImageModelConfig()` with a `DEFAULT_OPENAI_IMAGE_GENERATION_MODEL` fallback of `gpt-image-1` in `server/_core/image-generation/imageServiceConfig.ts` to centralize model selection.
- Updated `buildOpenAiRequest` in `server/_core/image-generation/openAiImageClient.ts` to read the model from `getOpenAiImageModelConfig()` instead of using hardcoded `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfd3414848325867a13ae5e613a82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation now honors a configurable model via environment variable, with automatic fallback to the default model.

* **Tests**
  * Added tests ensuring configured model is used, default fallback behavior, and that the model field is included for both standard and multipart (image-edit) requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->